### PR TITLE
Taxonomies: Improve pagination & layout

### DIFF
--- a/assets/_collapsible.scss
+++ b/assets/_collapsible.scss
@@ -1,7 +1,6 @@
 .collapsible {
   // control containers
-  h2, h3, h4, h5, h6 {
-
+  h2, h3, h4, h5, h6, .section-item {
     display: grid;
     grid: auto / auto max-content;
     align-items: center;
@@ -31,5 +30,22 @@
     &[aria-expanded="true"]:after {
       content: "";
     }
+  }
+
+  .collapsible-control,
+  .section-item > .size {
+    width: 30px;
+    text-align: center;
+  }
+}
+
+.book-toc .collapsible {
+  h2 {
+    font-size: 1em;
+  }
+
+  .anchor {
+    color: black;
+    font-weight: bold;
   }
 }

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -81,20 +81,36 @@
 }
 
 .book-page >.taxonomy-list {
+  // display: grid;
+  // grid: auto / 1fr 1fr;
   display: flex;
-  flex-flow: row wrap;
-  gap: 1em;
+  flex-flow: column wrap;
+  gap: 2em;
+  font-size: .9em;
+
+  .taxonomy-section {
+    display: flex;
+    flex-flow: column nowrap;
+    gap: 1em;
+
+    h2 {
+      margin: 0;
+      font-size: 1.2em;
+      font-weight: 600;
+    }
+  }
 
   .taxonomy-item {
-    font-size: 1.1em;
-    padding: 1em;
-    border: 2px solid black;
-    border-radius: 10px;
-    color: black;
-
     &:hover {
-      border-color: var(--color-link);
-      color: var(--color-link);
+      opacity: 0.5;
     }
+  }
+
+  @media(max-width: 768px) {
+    max-height: 100%;
+  }
+
+  @media(min-width: 769px) {
+    max-height: 50%;
   }
 }

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -24,13 +24,23 @@ menu:
         icon: ""
 
 taxonomies:
-  category: "categories"
-  custodian: "custodians"
+  category: "attacks/posts/categories"
+  custodian: "attacks/posts/custodians"
 
 cascade:
 - _target:
     path: "**/posts/**"
   type: posts
+
+- _target:
+    path: "**/posts/categories"
+  title: Categories
+  type: categories
+
+- _target:
+    path: "**/posts/custodians"
+  title: Custodians
+  type: custodians
 
 - _target:
     path: "**/docs/**"

--- a/content/attacks/posts/2012-07-16-BTC-e.md
+++ b/content/attacks/posts/2012-07-16-BTC-e.md
@@ -1,7 +1,7 @@
 ---
 date: 2012-07-16
-custodians: BTC-e
-categories: Custodian
+attacks/posts/custodians: BTC-e
+attacks/posts/categories: Custodian
 title: BTC-e hacked, losing around 4,500 BTC
 ---
 

--- a/content/attacks/posts/2013-05-23-Feathercoin.md
+++ b/content/attacks/posts/2013-05-23-Feathercoin.md
@@ -1,6 +1,6 @@
 ---
 date: 2013-05-23
-categories: 51%
+attacks/posts/categories: 51%
 title: FTC users lose millions after a 51% attack 
 ---
 

--- a/content/attacks/posts/2014-02-28-MtGox.md
+++ b/content/attacks/posts/2014-02-28-MtGox.md
@@ -1,7 +1,7 @@
 ---
 date: 2014-02-28
-custodians: MtGox
-categories: Custodian
+attacks/posts/custodians: MtGox
+attacks/posts/categories: Custodian
 title: Mt. Gox hacked, losing over $450 million worth of Bitcoin
 ---
 

--- a/content/attacks/posts/2015-01-04-Bitstamp.md
+++ b/content/attacks/posts/2015-01-04-Bitstamp.md
@@ -1,7 +1,7 @@
 ---
 date: 2015-01-04
-custodians: Bitstamp
-categories: Custodian
+attacks/posts/custodians: Bitstamp
+attacks/posts/categories: Custodian
 title: Bitstamp hot wallet hacked for 18,866 BTC due to human error
 ---
 

--- a/content/attacks/posts/2015-01-26-LocalBitcoins.md
+++ b/content/attacks/posts/2015-01-26-LocalBitcoins.md
@@ -1,7 +1,7 @@
 ---
 date: 2015-01-26
-custodians: LocalBitcoins
-categories: Custodian
+attacks/posts/custodians: LocalBitcoins
+attacks/posts/categories: Custodian
 title: LocalBitcoins suffers a security breach, resulting in the loss of 17 BTC
 ---
 

--- a/content/attacks/posts/2016-08-23-Krypton.md
+++ b/content/attacks/posts/2016-08-23-Krypton.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-08-23
-categories: 51%
+attacks/posts/categories: 51%
 title: "Krypton (KR) suffers a 51% attack in August 2016"
 ---
 

--- a/content/attacks/posts/2016-08-27-Shift.md
+++ b/content/attacks/posts/2016-08-27-Shift.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-08-27
-categories: 51%
+attacks/posts/categories: 51%
 title: "Shift (SHIFT) experiences a 51% attack in August 2016"
 ---
 

--- a/content/attacks/posts/2018-01-28-Coincheck.md
+++ b/content/attacks/posts/2018-01-28-Coincheck.md
@@ -1,7 +1,7 @@
 ---
 date: 2018-01-28
-custodians: "Coincheck"
-categories: "Custodian"
+attacks/posts/custodians: "Coincheck"
+attacks/posts/categories: "Custodian"
 title: "Coincheck Hack: A $530 Million NEM Theft Unveiling Centralized Exchange Vulnerabilities"
 
 ---

--- a/content/attacks/posts/2018-02-08-BitGrail.md
+++ b/content/attacks/posts/2018-02-08-BitGrail.md
@@ -1,7 +1,7 @@
 ---
 date: 2018-02-08
-custodians: BitGrail
-categories: Custodian
+attacks/posts/custodians: BitGrail
+attacks/posts/categories: Custodian
 title: "BitGrail Hack Results in $170 Million Loss"
 
 ---

--- a/content/attacks/posts/2018-04-04-Verge.md
+++ b/content/attacks/posts/2018-04-04-Verge.md
@@ -1,8 +1,8 @@
 ---
 date: 2018-04-04
-categories:
-- 51%
-- Protocol exploit
+attacks/posts/categories:
+    - 51%
+    - Protocol exploit
 title: Verge suffers a 51% attack in April 2018
 ---
 

--- a/content/attacks/posts/2018-05-19-Bitcoin-Gold.md
+++ b/content/attacks/posts/2018-05-19-Bitcoin-Gold.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-05-19
-categories: 51%
+attacks/posts/categories: 51%
 title: BTG users lose millions in a 51% attack
 ---
 

--- a/content/attacks/posts/2018-10-24-Vertcoin.md
+++ b/content/attacks/posts/2018-10-24-Vertcoin.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-10-24
-categories: 51%
+attacks/posts/categories: 51%
 title: Vertcoin suffers a 51% attack
 ---
 

--- a/content/attacks/posts/2018-11-AurumCoin-Cryptopia.md
+++ b/content/attacks/posts/2018-11-AurumCoin-Cryptopia.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11
-categories: 51%
+attacks/posts/categories: 51%
 title: "AurumCoin Users Face Losses in a 51% Attack"
 ---
 

--- a/content/attacks/posts/2019-01-05-Ethereum-Classic.md
+++ b/content/attacks/posts/2019-01-05-Ethereum-Classic.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-05
-categories: 51%
+attacks/posts/categories: 51%
 title: Ethereum Classic suffers a 51% attack
 ---
 

--- a/content/attacks/posts/2019-05-07-Binance-hack.md
+++ b/content/attacks/posts/2019-05-07-Binance-hack.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-05-07
-custodians: Binance
-categories: Custodian
+attacks/posts/custodians: Binance
+attacks/posts/categories: Custodian
 title: Binance Hack - Millions of Dollars Stolen in 2019
 
 ---

--- a/content/attacks/posts/2019-05-15-Bitcoin-Cash.md
+++ b/content/attacks/posts/2019-05-15-Bitcoin-Cash.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-15
-categories: 51%
+attacks/posts/categories: 51%
 title: "Bitcoin Cash Users Survive 51% Attack"
 ---
 

--- a/content/attacks/posts/2019-07-12-BITpoint.md
+++ b/content/attacks/posts/2019-07-12-BITpoint.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-12
-categories: Custodian
+attacks/posts/categories: Custodian
 title: "BITPoint hacked - $28 million stolen"
 ---
 

--- a/content/attacks/posts/2020-01-23-Bitcoin-Gold.md
+++ b/content/attacks/posts/2020-01-23-Bitcoin-Gold.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-23
-categories: 51%
+attacks/posts/categories: 51%
 title: Bitcoin Gold suffers a 51% attack again
 ---
 

--- a/content/attacks/posts/2020-08-29-Ethereum-Classic.md
+++ b/content/attacks/posts/2020-08-29-Ethereum-Classic.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-08-31
-categories: 51%
+attacks/posts/categories: 51%
 title: Ethereum Classic suffers three consecutive 51% attacks
 ---
 

--- a/content/attacks/posts/2020-08-31-2gether.md
+++ b/content/attacks/posts/2020-08-31-2gether.md
@@ -1,7 +1,7 @@
 ---
 date: 2020-08-31
-custodians: 2gether
-categories: Custodian
+attacks/posts/custodians: 2gether
+attacks/posts/categories: Custodian
 title: 2gether hacked, losing over €1.183 million worth of cryptocurrencies
 ---
 

--- a/content/attacks/posts/2021-04-13-Africrypt.md
+++ b/content/attacks/posts/2021-04-13-Africrypt.md
@@ -1,7 +1,7 @@
 ---
 date: 2021-04-13
-custodians: Africrypt
-categories: Custodian
+attacks/posts/custodians: Africrypt
+attacks/posts/categories: Custodian
 title: "Africrypt Founders Vanished with $3.6 Billion in Bitcoin"
 ---
 

--- a/content/attacks/posts/2021-08-10-poly-network.md
+++ b/content/attacks/posts/2021-08-10-poly-network.md
@@ -1,6 +1,6 @@
 ---
 date: 2021-08-10
-categories: Protocol exploit
+attacks/posts/categories: Protocol exploit
 title: "Poly Network Hack - $610 Million Stolen in 2021"
 ---
 

--- a/content/attacks/posts/2021-12-04-Bitmart-Exchange.md
+++ b/content/attacks/posts/2021-12-04-Bitmart-Exchange.md
@@ -1,7 +1,7 @@
 ---
 date: 2021-12-04
-custodians: BitMart Exchange
-categories: Custodian
+attacks/posts/custodians: BitMart Exchange
+attacks/posts/categories: Custodian
 title: "BitMart Exchange Suffers $196 Million Security Breach"
 ---
 

--- a/content/attacks/posts/2021-12-05-Polygon.md
+++ b/content/attacks/posts/2021-12-05-Polygon.md
@@ -1,6 +1,6 @@
 ---
 date: 2021-12-05
-categories: Protocol exploit
+attacks/posts/categories: Protocol exploit
 title: "Polygon hacked for over 800,000 MATIC"
 ---
 

--- a/content/attacks/posts/2021-12-13-Vulcan-Forged.md
+++ b/content/attacks/posts/2021-12-13-Vulcan-Forged.md
@@ -1,6 +1,6 @@
 ---
 date: 2021-12-13
-categories: Protocol exploit
+attacks/posts/categories: Protocol exploit
 title: "Vulcan Forged hacked for $140 million worth of PYR tokens"
 ---
 

--- a/content/attacks/posts/2022-02-02-Wormhole.md
+++ b/content/attacks/posts/2022-02-02-Wormhole.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-02-02
-categories: DeFi
+attacks/posts/categories: DeFi
 title: "Wormhole Hack: Code Vulnerability Has Led to $325 Million Stolen"
 ---
 

--- a/content/attacks/posts/2022-03-23-Ronin.md
+++ b/content/attacks/posts/2022-03-23-Ronin.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-03-23
-categories: 51%
+attacks/posts/categories: 51%
 title: Ronin Network suffers 51% attack, $625 million stolen
 ---
 

--- a/content/attacks/posts/2022-04-17-Beanstalk.md
+++ b/content/attacks/posts/2022-04-17-Beanstalk.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-04-17
-categories: Flash loan attack
+attacks/posts/categories: Flash loan attack
 title: Beanstalk Farms Lost $182 Million Due To The Governance Mechanism
 ---
 

--- a/content/attacks/posts/2022-05-08-Terra-Classic.md
+++ b/content/attacks/posts/2022-05-08-Terra-Classic.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-05-08
-categories: Protocol exploit
+attacks/posts/categories: Protocol exploit
 title: "The Collapse of Terra Classic Network Resulting in a $40 Billion Loss"
 ---
 

--- a/content/attacks/posts/2022-06-23-Harmony-Horizon.md
+++ b/content/attacks/posts/2022-06-23-Harmony-Horizon.md
@@ -1,6 +1,6 @@
 ﻿---
 date: 2022-06-23
-categories: Bridge Hack
+attacks/posts/categories: Bridge Hack
 title: "Harmony's Horizon Bridge was the victim of a massive cyberattack from North Korea"
 ---
 

--- a/content/attacks/posts/2022-09-20-Wintermute.md
+++ b/content/attacks/posts/2022-09-20-Wintermute.md
@@ -1,7 +1,7 @@
 ---
 date: 2022-09-20
-custodians: Wintermute
-categories: Custodian
+attacks/posts/custodians: Wintermute
+attacks/posts/categories: Custodian
 title: "Wintermute Incurs $160 Million Loss from Brute Force Private Key Compromise Linked to Profanity's Vulnerability"
 ---
 

--- a/content/attacks/posts/2022-10-06-BSC-Token-Hub.md
+++ b/content/attacks/posts/2022-10-06-BSC-Token-Hub.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-10-06
-categories: Bridge Hack
+attacks/posts/categories: Bridge Hack
 title: "BSC Token Hub Hit By $586 Million Bridge Hack"
 ---
 

--- a/content/attacks/posts/2023-03-13-Euler-Finance.md
+++ b/content/attacks/posts/2023-03-13-Euler-Finance.md
@@ -1,6 +1,6 @@
 ---
 date: 2023-03-13
-categories: Flash loan attack
+attacks/posts/categories: Flash loan attack
 title: "Euler Finance Exploited with Flash Loan Attack Resulting in Loss of $196 Million"
 ---
 

--- a/content/attacks/posts/2023-05-29-Qubit.md
+++ b/content/attacks/posts/2023-05-29-Qubit.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-03-23
-categories: Bridge Hack
+attacks/posts/categories: Bridge Hack
 title: "Hackers Breach Qubit Finance Platform, Stealing $80 Million"
 ---
 

--- a/layouts/README.md
+++ b/layouts/README.md
@@ -1,0 +1,1 @@
+The files in this directory are mostly modifications of the respective files from the theme at github.com/alex-shpak/hugo-book.

--- a/layouts/partials/docs/inject/footer.html
+++ b/layouts/partials/docs/inject/footer.html
@@ -1,0 +1,23 @@
+  <script type="module">
+    import Collapsible from "/js/collapsible.js"
+
+    const sections = document.querySelectorAll(".collapsible")
+
+    sections.forEach((item) => {
+      const control = item.querySelector(".collapsible-control")
+      const target = item.querySelector(".collapsible-target")
+
+      new Collapsible({
+        control: control,
+        target: {
+          element: target,
+        },
+        aria: {
+          expanded: true,
+          controls: true
+        },
+        debug: false
+      })
+    })
+  </script>
+

--- a/layouts/partials/docs/menu-anchor.html
+++ b/layouts/partials/docs/menu-anchor.html
@@ -1,0 +1,19 @@
+  {{ $isCurrent := hasPrefix .page.RelPermalink .item.RelPermalink | default false }}
+
+  {{ if .item.Page.Params.hide }}
+    <span
+      class="anchor"
+      {{ if $isCurrent }}aria-current="page"{{ end }}
+    >{{ .item.Title }}</span>
+
+  {{ else }}
+    <a
+      class="anchor"
+      href="{{ .item.RelPermalink }}"
+      {{ if $isCurrent }}aria-current="page"{{ end }}
+    >{{ .item.LinkTitle }}</a>
+  {{ end }}
+
+  {{ if .control }}
+    <button class="collapsible-control"></button>
+  {{ end }}

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -8,28 +8,6 @@
   {{ partial "docs/inject/menu-before" . }}
 
   {{ $page := .Page }}
-
-  {{ define "menu-anchor" }}
-    {{ $isCurrent := hasPrefix .page.RelPermalink .item.RelPermalink | default false }}
-
-    {{ if .item.Page.Params.hide }}
-    <span
-      class="anchor"
-      {{ if $isCurrent }}aria-current="page"{{ end }}
-    >{{ .item.Title }}</span>
-
-    {{ else }}
-      <a
-        class="anchor"
-        href="{{ .item.RelPermalink }}"
-        {{ if $isCurrent }}aria-current="page"{{ end }}
-      >{{ .item.LinkTitle }}</a>
-    {{ end }}
-
-    {{ if .control }}
-      <button class="collapsible-control"></button>
-    {{ end }}
-  {{ end }}
   
   <div class="book-tree">
     <!-- initialize sections ids -->
@@ -43,7 +21,7 @@
       {{ if (gt (.Pages | len) 0) }}
         <div class="submenu collapsible">
           {{ $ul2 = .LinkTitle | urlize | lower }}
-          <h2>{{ template "menu-anchor" (dict "page" $page "item" . "control" true) }}</h2>
+          <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h2>
           <ul class="collapsible-target" id="ul2-{{ $ul2 }}">
             <!-- list sub sections -->
             {{ range .Pages }}
@@ -52,21 +30,21 @@
                   <!-- special case: posts -->
                   {{ if eq .Type "posts" }}
                     {{ $ul3 = .LinkTitle | urlize | lower }}
-                    <h3>{{ template "menu-anchor" (dict "page" $page "item" . "control" true) }}</h3>
+                    <h3>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h3>
                     <ul class="taxonomies collapsible-target" id="ul3-{{ $ul2 }}-{{ $ul3 }}">
                       <!-- NOTE: Taxonomies are site-wide and not section-specific. -->
                       {{ range $taxonomy, $terms := site.Taxonomies }}
                         {{ if site.Params.expandTerms }}
                           <li class="taxonomy collapsible">
                             {{ with site.GetPage $taxonomy }}
-                              <h4>{{ template "menu-anchor" (dict "page" $page "item" . "control" true) }}</h4>
+                              <h4>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h4>
                             {{ end }}
 
                             {{ with $terms }}
                               {{ $ul4 = .LinkTitle | urlize | lower }}
                               <ul class="terms collapsible-target" id="ul4-{{ $ul2 }}-{{ $ul3 }}-{{ $ul4 }}">
                                 {{ range . }}
-                                  <li>{{ template "menu-anchor" (dict "page" $page "item" .Page) }}</li>
+                                  <li>{{ partial "docs/menu-anchor" (dict "page" $page "item" .Page) }}</li>
                                 {{ end }}
                               </ul>
                             {{ end }}
@@ -74,7 +52,7 @@
                         {{ else }}
                           {{ with site.GetPage $taxonomy }}
                           <li class="taxonomy">
-                            <h4>{{ template "menu-anchor" (dict "page" $page "item" . "control" false) }}</h4>
+                            <h4>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" false) }}</h4>
                           </li>
                           {{ end }}
                         {{ end }}
@@ -85,14 +63,14 @@
                   {{ else }}
                     {{ if .Pages }}
                       {{ $ul3 = .LinkTitle | urlize | lower }}
-                      <h3>{{ template "menu-anchor" (dict "page" $page "item" . "control" true) }}</h3>
+                      <h3>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h3>
                       <ul class="pages collapsible-target" id="ul3-{{ $ul2 }}-{{ $ul3 }}">
                         {{ range .Pages }}
-                          <li>{{ template "menu-anchor" (dict "page" $page "item" .) }}</li>
+                          <li>{{ partial "docs/menu-anchor" (dict "page" $page "item" .) }}</li>
                         {{ end }}
                       </ul>
                     {{ else }}
-                      <h3>{{ template "menu-anchor" (dict "page" $page "item" .) }}</h3>
+                      <h3>{{ partial "docs/menu-anchor" (dict "page" $page "item" .) }}</h3>
                     {{ end }}
                   {{ end }}
                 </li>
@@ -102,7 +80,7 @@
         </div>
       {{ else }}
         <div class="submenu">
-          <h2>{{ template "menu-anchor" (dict "page" $page "item" .) }}</h2>
+          <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" .) }}</h2>
         </div>
       {{ end }}
     {{ end }}
@@ -113,34 +91,6 @@
     </div>
   </div>
 
-  <script type="module">
-    import Collapsible from "/js/collapsible.js"
-
-
-    const sections = document.querySelectorAll(".collapsible")
-    sections.forEach((item) => {
-      const control = item.querySelector(".collapsible-control")
-      const target = item.querySelector(".collapsible-target")
-      // FIXME: Taxonomies pages will not trigger section as current due to different paths
-      // const isCurrent = (control.previousElementSibling.getAttribute("aria-current"))
-      const isCurrent = true
-
-      new Collapsible({
-        control: control,
-        target: {
-          element: target,
-        },
-        aria: {
-          expanded: isCurrent ? true : false,
-          controls: true
-        },
-      })
-
-      // if (!isCurrent)
-      //   target.hidden = true
-    })
-  </script>
-    
   {{ partial "docs/inject/menu-after" . }}
 </nav>
 

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -1,10 +1,14 @@
 <nav>
+  {{ $page := .Page }}
+
   <ul>
   {{ range $term, $_ := .Site.Taxonomies }}
     {{ with $.Site.GetPage (printf "/%s" $term | urlize) }}
-    <li class="book-section-flat">
-      <strong>{{ .Title | title }}</strong>
-      <ul>
+    <li class="book-section-flat collapsible">
+      {{ $ul2 := .Title | urlize | lower }}
+      <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h2>
+      
+      <ul class="collapsible-target" id="ul2-{{ $ul2 }}">
       {{ range .Pages.ByTitle }}
         <li class="flex justify-between">
           <a href="{{ .RelPermalink }}">{{ .Title }}</a>

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -5,22 +5,10 @@
     <li class="book-section-flat">
       <strong>{{ .Title | title }}</strong>
       <ul>
-      {{ $pages := slice }}
-
-      {{ range .Pages }}
-        {{ $page := (dict
-          "title" (.Title | default "") 
-          "url"   (.RelPermalink | default "")
-          "size"  (len .Pages)
-          )
-        }}
-        {{ $pages = $pages | append $page }}
-      {{ end }}
-
-      {{ range (sort $pages "size" "desc") }}
+      {{ range .Pages.ByTitle }}
         <li class="flex justify-between">
-          <a href="{{ .url }}">{{ .title }}</a>
-          <span>{{ .size }}</span>
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+          <span>{{ len .Pages }}</span>
         </li>
       {{ end }}
       </ul>

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -5,10 +5,22 @@
     <li class="book-section-flat">
       <strong>{{ .Title | title }}</strong>
       <ul>
-      {{ range .Pages.ByTitle }}
+      {{ $pages := slice }}
+
+      {{ range .Pages }}
+        {{ $page := (dict
+          "title" (.Title | default "") 
+          "url"   (.RelPermalink | default "")
+          "size"  (len .Pages)
+          )
+        }}
+        {{ $pages = $pages | append $page }}
+      {{ end }}
+
+      {{ range (sort $pages "size" "desc") }}
         <li class="flex justify-between">
-          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-          <span>{{ len .Pages }}</span>
+          <a href="{{ .url }}">{{ .title }}</a>
+          <span>{{ .size }}</span>
         </li>
       {{ end }}
       </ul>

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -1,0 +1,19 @@
+<nav>
+  <ul>
+  {{ range $term, $_ := .Site.Taxonomies }}
+    {{ with $.Site.GetPage (printf "/%s" $term | urlize) }}
+    <li class="book-section-flat">
+      <strong>{{ .Title | title }}</strong>
+      <ul>
+      {{ range .Pages.ByTitle }}
+        <li class="flex justify-between">
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+          <span>{{ len .Pages }}</span>
+        </li>
+      {{ end }}
+      </ul>
+    </li>
+    {{ end }}
+  {{ end }}
+  </ul>
+</nav>

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -10,9 +10,9 @@
       
       <ul class="collapsible-target" id="ul2-{{ $ul2 }}">
       {{ range .Pages.ByTitle }}
-        <li class="flex justify-between">
+        <li class="section-item">
           <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-          <span>{{ len .Pages }}</span>
+          <span class="size">{{ len .Pages }}</span>
         </li>
       {{ end }}
       </ul>

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -9,7 +9,7 @@
       {{ $currDropCap = .Title | upper | truncate 1 "" }}
 
       {{ if not (eq $currDropCap $lastDropCap) }}
-        {{ if not (eq $currDropCap "") }}
+        {{ if not (eq $lastDropCap "") }}
         </ul>
         {{ end }}
 

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -1,11 +1,26 @@
 {{ define "main" }}
   {{ $paginator := .Paginate (.Pages.ByTitle) 50 }}
 
-  <div class="taxonomy-list">
+  <ul class="taxonomy-list">
+    {{ $lastDropCap := "" }}
+    {{ $currDropCap := "" }}
+
     {{ range $paginator.Pages }}
-      <a class="taxonomy-item" href="{{ .RelPermalink }}">{{ partial "docs/title.html" . }}</a>
+      {{ $currDropCap = .Title | upper | truncate 1 "" }}
+
+      {{ if not (eq $currDropCap $lastDropCap) }}
+        {{ if not (eq $currDropCap "") }}
+        </ul>
+        {{ end }}
+
+        <ul class="taxonomy-section">
+          <h2>{{ $currDropCap }}</h2>
+      {{ end }}
+
+      {{ $lastDropCap = $currDropCap }}
+          <a class="taxonomy-item" href="{{ .RelPermalink }}">{{ partial "docs/title.html" . }}</a>
     {{ end }}
-  </div>
+  </ul>
 
   {{ template "_internal/pagination.html" . }}
 {{ end }}

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
+  {{ $paginator := .Paginate (.Pages.ByTitle) 50 }}
+
   <div class="taxonomy-list">
-    {{ range sort .Paginator.Pages }}
+    {{ range $paginator.Pages }}
       <a class="taxonomy-item" href="{{ .RelPermalink }}">{{ partial "docs/title.html" . }}</a>
     {{ end }}
   </div>

--- a/static/js/collapsible.js
+++ b/static/js/collapsible.js
@@ -20,6 +20,7 @@ export default class Collapsible {
   constructor(opts) {
     this.control = opts.control
     this.target = opts.target
+    this.debug = opts.debug
 
     if (this.control === null)
       throw new Error("Control element is null");
@@ -27,9 +28,8 @@ export default class Collapsible {
     if (this.target === null)
       throw new Error("Target element is null");
 
-    if (opts.aria) {
+    if (opts.aria)
       this.setAria(opts.aria)
-    }
 
     this.control.addEventListener("click", () => {
       this.dispatch("toggle")
@@ -68,7 +68,7 @@ export default class Collapsible {
   }
 
   hide(item) {
-    if (item.debug)
+    if (this.debug)
       console.log(`"action: hide; id: ${item.element.id}; class: ${item.element.class}"`)
 
     // 'hidden' remove from layout
@@ -85,7 +85,7 @@ export default class Collapsible {
   }
 
   show(item) {
-    if (item.debug)
+    if (this.debug == true)
       console.log(`"action: show; id: ${item.element.id}; class: ${item.element.class}"`)
 
     if (!item.visibility) {


### PR DESCRIPTION
Fix #36

### Changes

- Order terms in the book section *(on the right side)* by their size *(n of pages)*
- Order terms in terms list alphabetically
- Increase pagination size to 50 in terms list
- Implement new layout where terms are grouped by their initial letter *(drop cap)*