### PR TITLE
Fix taxonomies metadata

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -24,23 +24,13 @@ menu:
         icon: ""
 
 taxonomies:
-  category: "attacks/posts/categories"
-  custodian: "attacks/posts/custodians"
+  attacks/posts/category: "attacks/posts/categories"
+  attacks/posts/custodian: "attacks/posts/custodians"
 
 cascade:
 - _target:
     path: "**/posts/**"
   type: posts
-
-- _target:
-    path: "**/posts/categories"
-  title: Categories
-  type: categories
-
-- _target:
-    path: "**/posts/custodians"
-  title: Custodians
-  type: custodians
 
 - _target:
     path: "**/docs/**"

--- a/content/attacks/posts/categories/_index.md
+++ b/content/attacks/posts/categories/_index.md
@@ -1,0 +1,4 @@
+---
+title: Categories
+type: categories
+---

--- a/content/attacks/posts/custodians/_index.md
+++ b/content/attacks/posts/custodians/_index.md
@@ -1,0 +1,4 @@
+---
+title: Custodians
+type: custodians
+---


### PR DESCRIPTION
Follow up #117

Apparently there is no order of preference in config cascade so rules are applied randomly resulting in the taxonomy page sometimes rendering with the wrong template. But metadata in front matter has preference over cascade which solves the issue.