### PR TITLE
Taxonomies: Recreate 'tags'

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -24,11 +24,16 @@ menu:
         icon: ""
 
 taxonomies:
+  # global
+  tag: "tags"
+
+  # attacks/incidents
   target-entity: "target-entities"
   entity-type: "entity-types"
   attack-type: "attack-types"
 
 permalinks:
+  # attacks/incidents
   target-entities: "/attacks/posts/target-entities/:title"
   entity-types: "/attacks/posts/entity-types/:title"
   attack-types: "/attacks/posts/attack-types/:title"

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -8,6 +8,7 @@
   {{ partial "docs/inject/menu-before" . }}
 
   {{ $page := .Page }}
+  {{ $expandTerms := site.Params.expandTerms | default false }}
   
   <div class="book-tree">
     <!-- initialize sections ids -->
@@ -29,31 +30,28 @@
                 <li class="subsection collapsible">
                   <!-- special case: posts -->
                   {{ if eq .Type "posts" }}
+                    {{ $subsection := . }}
                     {{ $ul3 = .LinkTitle | urlize | lower }}
                     <h3>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h3>
                     <ul class="taxonomies collapsible-target" id="ul3-{{ $ul2 }}-{{ $ul3 }}">
                       <!-- NOTE: Taxonomies are site-wide and not section-specific. -->
                       {{ range $taxonomy, $terms := site.Taxonomies }}
-                        {{ if site.Params.expandTerms }}
-                          <li class="taxonomy collapsible">
-                            {{ with site.GetPage $taxonomy }}
-                              <h4>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h4>
-                            {{ end }}
+                        {{ with site.GetPage $taxonomy }}
+                          {{ if (hasPrefix .RelPermalink $subsection.RelPermalink) }}
+                            <li class="taxonomy {{ if $expandTerms }}collapsible{{ end }}">
+                              <h4>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" $expandTerms) }}</h4>
 
-                            {{ with $terms }}
-                              {{ $ul4 = .LinkTitle | urlize | lower }}
-                              <ul class="terms collapsible-target" id="ul4-{{ $ul2 }}-{{ $ul3 }}-{{ $ul4 }}">
-                                {{ range . }}
-                                  <li>{{ partial "docs/menu-anchor" (dict "page" $page "item" .Page) }}</li>
+                              {{ if $expandTerms }}
+                                {{ with $terms }}
+                                  {{ $ul4 = .LinkTitle | urlize | lower }}
+                                  <ul class="terms collapsible-target" id="ul4-{{ $ul2 }}-{{ $ul3 }}-{{ $ul4 }}">
+                                    {{ range . }}
+                                      <li>{{ partial "docs/menu-anchor" (dict "page" $page "item" .Page) }}</li>
+                                    {{ end }}
+                                  </ul>
                                 {{ end }}
-                              </ul>
-                            {{ end }}
-                          </li>
-                        {{ else }}
-                          {{ with site.GetPage $taxonomy }}
-                          <li class="taxonomy">
-                            <h4>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" false) }}</h4>
-                          </li>
+                              {{ end }}
+                            </li>
                           {{ end }}
                         {{ end }}
                       {{ end }}

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -84,12 +84,6 @@
     {{ end }}
 
     <!-- list global taxonomies -->
-    <div class="submenu tags">
-      {{ with site.GetPage "tags" }}
-        {{ $ul2 = .LinkTitle | urlize | lower }}
-        <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" .) }}</h2>
-      {{ end }}
-    </div>
 
     <div class="submenu external-links">
       <h2>External</h2>

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -83,6 +83,14 @@
       {{ end }}
     {{ end }}
 
+    <!-- list global taxonomies -->
+    <div class="submenu tags">
+      {{ with site.GetPage "tags" }}
+        {{ $ul2 = .LinkTitle | urlize | lower }}
+        <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" .) }}</h2>
+      {{ end }}
+    </div>
+
     <div class="submenu external-links">
       <h2>External</h2>
       {{ partial "docs/menu-hugo" .Site.Menus.external }}


### PR DESCRIPTION
@evgenydmitriev 

- Added anchor to taxonomy in the left menu
- Currently the right menu is listing all taxonomies. Should I change this behavior? 

![localhost_1313_tags_(Full HD)](https://github.com/1712n/dn-institute/assets/13279154/087447fa-cf7a-4a8d-bec9-6883c4d8a334)