### PR TITLE
Fix & Improve Taxonomies Menu

### DIFF
--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -1,0 +1,21 @@
+<script type="module">
+  import Collapsible from "/js/collapsible.js"
+  const sections = document.querySelectorAll(".collapsible")
+
+  sections.forEach((item) => {
+    const control = item.querySelector(".collapsible-control")
+    const target = item.querySelector(".collapsible-target")
+
+    new Collapsible({
+      control: control,
+      target: {
+        element: target,
+      },
+      aria: {
+        expanded: (target.hidden == true) ? false : true,
+        controls: true
+      },
+      debug: false 
+    })
+  })
+</script>

--- a/layouts/partials/docs/menu-anchor.html
+++ b/layouts/partials/docs/menu-anchor.html
@@ -1,6 +1,6 @@
   {{ $isCurrent := hasPrefix .page.RelPermalink .item.RelPermalink | default false }}
 
-  {{ if .item.Page.Params.navHideLink }}
+  {{ if .hideLink }}
     <span
       class="anchor"
       {{ if $isCurrent }}aria-current="page"{{ end }}

--- a/layouts/partials/docs/menu-filetree.html
+++ b/layouts/partials/docs/menu-filetree.html
@@ -53,9 +53,10 @@
   {{ $showTaxonomies := .item.Param "navShowTaxonomies" | default false }}
   {{ $isCollapsible := (or $showPages $showTaxonomies) | default false }}
   {{ $isCollapsed := .item.Param "bookCollapseSection" | default false  }}
+  {{ $hideLink := .item.Page.Params.navHideLink | default false }}
 
   <li class="li-h{{ $level }} {{ if $isCollapsible }}collapsible{{ end }}">
-    <h{{ $level }}>{{ partial "docs/menu-anchor" (dict "page" $page "item" .item "showControls" $isCollapsible) }}</h{{ $level }}>
+    <h{{ $level }}>{{ partial "docs/menu-anchor" (dict "page" $page "item" .item "showControls" $isCollapsible "hideLink" $hideLink) }}</h{{ $level }}>
 
     {{ if $showTaxonomies }}
       <ul class="taxonomies collapsible-target" id="{{ $id }}">

--- a/layouts/partials/docs/menu-filetree.html
+++ b/layouts/partials/docs/menu-filetree.html
@@ -14,7 +14,7 @@
 
           {{ if $showTerms }}
             {{ with $terms }}
-              {{ $name := .LinkTitle | urlize | lower }}
+              {{ $name := .item.LinkTitle | urlize | lower }}
               {{ $path = printf "%s-%s" $path $name }}
               {{ $id := printf "ul%d-%s" $level $path }} 
 
@@ -33,21 +33,17 @@
 
 {{ define "menu" }}
   {{ $page := .page }}
-  {{ $path := .path }}
+  {{ $path := "" }}
   {{ $level := add .level 1 }}
+  {{ $name := .item.LinkTitle | urlize | lower }}
 
-  {{ $name := "" }}
-  {{ $id := "" }}
-
-  {{ $name = .LinkTitle | urlize | lower }}
-
-  {{ if $path }}
-    {{ $path = printf "%s-%s" $path $name }}
+  {{ if .path }}
+    {{ $path = printf "%s-%s" .path $name }}
   {{ else }}
     {{ $path = $name }}
   {{ end }}
 
-  {{ $id = printf "ul%d-%s" $level $path }} 
+  {{ $id := printf "ul%d-%s" $level $path }}
 
   {{ $showPages := (and (.item.Param "navShowPages") (gt (.item.Pages | len) 0)) | default false }}
   {{ $showTaxonomies := .item.Param "navShowTaxonomies" | default false }}
@@ -77,7 +73,7 @@
 <ul class="book-tree">
   {{ range site.Home.Pages }}
     {{ if not (.Param "navHide") }}
-      {{ template "menu" (dict "page" . "item" . "level" 1 "path" "") }}
+      {{ template "menu" (dict "page" . "item" . "level" 1) }}
     {{ end }}
   {{ end }}
   

--- a/layouts/partials/docs/menu-filetree.html
+++ b/layouts/partials/docs/menu-filetree.html
@@ -43,7 +43,7 @@
     {{ $path = $name }}
   {{ end }}
 
-  {{ $id := printf "ul%d-%s" $level $path }}
+  {{ $id := printf "book-tree-ul%d-%s" $level $path }}
 
   {{ $showPages := (and (.item.Param "navShowPages") (gt (.item.Pages | len) 0)) | default false }}
   {{ $showTaxonomies := .item.Param "navShowTaxonomies" | default false }}
@@ -84,26 +84,3 @@
     </li>
   {{ end }}
 </ul>
-
-<script type="module">
-  import Collapsible from "/js/collapsible.js"
-
-  const sections = document.querySelectorAll(".collapsible")
-
-  sections.forEach((item) => {
-    const control = item.querySelector(".collapsible-control")
-    const target = item.querySelector(".collapsible-target")
-
-    new Collapsible({
-      control: control,
-      target: {
-        element: target,
-      },
-      aria: {
-        expanded: (target.hidden == true) ? false : true,
-        controls: true
-      },
-      debug: false
-    })
-  })
-</script>

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -2,21 +2,24 @@
   {{ $page := .Page }}
 
   <ul>
-  {{ range $term, $_ := .Site.Taxonomies }}
-    {{ with $.Site.GetPage (printf "/%s" $term | urlize) }}
-    <li class="book-section-flat collapsible">
-      <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "showControls" true) }}</h2>
-      
-      {{ $name := .Title | urlize | lower }}
-      <ul class="collapsible-target" id="book-taxonomies-{{ $name }}">
-        {{ range .Pages.ByTitle }}
-          <li class="section-item">
-            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-            <span class="size">{{ len .Pages }}</span>
-          </li>
-        {{ end }}
-      </ul>
-    </li>
+  {{ range $taxonomy, $terms := site.Taxonomies }}
+    {{ with site.GetPage $taxonomy }}
+      {{ $taxonomyParent := replaceRE "/[^/]+/?$" "/" .RelPermalink 1 }}
+      {{ if or (eq $taxonomyParent "/") (hasPrefix $.Page.RelPermalink $taxonomyParent) }}
+        <li class="book-section-flat collapsible">
+          <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "showControls" true) }}</h2>
+
+          {{ $name := .Title | urlize | lower }}
+          <ul class="collapsible-target" id="book-taxonomies-{{ $name }}">
+            {{ range .Pages.ByTitle }}
+              <li class="section-item">
+                <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                <span class="size">{{ len .Pages }}</span>
+              </li>
+            {{ end }}
+          </ul>
+        </li>
+      {{ end }}
     {{ end }}
   {{ end }}
   </ul>

--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -5,16 +5,16 @@
   {{ range $term, $_ := .Site.Taxonomies }}
     {{ with $.Site.GetPage (printf "/%s" $term | urlize) }}
     <li class="book-section-flat collapsible">
-      {{ $ul2 := .Title | urlize | lower }}
-      <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "control" true) }}</h2>
+      <h2>{{ partial "docs/menu-anchor" (dict "page" $page "item" . "showControls" true) }}</h2>
       
-      <ul class="collapsible-target" id="ul2-{{ $ul2 }}">
-      {{ range .Pages.ByTitle }}
-        <li class="section-item">
-          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-          <span class="size">{{ len .Pages }}</span>
-        </li>
-      {{ end }}
+      {{ $name := .Title | urlize | lower }}
+      <ul class="collapsible-target" id="book-taxonomies-{{ $name }}">
+        {{ range .Pages.ByTitle }}
+          <li class="section-item">
+            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+            <span class="size">{{ len .Pages }}</span>
+          </li>
+        {{ end }}
       </ul>
     </li>
     {{ end }}

--- a/static/js/collapsible.js
+++ b/static/js/collapsible.js
@@ -18,9 +18,12 @@
 
 export default class Collapsible {
   constructor(opts) {
+    this.debug = opts.debug
     this.control = opts.control
     this.target = opts.target
-    this.debug = opts.debug
+
+    if (opts.debug)
+      console.log(`constructor; control: ${this.control}; target: ${this.target}`)
 
     if (this.control === null)
       throw new Error("Control element is null");
@@ -69,7 +72,7 @@ export default class Collapsible {
 
   hide(item) {
     if (this.debug)
-      console.log(`"action: hide; id: ${item.element.id}; class: ${item.element.class}"`)
+      console.log(`action: hide; id: ${item.element.id}; class: ${item.element.class}`)
 
     // 'hidden' remove from layout
     if (!item.visibility) {
@@ -86,7 +89,7 @@ export default class Collapsible {
 
   show(item) {
     if (this.debug == true)
-      console.log(`"action: show; id: ${item.element.id}; class: ${item.element.class}"`)
+      console.log(`action: show; id: ${item.element.id}; class: ${item.element.class}`)
 
     if (!item.visibility) {
       item.element.hidden = false


### PR DESCRIPTION
This in overall improve the taxonomies/right menu:

- fix collapsible sections which were broke by me at #235  
- filter out taxonomies that are unrelated to the current page
- limit the effect of the param `navHideLink` to the main/left menu 

![Screenshot from 2023-09-15 23-46-45](https://github.com/1712n/dn-institute/assets/13279154/97da1db0-e10c-48bf-b37e-5b943a54abdc)

