### PR TITLE
Defer collapsibles init to prevent race condition

### DIFF
--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -1,21 +1,28 @@
 <script type="module">
   import Collapsible from "/js/collapsible.js"
-  const sections = document.querySelectorAll(".collapsible")
 
-  sections.forEach((item) => {
-    const control = item.querySelector(".collapsible-control")
-    const target = item.querySelector(".collapsible-target")
+  function initCollapsibles() {
+    const sections = document.querySelectorAll(".collapsible")
 
-    new Collapsible({
-      control: control,
-      target: {
-        element: target,
-      },
-      aria: {
-        expanded: (target.hidden == true) ? false : true,
-        controls: true
-      },
-      debug: false 
+    sections.forEach((item) => {
+      const control = item.querySelector(".collapsible-control")
+      const target = item.querySelector(".collapsible-target")
+
+      new Collapsible({
+        control: control,
+        target: {
+          element: target,
+        },
+        aria: {
+          expanded: (target.hidden == true) ? false : true,
+          controls: true
+        },
+        debug: false 
+      })
     })
-  })
+  }
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", initCollapsibles, { passive: true })
+  else initCollapsibles()
 </script>


### PR DESCRIPTION
Defer initialization of collapsibles to after page is load prevent a potential race condition.

Not sure this is the cause as I'm unable to replicate locally but this is harmless and better.

@marina-chibizova hopefully this fix the issue.