### PR TITLE
Raft exploit fixes

### DIFF
--- a/content/attacks/posts/2023-11-10-Raft.md
+++ b/content/attacks/posts/2023-11-10-Raft.md
@@ -2,37 +2,39 @@
 date: 2023-11-10  
 target-entities: Raft Protocol
 entity-types: 
-   - DeFi
-attack-types: 
-   - Smart Contract Exploit
-title: “Raft Protocol loses $6,700,000 in Smart Contract Exploit”
+  - DeFi
+  - Stablecoin
+attack-types:
+  - Smart Contract Exploit
+  - Flash Loan Attack
+title: "Raft Protocol loses $6,700,000 in Smart Contract Exploit"
 loss: 6700000
 ---
 
 ## Summary
 
-On November 10, 2023, Raft Protocol experienced an exploit resulting in a loss of about 1575 cbETH. The exploiter employed a sophisticated [multistep attack](https://www.immunebytes.com/blog/raft-protocol-exploit-nov-10-2023-detailed-analysis/) strategy focusing on a smart contract's precision calculation vulnerability. Initially, the attacker obtained cbETH through a flash loan before donating and liquidating the cbETH to the Interest Rate Position Manager. This maneuver manipulated the collateral token's index rate, allowing the exploiter to systematically increase their position in small increments, exploiting a rounding issue in the mint function. This strategy enabled repeated minting of cbETH, resulting in the unauthorized creation of approximately 6.003 quadrillion tokens. However, the attacker missed an important aspect of a connected smart contract essential for transferring funds and sent 1577.57 ETH to a burn wallet.
+On November 10, 2023, Raft Protocol experienced an exploit resulting in a loss of about 1,575 cbETH. The exploiter employed a sophisticated [multistep attack](https://www.immunebytes.com/blog/raft-protocol-exploit-nov-10-2023-detailed-analysis/) strategy focusing on a smart contract's precision calculation vulnerability. Initially, the attacker obtained cbETH through a flash loan before donating and liquidating the cbETH to the Interest Rate Position Manager. This maneuver manipulated the collateral token's index rate, allowing the exploiter to systematically increase their position in small increments, exploiting a rounding issue in the mint function. This strategy enabled repeated minting of cbETH, resulting in the unauthorized creation of approximately 6.003 quadrillion tokens. However, the attacker missed an important aspect of a connected smart contract essential for transferring funds and sent 1,577.57 ETH to a burn wallet.
 
 ## Attackers
 
 The identity of the attacker is unknown. The following addresses are associated with this attack:
 
-   - Etherscan: 0xc1f2b71a502b551a65eee9c96318afdd5fd439fa 
-   - Tornado Cash: 0x6fbc085e6b1ddce157a8b06978623b4b60db176e101f7f85215190bb28a21e3d
+   - [0xc1f2b71a502b551a65eee9c96318afdd5fd439fa](https://etherscan.io/address/0xc1f2b71a502b551a65eee9c96318afdd5fd439fa)
 
 ## Losses
 
-Raft R lost approximately $6,700,000 during the attack. 
+Raft lost approximately $6,700,000 during the attack. 
 
 ## Timeline
 
-   - **November 10, 2023, 18:46 UTC:** [Initial transactions](https://etherscan.io/txs) occur.
-   - **November 10, 2023, 19:18 UTC:** Raft [announces](https://twitter.com/raft_fi/status/1723057566664548623) security vulnerability in an X post.
-   - **November 11, 2023, 12:30 UTC:** Raft posts an [update](https://twitter.com/raft_fi/status/1723317254480425028) on X informing customers the attack total has increased from $3,300,000 to $6,700,000.
-   - **November 13, 2023:** [Post Mortem Report](https://mirror.xyz/0xa486d3a7679D56D545dd5d357469Dd5ed4259340/_Nk6_1_VvInyC0pdvHiZuAXiqm6tYSsGYGHSfOhcO1I) is released on Mirror. 
-   - **November 17, 2023, 15:31 UTC:** Raft releases updated [recovery plan.](https://forum.raft.fi/t/revised-raft-recovery-plan-17-november-2023/256) 
+- **November 10, 2023, 06:59 PM UTC:** [Initial malicious transaction](https://etherscan.io/tx/0xfeedbf51b4e2338e38171f6e19501327294ab1907ab44cfd2d7e7336c975ace7) occured.
+- **November 10, 2023, 19:18 UTC:** Raft [announces](https://twitter.com/raft_fi/status/1723057566664548623) security vulnerability in an X post.
+- **November 11, 2023, 12:30 UTC:** Raft posts an [update](https://twitter.com/raft_fi/status/1723317254480425028) on X informing customers the attack total has increased from $3,300,000 to $6,700,000.
+- **November 13, 2023:** [Post Mortem Report](https://mirror.xyz/0xa486d3a7679D56D545dd5d357469Dd5ed4259340/_Nk6_1_VvInyC0pdvHiZuAXiqm6tYSsGYGHSfOhcO1I) is released. 
+- **November 17, 2023, 15:31 UTC:** Raft [releases updated recovery plan](https://forum.raft.fi/t/revised-raft-recovery-plan-17-november-2023/256).
 
 ## Security Failure Causes
 
-   - **Smart Contract Vulnerability:** The exploit was a direct consequence of a loophole in the smart contract code, underscoring the need for more robust code review and testing procedures. Specifically, a critical precision calculation vulnerability in the token minting process allowed unauthorized minting of R tokens.
-   - **Audit Ineffectiveness:** Despite undergoing prior security audits, this particular vulnerability was not detected, indicating a possible deficiency in audit scope or depth.
+- **Smart Contract Vulnerability:** The exploit was a direct consequence of a loophole in the smart contract code. Specifically, a critical precision calculation vulnerability in the token minting process allowed unauthorized minting of R tokens.
+
+- **Audit Ineffectiveness:** Despite undergoing prior security audits, this particular vulnerability was not detected, indicating a possible deficiency in audit scope or depth.


### PR DESCRIPTION
Fixes for Raft Protocol incident:
- Fixed formatting issue where quotes shows in titles on the website
- Deleted TornadoCash link in attacker's section, it was only hash of tx and is was not relevant to the section
- Fixed malicious transaction link that refers to right one and it's exact time
- Included missing headers as attack types and entity types