### PR TITLE
Headers typos fix

### DIFF
--- a/tools/claude_retriever/client.py
+++ b/tools/claude_retriever/client.py
@@ -78,20 +78,20 @@ Check for the presence of specific metadata headers between "---" lines, such as
 
 The 'date' metadata header must match the actual date of the event described within the <text></text> tags, possibly mentioned in the Summary section. 
 To achieve this, search for dates within the text to identify the occurrence date of the event. 
-Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two.
-Please approach this task step by step. Point out the discrepancies in the designated "Notes" field.
+Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two. 
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
 
-The "target-entities" metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
-To achieve this, perform a text search to identify the target enitites. Then place these enitites in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them.
-Please approach this task step by step. Indicate any inaccuracies in the “Notes” field.
+The 'target-entities' metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, perform a text search to identify the target entities. Then place these entities in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them. 
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
 
-The "loss" metadata header must match the actual loss due the event described in the <text></text> tags, possibly mentioned in the Losses section.
-To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare them.
-Please approach this task step by step. Indicate any inaccuracies in the “Notes” field.
+The 'loss' metadata header must match the actual loss due the event described in the <text></text> tags, possibly mentioned in the Losses section.
+To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare the two. 
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
 
-Ensure that the value of the "entity-types" metadata header corresponds to the target entity. Indicate any inaccuracies in the “Notes” field.
+Ensure that the value of the 'entity-types' metadata header corresponds to the target entity. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
 
-Ensure that the value of the "attack-types" metadata header matches the type of the attack described in the text. Indicate any inaccuracies in the “Notes” field.
+Ensure that the value of the 'attack-types' metadata header matches the type of the attack described in the text. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
 
 Output example:
 '''## Filename Check
@@ -106,7 +106,7 @@ Output example:
 - Allowed Metadata Headers: `date, target-entities, entity-types, attack-types, title, loss`
 - Your Metadata Headers: `date, target-entities, entity-types` :x:
 - Notes: 
-    - The `date` header contains the wrong date. It states 2022-03-15, but it should be 2022-02-15 ":warning:"
+    - The `date` header has an incorrect date. It lists 2022-03-15, whereas it should be 2022-02-15 ":warning:"
     - The `loss` header displays an incorrect value. It shows $100, whereas it should indicate $1000. ":warning:"
 '''
 

--- a/tools/claude_retriever/client.py
+++ b/tools/claude_retriever/client.py
@@ -72,16 +72,31 @@ Output example:
 
 4. Check if the text between <text></text> follows the Markdown format, including appropriate headers.
 Confirm if it meets submission guidelines, particularly the file naming convention ("YYYY-MM-DD-entity-that-was-hacked.md"). Extract the name of the file from the text between <text></text> tags and compare it to the correct name.
-Pay special attention to matching the dates and names in the file name with the dates and names from the text.
-If you notice any discrepancies, write about them in the Notes field.
-
+Pay special attention to matching the dates and names in the filename with the dates and names from the text.
 Verify that the text between <text></text> includes only the allowed headers: "## Summary", "## Attackers", "## Losses", "## Timeline", "## Security Failure Causes".
 Check for the presence of specific metadata headers between "---" lines, such as "date", "target-entities", "entity-types", "attack-types", "title", "loss" in the text within <text></text> tags. It must contain all and only allowed metadata headers.
+
+The 'date' metadata header must match the actual date of the event described within the <text></text> tags, possibly mentioned in the Summary section. 
+To achieve this, search for dates within the text to identify the occurrence date of the event. 
+Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two.
+Please approach this task step by step. Point out the discrepancies in the designated "Notes" field.
+
+The "target-entities" metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, perform a text search to identify the target enitites. Then place these enitites in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them.
+Please approach this task step by step. Indicate any inaccuracies in the “Notes” field.
+
+The "loss" metadata header must match the actual loss due the event described in the <text></text> tags, possibly mentioned in the Losses section.
+To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare them.
+Please approach this task step by step. Indicate any inaccuracies in the “Notes” field.
+
+Ensure that the value of the "entity-types" metadata header corresponds to the target entity. Indicate any inaccuracies in the “Notes” field.
+
+Ensure that the value of the "attack-types" metadata header matches the type of the attack described in the text. Indicate any inaccuracies in the “Notes” field.
+
 Output example:
 '''## Filename Check
 - Correct Filename: `2022-02-15-ValentineFloki.md`
 - Your Filename: `scam.md` :x:
-— Notes: `The filename uses the wrong date. The text states that the incident occurred 2022-02-14, not 2022-02-15`
 
 ## Section Headers Check
 - Allowed Headers: `## Summary, ## Attackers, ## Losses, ## Timeline, ## Security Failure Causes`
@@ -89,7 +104,11 @@ Output example:
 
 ## Metadata Headers Check
 - Allowed Metadata Headers: `date, target-entities, entity-types, attack-types, title, loss`
-- Your Metadata Headers: `date, target-entities, entity-types` :x:'''
+- Your Metadata Headers: `date, target-entities, entity-types` :x:
+- Notes: 
+    - The `date` header contains the wrong date. It states 2022-03-15, but it should be 2022-02-15 ":warning:"
+    - The `loss` header displays an incorrect value. It shows $100, whereas it should indicate $1000. ":warning:"
+'''
 
 Combine the results of all steps into a single output that complies with Markdown format and return it to me in <answer></answer> tags. 
 """

--- a/tools/claude_retriever/client.py
+++ b/tools/claude_retriever/client.py
@@ -72,12 +72,16 @@ Output example:
 
 4. Check if the text between <text></text> follows the Markdown format, including appropriate headers.
 Confirm if it meets submission guidelines, particularly the file naming convention ("YYYY-MM-DD-entity-that-was-hacked.md"). Extract the name of the file from the text between <text></text> tags and compare it to the correct name.
+Pay special attention to matching the dates and names in the file name with the dates and names from the text.
+If you notice any discrepancies, write about them in the Notes field.
+
 Verify that the text between <text></text> includes only the allowed headers: "## Summary", "## Attackers", "## Losses", "## Timeline", "## Security Failure Causes".
 Check for the presence of specific metadata headers between "---" lines, such as "date", "target-entities", "entity-types", "attack-types", "title", "loss" in the text within <text></text> tags. It must contain all and only allowed metadata headers.
 Output example:
 '''## Filename Check
-- Correct Filename: `2022-02-14-ValentineFloki.md`
+- Correct Filename: `2022-02-15-ValentineFloki.md`
 - Your Filename: `scam.md` :x:
+— Notes: `The filename uses the wrong date. The text states that the incident occurred 2022-02-14, not 2022-02-15`
 
 ## Section Headers Check
 - Allowed Headers: `## Summary, ## Attackers, ## Losses, ## Timeline, ## Security Failure Causes`


### PR DESCRIPTION
Now the bot searches for discrepancies in metadata headers. Example [here](https://github.com/Kseymur/dn-institute/pull/38)