### PR TITLE
Add similarity search batch processing and tests

### DIFF
--- a/tools/similarity_search/.prettierrc.json
+++ b/tools/similarity_search/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": false
+}

--- a/tools/similarity_search/package.json
+++ b/tools/similarity_search/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240403.0",
+    "prettier": "^3.2.5",
     "wrangler": "^3.47.0"
   }
 }

--- a/tools/similarity_search/src/env.d.ts
+++ b/tools/similarity_search/src/env.d.ts
@@ -1,0 +1,6 @@
+type Env = {
+  API_KEY_TOKEN_CHECK: string
+  AI: Ai
+  VECTORIZE_INDEX: VectorizeIndex
+  MAX_INPUT: number
+}

--- a/tools/similarity_search/src/env.d.ts
+++ b/tools/similarity_search/src/env.d.ts
@@ -1,6 +1,7 @@
 type Env = {
+  API_GATEWAY_UNIVERSAL_API: string
   API_KEY_TOKEN_CHECK: string
-  AI: Ai
+  WORKERS_API_KEY: string
   VECTORIZE_INDEX: VectorizeIndex
   MAX_INPUT: number
 }

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -35,21 +35,33 @@ app.post("/", async (c) => {
   let texts: string[]
   if (typeof text === "string") {
     texts = [text]
-  } else if (Array.isArray(data.text) && data.text.every((element) => typeof element === "string")) {
+  } else if (
+    Array.isArray(data.text) &&
+    data.text.every((element) => typeof element === "string")
+  ) {
     texts = text
   } else {
-    return c.text("Invalid JSON format, property `text` must be a string or array of strings", 400)
+    return c.text(
+      "Invalid JSON format, property `text` must be a string or array of strings",
+      400,
+    )
   }
   const MAX_INPUT = Number(c.env.MAX_INPUT) || 100
   if (texts.length > MAX_INPUT) {
-    return c.text(`Too big input, property \`text\` can have max ${MAX_INPUT} items`, 400)
+    return c.text(
+      `Too big input, property \`text\` can have max ${MAX_INPUT} items`,
+      400,
+    )
   }
   if (typeof namespace !== "string") {
-    return c.text("Invalid JSON format, property `namespace` must be a string", 400)
+    return c.text(
+      "Invalid JSON format, property `namespace` must be a string",
+      400,
+    )
   }
 
   const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: texts
+    text: texts,
   })
 
   let index = 0
@@ -57,7 +69,7 @@ app.post("/", async (c) => {
     const vector = modelResp.data[index++]
     return c.env.VECTORIZE_INDEX.query(vector, {
       namespace,
-      topK: 1
+      topK: 1,
     })
   })
   const responses = await Promise.all(requests)
@@ -67,7 +79,7 @@ app.post("/", async (c) => {
     similarityScores.push(similarityScore)
   }
 
-  if (typeof text === 'string') {
+  if (typeof text === "string") {
     return c.json({ similarity_score: similarityScores[0] })
   } else {
     return c.json({ similarity_score: similarityScores })

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -4,10 +4,11 @@ type Env = {
   API_KEY_TOKEN_CHECK: string
   AI: Ai
   VECTORIZE_INDEX: VectorizeIndex
+  MAX_INPUT: number
 }
 
 type TextEntry = {
-  text: string
+  text: string | string[]
   namespace: string
 }
 
@@ -31,21 +32,46 @@ app.post("/", async (c) => {
   const data = await c.req.json<TextEntry>()
   const { text, namespace } = data
 
-  if (typeof text !== "string" || typeof namespace !== "string") {
-    return c.text("Invalid JSON format", 400)
+  let texts: string[]
+  if (typeof text === "string") {
+    texts = [text]
+  } else if (Array.isArray(data.text) && data.text.every((element) => typeof element === "string")) {
+    texts = text
+  } else {
+    return c.text("Invalid JSON format, property `text` must be a string or array of strings", 400)
+  }
+  const MAX_INPUT = Number(c.env.MAX_INPUT) || 100
+  if (texts.length > MAX_INPUT) {
+    return c.text(`Too big input, property \`text\` can have max ${MAX_INPUT} items`, 400)
+  }
+  if (typeof namespace !== "string") {
+    return c.text("Invalid JSON format, property `namespace` must be a string", 400)
   }
 
   const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: [text]
+    text: texts
   })
-  const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
-    namespace,
-    topK: 1
-  })
-  const similarityScore = searchResponse.matches[0]?.score || 0
 
-  return c.json({ similarity_score: similarityScore })
+  let index = 0
+  const requests = texts.map((text) => {
+    const vector = modelResp.data[index++]
+    return c.env.VECTORIZE_INDEX.query(vector, {
+      namespace,
+      topK: 1
+    })
+  })
+  const responses = await Promise.all(requests)
+  const similarityScores = []
+  for (const searchResponse of responses) {
+    const similarityScore = searchResponse.matches[0]?.score || 0
+    similarityScores.push(similarityScore)
+  }
+
+  if (typeof text === 'string') {
+    return c.json({ similarity_score: similarityScores[0] })
+  } else {
+    return c.json({ similarity_score: similarityScores })
+  }
 })
 
 export default app

--- a/tools/similarity_search/test/env.d.ts
+++ b/tools/similarity_search/test/env.d.ts
@@ -1,0 +1,3 @@
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -20,3 +20,64 @@ describe("Authentication", () => {
     expect(await response.text()).toBe("Unauthorized")
   })
 })
+
+describe("Single message processing", () => {
+  it("returns single scalar result when single scalar text is given", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key",
+      },
+      body: JSON.stringify({
+        text: "Sample text",
+        namespace: "test-namespace"
+      })
+    })
+    expect(response.status).toBe(200)
+    expect(await response.text()).toEqual('{"similarity_score":0.5678}')
+  })
+})
+
+describe("Batch message processing", () => {
+  it ("limits max inputs", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key",
+      },
+      body: JSON.stringify({
+        text: [
+          "This is a story about an orange cloud",
+          "This is a story about a llama",
+          "This is a story about a hugging emoji",
+          "This is a story about overwhelming courage",
+        ],
+        namespace: "test-namespace"
+      })
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toEqual("Too big input, property `text` can have max 3 items")
+  })
+
+  it ("returns array results when multiple texts are given", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key",
+      },
+      body: JSON.stringify({
+        text: [
+          "This is a story about an orange cloud",
+          "This is a story about a llama",
+          "This is a story about a hugging emoji"
+        ],
+        namespace: "test-namespace"
+      })
+    })
+    expect(response.status).toBe(200)
+    expect(await response.text()).toEqual('{"similarity_score":[0.5678,0.5678,0.5678]}')
+  })
+})

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -8,12 +8,12 @@ describe("Authentication", () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         text: "Sample text",
-        namespace: "test-namespace"
-      })
+        namespace: "test-namespace",
+      }),
     })
 
     expect(response.status).toBe(401)
@@ -31,8 +31,8 @@ describe("Single message processing", () => {
       },
       body: JSON.stringify({
         text: "Sample text",
-        namespace: "test-namespace"
-      })
+        namespace: "test-namespace",
+      }),
     })
     expect(response.status).toBe(200)
     expect(await response.text()).toEqual('{"similarity_score":0.5678}')
@@ -40,7 +40,7 @@ describe("Single message processing", () => {
 })
 
 describe("Batch message processing", () => {
-  it ("limits max inputs", async () => {
+  it("limits max inputs", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
       headers: {
@@ -54,14 +54,16 @@ describe("Batch message processing", () => {
           "This is a story about a hugging emoji",
           "This is a story about overwhelming courage",
         ],
-        namespace: "test-namespace"
-      })
+        namespace: "test-namespace",
+      }),
     })
     expect(response.status).toBe(400)
-    expect(await response.text()).toEqual("Too big input, property `text` can have max 3 items")
+    expect(await response.text()).toEqual(
+      "Too big input, property `text` can have max 3 items",
+    )
   })
 
-  it ("returns array results when multiple texts are given", async () => {
+  it("returns array results when multiple texts are given", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
       headers: {
@@ -72,12 +74,14 @@ describe("Batch message processing", () => {
         text: [
           "This is a story about an orange cloud",
           "This is a story about a llama",
-          "This is a story about a hugging emoji"
+          "This is a story about a hugging emoji",
         ],
-        namespace: "test-namespace"
-      })
+        namespace: "test-namespace",
+      }),
     })
     expect(response.status).toBe(200)
-    expect(await response.text()).toEqual('{"similarity_score":[0.5678,0.5678,0.5678]}')
+    expect(await response.text()).toEqual(
+      '{"similarity_score":[0.5678,0.5678,0.5678]}',
+    )
   })
 })

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -84,36 +84,4 @@ describe("Batch message processing", () => {
       '{"similarity_score":[0.5678,0.5678,0.5678]}',
     )
   })
-
-  it("runs only unique inputs for duplicate-heavy use cases", async () => {
-    const runSpy = vi.spyOn(env.AI, "run")
-    const querySpy = vi.spyOn(env.VECTORIZE_INDEX, "query")
-
-    const response = await SELF.fetch("https://example.com/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": "test-api-key",
-      },
-      body: JSON.stringify({
-        text: [
-          "This is a story about an orange cloud",
-          "This is a story about a llama",
-          "This is a story about an orange cloud",
-        ],
-        namespace: "test-namespace",
-      }),
-    })
-    expect(response.status).toBe(200)
-    expect(await response.text()).toEqual(
-      '{"similarity_score":[0.5678,0.5678,0.5678]}',
-    )
-    expect(runSpy).toHaveBeenCalledWith("@cf/baai/bge-base-en-v1.5", {
-      text: [
-        "This is a story about an orange cloud",
-        "This is a story about a llama",
-      ],
-    })
-    expect(querySpy).toHaveBeenCalledTimes(2)
-  })
 })

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -1,5 +1,5 @@
-import { SELF } from "cloudflare:test"
-import { describe, it, expect } from "vitest"
+import { SELF, env } from "cloudflare:test"
+import { describe, it, expect, vi } from "vitest"
 
 import "../src/index"
 
@@ -83,5 +83,37 @@ describe("Batch message processing", () => {
     expect(await response.text()).toEqual(
       '{"similarity_score":[0.5678,0.5678,0.5678]}',
     )
+  })
+
+  it("runs only unique inputs for duplicate-heavy use cases", async () => {
+    const runSpy = vi.spyOn(env.AI, "run")
+    const querySpy = vi.spyOn(env.VECTORIZE_INDEX, "query")
+
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key",
+      },
+      body: JSON.stringify({
+        text: [
+          "This is a story about an orange cloud",
+          "This is a story about a llama",
+          "This is a story about an orange cloud",
+        ],
+        namespace: "test-namespace",
+      }),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.text()).toEqual(
+      '{"similarity_score":[0.5678,0.5678,0.5678]}',
+    )
+    expect(runSpy).toHaveBeenCalledWith("@cf/baai/bge-base-en-v1.5", {
+      text: [
+        "This is a story about an orange cloud",
+        "This is a story about a llama",
+      ],
+    })
+    expect(querySpy).toHaveBeenCalledTimes(2)
   })
 })

--- a/tools/similarity_search/test/tsconfig.json
+++ b/tools/similarity_search/test/tsconfig.json
@@ -1,11 +1,11 @@
 {
-    "extends": "../tsconfig.json",
-    "compilerOptions": {
-      "moduleResolution": "bundler",
-      "types": [
-        "@cloudflare/workers-types/experimental",
-        "@cloudflare/vitest-pool-workers"
-      ]
-    },
-    "include": ["./**/*.ts", "../src/env.d.ts"]
-  }
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "types": [
+      "@cloudflare/workers-types/experimental",
+      "@cloudflare/vitest-pool-workers"
+    ]
+  },
+  "include": ["./**/*.ts", "../src/env.d.ts"]
+}

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -9,7 +9,8 @@ export default defineWorkersConfig({
         },
         miniflare: {
           bindings: {
-            API_KEY_TOKEN_CHECK: "test-api-key"
+            API_KEY_TOKEN_CHECK: "test-api-key",
+            MAX_INPUT: 3
           },
           wrappedBindings: {
             AI: {

--- a/tools/similarity_search/wrangler.toml
+++ b/tools/similarity_search/wrangler.toml
@@ -21,3 +21,10 @@ compatibility_flags = ["nodejs_compat"]
 
 # [ai]
 # binding = "AI"
+
+[[vectorize]]
+binding = "VECTORIZE_INDEX"
+index_name = "embeddings-index"
+
+[limits]
+cpu_ms = 50


### PR DESCRIPTION
Hi! This pull request adds ability to pass multiple texts in single request, but also is compatible with single-text format.

Solves issues https://github.com/1712n/dn-institute/issues/431 and https://github.com/1712n/dn-institute/issues/430

Considerations taken:

- max input items for Workers AI - https://developers.cloudflare.com/workers-ai/models/bge-base-en-v1.5/#api-schema
    > Max input tokens: 512

    API Schema suggests `"maxItems": 100`
    Uncertain which is correct, but this is configurable as an environment variable `MAX_INPUT`, leaving 100 as a default

- [Query vectors](https://developers.cloudflare.com/vectorize/best-practices/query-vectors/) doesn't seem to provide a batch support, so I opted to run all requests in parallel with `Promise.all` - all requests must succeed. An alternative is `Promise.allSettled` that can tolerate individual request errors, but then we'll have to come up with error format per item, which isn't worth it for now

<img width="552" alt="Screenshot 2024-05-19 at 17 19 19" src="https://github.com/1712n/dn-institute/assets/4685931/3d1cd972-3bec-4989-aa07-61cb0cc79caa">
<img width="532" alt="Screenshot 2024-05-19 at 17 18 22" src="https://github.com/1712n/dn-institute/assets/4685931/ea29acdb-cfb0-4e43-8ea7-3788d5407e7b">

In addition, basic high level integration tests were added.