### PR TITLE
Migrate /articlecheck bot to Cloudflare Workers (producer+queue+consumer)

### DIFF
--- a/.github/workflows/article-check-claude.yml
+++ b/.github/workflows/article-check-claude.yml
@@ -1,6 +1,7 @@
+# Deprecated: replaced by Cloudflare Workers webhook bot.
+# See: workers/articlecheck/
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/workers/articlecheck/README.md
+++ b/workers/articlecheck/README.md
@@ -1,0 +1,120 @@
+# Cloudflare Workers Article Check Bot (Issue #425)
+
+This folder contains a webhook-based replacement for the GitHub Actions QA bot (`/articlecheck`), implemented as **two Cloudflare Workers** connected by a **Cloudflare Queue**:
+
+- **Producer worker** (`producer/`): receives GitHub `issue_comment` webhooks, verifies signature, checks reviewer allowlist, enqueues a job, and responds quickly (GitHub webhook timeout friendly).
+- **Consumer worker** (`consumer/`): consumes queued jobs, fetches PR article content, runs the Claude + Brave fact-check pipeline, and posts a comment back on the PR.
+
+Idempotency is enforced via:
+- KV keys for `delivery_id` and `comment_id`
+- a hidden HTML marker embedded in the posted PR comment
+
+## Prereqs
+
+- Cloudflare account with Workers, Queues, and KV enabled.
+- A GitHub App installed on the target repo (recommended for least-privilege auth).
+- Anthropic API key (Claude).
+- Brave Search API key.
+
+## GitHub App Setup (Recommended)
+
+1. Create a GitHub App (Organization or personal, depending on where the repo lives).
+2. Enable **webhooks** and set:
+   - Webhook URL: your deployed Producer worker URL (for example `https://dn-institute-articlecheck-producer.<your-subdomain>.workers.dev/`)
+   - Webhook secret: generate one and store it as `GITHUB_WEBHOOK_SECRET` in the Producer worker.
+3. Subscribe to events:
+   - **Issue comments**
+4. Permissions (minimum):
+   - Repository permissions:
+     - Contents: Read
+     - Pull requests: Read
+     - Issues: Read + Write (to post comments on PRs; PRs are issues in GitHub API)
+5. Install the GitHub App on the repo.
+6. Download the App private key (`.pem`) and store it as a secret for the Consumer worker (`GITHUB_APP_PRIVATE_KEY`).
+
+The webhook payload includes `installation.id`, which the Consumer uses to mint an installation token.
+
+## Cloudflare Setup
+
+### 1) Create Queue
+
+Create a queue named `dn-institute-articlecheck`:
+
+```bash
+wrangler queues create dn-institute-articlecheck
+```
+
+### 2) Create KV Namespace
+
+Create a KV namespace for idempotency:
+
+```bash
+wrangler kv namespace create ARTICLECHECK_DEDUP
+```
+
+Update `consumer/wrangler.toml` with the returned KV namespace id.
+
+## Configure Secrets / Vars
+
+### Producer (`producer/`)
+
+Secrets:
+
+```bash
+wrangler secret put GITHUB_WEBHOOK_SECRET
+```
+
+Vars:
+- `WIKI_REVIEWERS`: JSON array of allowed GitHub usernames (preferred), matching the existing GitHub Actions behavior.
+  - Example: `["harmatta","someReviewer"]`
+
+### Consumer (`consumer/`)
+
+Secrets:
+
+```bash
+wrangler secret put GITHUB_APP_PRIVATE_KEY
+wrangler secret put ANTHROPIC_API_KEY
+wrangler secret put BRAVE_API_KEY
+```
+
+Vars:
+- `GITHUB_APP_ID`: numeric GitHub App id
+- Optional tuning:
+  - `ANTHROPIC_MODEL` (default: `claude-3-opus-20240229`)
+  - `ANTHROPIC_TEMPERATURE` (default: `0`)
+  - `MAX_STATEMENTS` (default: `12`)
+  - `MAX_SEARCH_RESULTS` (default: `3`)
+  - `MAX_FILES` (default: `1`)
+  - `MAX_ARTICLE_CHARS` (default: `60000`)
+  - `DEDUP_TTL_SECONDS` (default: `604800` = 7 days)
+
+## Deploy
+
+From this folder:
+
+```bash
+# Producer
+wrangler deploy --config producer/wrangler.toml
+
+# Consumer
+wrangler deploy --config consumer/wrangler.toml
+```
+
+## Behavior Notes
+
+- Trigger: new `issue_comment` containing `/articlecheck` on a PR.
+- Allowlist gate: the Producer checks `sender.login` is in `WIKI_REVIEWERS` before enqueueing.
+- Content fetch strategy (upgrade over diff-only): the Consumer fetches full `content/attacks/*.md` file content at the PR head SHA.
+- One comment per run: the Consumer posts a single PR comment containing results (and a hidden marker).
+
+## Local Development / Tests
+
+Typecheck + unit tests live in this folder:
+
+```bash
+npm install
+npm run typecheck
+npm test
+```
+

--- a/workers/articlecheck/common/src/allowlist.ts
+++ b/workers/articlecheck/common/src/allowlist.ts
@@ -1,0 +1,30 @@
+export function parseReviewerAllowlist(raw: string | undefined | null): Set<string> {
+  const out = new Set<string>();
+  if (!raw) return out;
+  const trimmed = raw.trim();
+  if (!trimmed) return out;
+
+  // Preferred format (parity with GitHub Actions secret): JSON array of usernames.
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        for (const item of parsed) {
+          if (typeof item === "string" && item.trim()) out.add(item.trim().toLowerCase());
+        }
+        return out;
+      }
+    } catch {
+      // fall through to delimiter parsing
+    }
+  }
+
+  // Fallback: newline/comma/space separated.
+  for (const part of trimmed.split(/[\n,\s]+/g)) {
+    const u = part.trim();
+    if (!u) continue;
+    out.add(u.toLowerCase());
+  }
+  return out;
+}
+

--- a/workers/articlecheck/common/src/anthropic.ts
+++ b/workers/articlecheck/common/src/anthropic.ts
@@ -1,0 +1,49 @@
+export type AnthropicMessage = { role: "user" | "assistant"; content: string };
+
+export async function anthropicCreateMessage(opts: {
+  apiKey: string;
+  model: string;
+  system: string;
+  messages: AnthropicMessage[];
+  maxTokens: number;
+  temperature: number;
+  stopSequences?: string[];
+  timeoutMs?: number;
+}): Promise<string> {
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 60_000);
+  try {
+    const resp = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      signal: ctrl.signal,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": opts.apiKey,
+        // Keep the stable version header for broad compatibility.
+        "anthropic-version": "2023-06-01"
+      },
+      body: JSON.stringify({
+        model: opts.model,
+        max_tokens: opts.maxTokens,
+        temperature: opts.temperature,
+        system: opts.system,
+        stop_sequences: opts.stopSequences,
+        messages: opts.messages.map((m) => ({
+          role: m.role,
+          content: [{ type: "text", text: m.content }]
+        }))
+      })
+    });
+    const text = await resp.text();
+    if (!resp.ok) {
+      throw new Error(`anthropic_error status=${resp.status} body=${text.slice(0, 1200)}`);
+    }
+    const data = JSON.parse(text) as { content: Array<{ type: string; text: string }> };
+    const first = data?.content?.find((c) => c?.type === "text");
+    if (!first?.text) throw new Error("anthropic_missing_text_content");
+    return first.text;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+

--- a/workers/articlecheck/common/src/base64url.ts
+++ b/workers/articlecheck/common/src/base64url.ts
@@ -1,0 +1,21 @@
+const encoder = new TextEncoder();
+
+export function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let str = "";
+  for (const b of bytes) str += String.fromCharCode(b);
+  // btoa expects binary string (Latin-1).
+  const base64 = btoa(str);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function base64UrlEncodeString(s: string): string {
+  return base64UrlEncodeBytes(encoder.encode(s));
+}
+
+export function base64DecodeToBytes(base64: string): Uint8Array<ArrayBuffer> {
+  const bin = atob(base64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  // The underlying buffer is always an ArrayBuffer in this environment.
+  return bytes as Uint8Array<ArrayBuffer>;
+}

--- a/workers/articlecheck/common/src/brave.ts
+++ b/workers/articlecheck/common/src/brave.ts
@@ -1,0 +1,52 @@
+export type BraveWebResult = {
+  title: string;
+  url: string;
+  description: string;
+};
+
+export async function braveSearchWeb(opts: {
+  apiKey: string;
+  query: string;
+  count: number;
+}): Promise<BraveWebResult[]> {
+  const url = new URL("https://api.search.brave.com/res/v1/web/search");
+  url.searchParams.set("q", opts.query);
+  url.searchParams.set("count", String(Math.min(Math.max(opts.count, 1), 20)));
+
+  const resp = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      "X-Subscription-Token": opts.apiKey
+    }
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`brave_search_failed status=${resp.status} body=${text.slice(0, 600)}`);
+  }
+  const data = (await resp.json()) as any;
+  const web = data?.web?.results;
+  if (!Array.isArray(web)) return [];
+  return web
+    .map((r: any) => ({
+      title: typeof r?.title === "string" ? r.title : "",
+      url: typeof r?.url === "string" ? r.url : "",
+      description: typeof r?.description === "string" ? r.description : ""
+    }))
+    .filter((r: BraveWebResult) => !!r.url)
+    .slice(0, opts.count);
+}
+
+export function formatBraveResults(results: BraveWebResult[]): string {
+  const items = results.map((r, i) => {
+    const content = [
+      `Web Page Title: ${r.title || "Unknown"}`,
+      `Web Page URL: ${r.url}`,
+      r.description ? `Web Page Description: ${r.description.replaceAll("<strong>", "").replaceAll("</strong>", "")}` : ""
+    ]
+      .filter(Boolean)
+      .join("\n");
+    return `<item index="${i + 1}">\n<page_content>\n${content}\n</page_content>\n</item>`;
+  });
+  return `<search_results>\n${items.join("\n")}\n</search_results>`;
+}
+

--- a/workers/articlecheck/common/src/crypto.ts
+++ b/workers/articlecheck/common/src/crypto.ts
@@ -1,0 +1,29 @@
+import { timingSafeEqual, toLowerAscii } from "./strings";
+
+const encoder = new TextEncoder();
+
+function hexEncode(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+export async function verifyHmacSha256HexSignature(opts: {
+  secret: string;
+  payload: ArrayBuffer;
+  expectedHexDigest: string;
+}): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(opts.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, opts.payload);
+  const ours = toLowerAscii(hexEncode(mac));
+  const theirs = toLowerAscii(opts.expectedHexDigest);
+  return timingSafeEqual(ours, theirs);
+}
+

--- a/workers/articlecheck/common/src/github/api.ts
+++ b/workers/articlecheck/common/src/github/api.ts
@@ -1,0 +1,49 @@
+export type GitHubApiConfig = {
+  token: string;
+};
+
+export async function githubRequestJson<T>(opts: {
+  method?: string;
+  url: string;
+  token: string;
+  body?: unknown;
+}): Promise<T> {
+  const resp = await fetch(opts.url, {
+    method: opts.method ?? "GET",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `token ${opts.token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "dn-institute-articlecheck-worker",
+      "X-GitHub-Api-Version": "2022-11-28"
+    },
+    body: opts.body ? JSON.stringify(opts.body) : undefined
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`github_api_error status=${resp.status} url=${opts.url} body=${text.slice(0, 1200)}`);
+  }
+  return (await resp.json()) as T;
+}
+
+export async function githubRequestText(opts: {
+  url: string;
+  token: string;
+  accept?: string;
+}): Promise<string> {
+  const resp = await fetch(opts.url, {
+    method: "GET",
+    headers: {
+      Accept: opts.accept ?? "application/vnd.github.raw",
+      Authorization: `token ${opts.token}`,
+      "User-Agent": "dn-institute-articlecheck-worker",
+      "X-GitHub-Api-Version": "2022-11-28"
+    }
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`github_api_error status=${resp.status} url=${opts.url} body=${text.slice(0, 1200)}`);
+  }
+  return await resp.text();
+}
+

--- a/workers/articlecheck/common/src/github/app.ts
+++ b/workers/articlecheck/common/src/github/app.ts
@@ -1,0 +1,74 @@
+import { base64UrlEncodeString, base64UrlEncodeBytes } from "../base64url";
+import { pemToDerBytes } from "../pem";
+
+export type GitHubAppConfig = {
+  appId: string;
+  privateKeyPem: string;
+};
+
+type CachedToken = { token: string; expiresAtMs: number };
+
+// Best-effort in-memory cache per isolate. KV not necessary for short-lived installation tokens.
+const installationTokenCache = new Map<number, CachedToken>();
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+async function importGitHubAppPrivateKey(privateKeyPem: string): Promise<CryptoKey> {
+  const pkcs8 = pemToDerBytes(privateKeyPem);
+  return crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+}
+
+async function signRs256(
+  privateKey: CryptoKey,
+  data: Uint8Array<ArrayBuffer>
+): Promise<Uint8Array<ArrayBuffer>> {
+  const sig = await crypto.subtle.sign({ name: "RSASSA-PKCS1-v1_5" }, privateKey, data);
+  return new Uint8Array(sig) as Uint8Array<ArrayBuffer>;
+}
+
+export async function createGitHubAppJwt(opts: GitHubAppConfig): Promise<string> {
+  const iat = nowSeconds() - 5;
+  const exp = iat + 9 * 60; // <= 10 minutes per GitHub docs; keep a buffer.
+  const header = base64UrlEncodeString(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64UrlEncodeString(JSON.stringify({ iat, exp, iss: opts.appId }));
+  const signingInput = `${header}.${payload}`;
+  const key = await importGitHubAppPrivateKey(opts.privateKeyPem);
+  const sigBytes = await signRs256(key, new TextEncoder().encode(signingInput) as Uint8Array<ArrayBuffer>);
+  const sig = base64UrlEncodeBytes(sigBytes);
+  return `${signingInput}.${sig}`;
+}
+
+export async function getInstallationAccessToken(opts: {
+  installationId: number;
+  app: GitHubAppConfig;
+}): Promise<string> {
+  const cached = installationTokenCache.get(opts.installationId);
+  if (cached && cached.expiresAtMs - Date.now() > 60_000) return cached.token; // 60s safety window
+
+  const jwt = await createGitHubAppJwt(opts.app);
+  const resp = await fetch(`https://api.github.com/app/installations/${opts.installationId}/access_tokens`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${jwt}`,
+      "User-Agent": "dn-institute-articlecheck-worker",
+      "X-GitHub-Api-Version": "2022-11-28"
+    }
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`github_installation_token_failed status=${resp.status} body=${text.slice(0, 600)}`);
+  }
+  const data = (await resp.json()) as { token: string; expires_at: string };
+  const expiresAtMs = Date.parse(data.expires_at);
+  installationTokenCache.set(opts.installationId, { token: data.token, expiresAtMs });
+  return data.token;
+}

--- a/workers/articlecheck/common/src/github/events.ts
+++ b/workers/articlecheck/common/src/github/events.ts
@@ -1,0 +1,21 @@
+export type IssueCommentCreatedEvent = {
+  action: "created";
+  issue: {
+    number: number;
+    pull_request?: unknown;
+  };
+  comment: {
+    id: number;
+    body: string;
+  };
+  repository: {
+    full_name: string;
+  };
+  sender: {
+    login: string;
+  };
+  installation?: {
+    id: number;
+  };
+};
+

--- a/workers/articlecheck/common/src/github/webhook.ts
+++ b/workers/articlecheck/common/src/github/webhook.ts
@@ -1,0 +1,34 @@
+import { verifyHmacSha256HexSignature } from "../crypto";
+
+export type GitHubWebhookHeaders = {
+  event: string | null;
+  deliveryId: string | null;
+  signature256: string | null;
+};
+
+export function readGitHubWebhookHeaders(headers: Headers): GitHubWebhookHeaders {
+  return {
+    event: headers.get("X-GitHub-Event"),
+    deliveryId: headers.get("X-GitHub-Delivery"),
+    signature256: headers.get("X-Hub-Signature-256")
+  };
+}
+
+export async function verifyGitHubWebhookSignature(opts: {
+  headers: GitHubWebhookHeaders;
+  secret: string | undefined;
+  rawBody: ArrayBuffer;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  if (!opts.secret) return { ok: false, reason: "missing_webhook_secret" };
+  const sig = opts.headers.signature256;
+  if (!sig || !sig.startsWith("sha256=")) return { ok: false, reason: "missing_signature" };
+  const expected = sig.slice("sha256=".length);
+  if (!expected) return { ok: false, reason: "missing_signature_digest" };
+  const ok = await verifyHmacSha256HexSignature({
+    secret: opts.secret,
+    payload: opts.rawBody,
+    expectedHexDigest: expected
+  });
+  return ok ? { ok: true } : { ok: false, reason: "bad_signature" };
+}
+

--- a/workers/articlecheck/common/src/job.ts
+++ b/workers/articlecheck/common/src/job.ts
@@ -1,0 +1,9 @@
+export type ArticleCheckJob = {
+  delivery_id: string;
+  repo_full_name: string;
+  pr_number: number;
+  comment_id: number;
+  actor: string;
+  installation_id: number;
+};
+

--- a/workers/articlecheck/common/src/log.ts
+++ b/workers/articlecheck/common/src/log.ts
@@ -1,0 +1,27 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogRecord = {
+  level: LogLevel;
+  msg: string;
+  at: string;
+  [key: string]: unknown;
+};
+
+export function log(level: LogLevel, msg: string, fields: Record<string, unknown> = {}): void {
+  const rec: LogRecord = {
+    level,
+    msg,
+    at: new Date().toISOString(),
+    ...fields
+  };
+  // Cloudflare Logs is line-oriented; JSON keeps it grep-friendly and structured.
+  console.log(JSON.stringify(rec));
+}
+
+export const logger = {
+  debug: (msg: string, fields?: Record<string, unknown>) => log("debug", msg, fields),
+  info: (msg: string, fields?: Record<string, unknown>) => log("info", msg, fields),
+  warn: (msg: string, fields?: Record<string, unknown>) => log("warn", msg, fields),
+  error: (msg: string, fields?: Record<string, unknown>) => log("error", msg, fields)
+};
+

--- a/workers/articlecheck/common/src/pem.ts
+++ b/workers/articlecheck/common/src/pem.ts
@@ -1,0 +1,15 @@
+import { base64DecodeToBytes } from "./base64url";
+
+export function normalizePem(pem: string): string {
+  // Wrangler secrets often end up with literal "\n" sequences.
+  return pem.replace(/\\n/g, "\n").trim();
+}
+
+export function pemToDerBytes(pem: string): Uint8Array<ArrayBuffer> {
+  const normalized = normalizePem(pem);
+  const body = normalized
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  return base64DecodeToBytes(body);
+}

--- a/workers/articlecheck/common/src/prompts.ts
+++ b/workers/articlecheck/common/src/prompts.ts
@@ -1,0 +1,105 @@
+// Ported (verbatim) from tools/article_checker/claude_retriever/client.py where practical.
+
+export const EXTRACTING_PROMPT = `
+Please extract important statements that appear to be factual from the text provided between <text></text> tags.
+Return the extracted statements. Place each statement within <statement></statement> tags.
+Also, return the number of extracted statements within <number_of_statements></number_of_statements> tags.
+Aim to extract important statements with numbers, dates, and names of organizations. There should not be too many extracted statements.
+Skip the preamble; go straight into the result.
+`;
+
+// Instead of interactive tool-calling (used in the Python version), we provide search results up-front.
+export const VERDICT_PROMPT = `
+Your timeline extends up to the current one.
+You are tasked with verifying the accuracy of a series of factual statements using a search engine.
+For each <statement></statement> block, you will also be given <search_results></search_results> (multiple items).
+
+Based ONLY on information that is contained in the <search_results>, determine the accuracy of each statement and categorize it as 'True', 'False', or 'Unverified'.
+Put your verdict in <verdict></verdict> tags.
+Include the best supporting Web Page URL in <source></source> tags. If there is no suitable URL at all, put 'None'.
+If a statement is false, include an explanation in <explanation></explanation> tags.
+Focus particularly on verifying numbers, dates, monetary values, and names of people or organizations.
+Do not introduce any information that is not supported by the <search_results>.
+
+Return results as a flat list of repeated tags:
+<statement>...</statement>
+<verdict>True|False|Unverified</verdict>
+<source>...</source>
+<explanation>...</explanation>
+`;
+
+export const ANSWER_PROMPT = `
+You are an editor. Perform the following tasks:
+1. Using the information provided within the <fact_checking_results></fact_checking_results> tags, 
+please form the desired output with results of fact-checking. 
+List each statement from the tags <statement></statement> and accompany it with the fact-checking source 
+between the tags <source></source>.  If there is no source, try to find a related link in the text between <text></text> tags and place this link in the "source" field. If there is no source at all put "None" in the "source" field.
+If the verdict is True, put the symbol ":white_check_mark:" after the statement.
+If the verdict is False, put the symbol ":x:" after the statement and also provide an explanation why.
+If the verdict is Unverified or the link was taken from the text in <text></text> tags, put the symbol ":warning:" after the statement.
+Output example:
+'''- **Statement**: Squid Game: November 1, 2021 - $5.7m :x:
+  - **Source**: [https://www.wired.co.uk/article/squid-game-crypto-scam](https://www.wired.co.uk/article/squid-game-crypto-scam)
+  - **Explanation**: The article states the Squid Game crypto scam creators pulled out $3.36 million on November 1, 2021, not $5.7 million as the statement claims.'''
+
+2. Make detailed editor's notes on the text in <text></text> tags. 
+Suggest stylistic and grammatical improvements and point out any error in the text between <text></text> tags. 
+Please make sure that in the '## Timeline' section, dates are written in the correct format 'Month day, year, time PM UTC:'.
+Example: 'May 05, 2023, 05:52 PM UTC:'.
+Put your detailed notes and the list of errors below the header. 
+Output example:
+'''## Editor's Notes
+...'''
+
+3. Additionally, since the text between <text></text> is a Markdown document for Hugo SSG, ensure it adheres to specific Markdown formatting requirements.
+If it adheres, put the symbol ":white_check_mark:".
+If does not adhere, put the symbol ":x:" and also provide an explanation why.
+If you are not sure, put the symbol ":warning:".
+Output example:
+'''## Hugo SSG Formatting Check
+- Does it match Hugo SSG formatting? :x:
+  - **Explanation**: ...'''
+
+4. Check if the text between <text></text> follows the Markdown format, including appropriate headers.
+Confirm if it meets submission guidelines, particularly the file naming convention ("YYYY-MM-DD-entity-that-was-hacked.md"). Extract the name of the file from the text between <text></text> tags and compare it to the correct name.
+Pay special attention to matching the dates and names in the filename with the dates and names from the text.
+Verify that the text between <text></text> includes only the allowed headers: "## Summary", "## Attackers", "## Losses", "## Timeline", "## Security Failure Causes".
+Check for the presence of specific metadata headers between "---" lines, such as "date", "target-entities", "entity-types", "attack-types", "title", "loss" in the text within <text></text> tags. It must contain all and only allowed metadata headers.
+
+The 'date' metadata header must match the actual date of the event described within the <text></text> tags, possibly mentioned in the Summary section. 
+To achieve this, search for dates within the text to identify the occurrence date of the event. 
+Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two. 
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'target-entities' metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, perform a text search to identify the target entities. Then place these entities in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them. 
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'loss' metadata header must match the actual loss due the event described in the Losses section.
+To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare the two. 
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'entity-types' metadata header corresponds to the target entity. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'attack-types' metadata header matches the type of the attack described in the text. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Output example:
+'''## Filename Check
+- Correct Filename: \`2022-02-15-ValentineFloki.md\`
+- Your Filename: \`scam.md\` :x:
+
+## Section Headers Check
+- Allowed Headers: \`## Summary, ## Attackers, ## Losses, ## Timeline, ## Security Failure Causes\`
+- Your Headers: \`# Cryptocurrency Scam Types and Prevention Measures, ## 1. Rug Pull, ### Overview, ### Recognition Tips, ## 2. Honeypot, ### Overview, ### Recognition Tips\` :x:
+
+## Metadata Headers Check
+- Allowed Metadata Headers: \`date, target-entities, entity-types, attack-types, title, loss\`
+- Your Metadata Headers: \`date, target-entities, entity-types\` :x:
+- Notes: 
+    - The \`date\` header has an incorrect date. It lists 2022-03-15, whereas it should be 2022-02-15 ":warning:"
+    - The \`loss\` header displays an incorrect value. It shows $100, whereas it should indicate $1000. ":warning:"
+'''
+
+Combine the results of all steps into a single output that complies with Markdown format and return it to me in <answer></answer> tags. 
+`;
+

--- a/workers/articlecheck/common/src/strings.ts
+++ b/workers/articlecheck/common/src/strings.ts
@@ -1,0 +1,12 @@
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let out = 0;
+  for (let i = 0; i < a.length; i++) out |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return out === 0;
+}
+
+export function toLowerAscii(s: string): string {
+  // GitHub signature is hex; ASCII lowercasing is sufficient.
+  return s.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) | 32));
+}
+

--- a/workers/articlecheck/common/src/tags.ts
+++ b/workers/articlecheck/common/src/tags.ts
@@ -1,0 +1,12 @@
+export function extractAllBetweenTags(tag: string, input: string): string[] {
+  const re = new RegExp(`<${tag}\\s?>(.+?)</${tag}\\s?>`, "gs");
+  const out: string[] = [];
+  for (const m of input.matchAll(re)) out.push(m[1]?.trim() ?? "");
+  return out.filter(Boolean);
+}
+
+export function extractLastBetweenTags(tag: string, input: string): string | null {
+  const all = extractAllBetweenTags(tag, input);
+  return all.length ? all[all.length - 1] : null;
+}
+

--- a/workers/articlecheck/consumer/src/index.ts
+++ b/workers/articlecheck/consumer/src/index.ts
@@ -1,0 +1,299 @@
+import type { ArticleCheckJob } from "../../common/src/job";
+import { logger } from "../../common/src/log";
+import { getInstallationAccessToken } from "../../common/src/github/app";
+import { githubRequestJson, githubRequestText } from "../../common/src/github/api";
+import { braveSearchWeb, formatBraveResults } from "../../common/src/brave";
+import { anthropicCreateMessage } from "../../common/src/anthropic";
+import { extractAllBetweenTags, extractLastBetweenTags } from "../../common/src/tags";
+import { ANSWER_PROMPT, EXTRACTING_PROMPT, VERDICT_PROMPT } from "../../common/src/prompts";
+
+type Env = {
+  ARTICLECHECK_DEDUP: KVNamespace;
+
+  GITHUB_APP_ID: string;
+  GITHUB_APP_PRIVATE_KEY: string;
+
+  ANTHROPIC_API_KEY: string;
+  BRAVE_API_KEY: string;
+
+  ANTHROPIC_MODEL?: string;
+  ANTHROPIC_TEMPERATURE?: string;
+
+  MAX_STATEMENTS?: string;
+  MAX_SEARCH_RESULTS?: string;
+  MAX_FILES?: string;
+  MAX_ARTICLE_CHARS?: string;
+  DEDUP_TTL_SECONDS?: string;
+};
+
+type PullResponse = { head: { sha: string } };
+type PullFile = { filename: string };
+
+function clampInt(raw: string | undefined, def: number, min: number, max: number): number {
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n)) return def;
+  return Math.min(Math.max(n, min), max);
+}
+
+function marker(deliveryId: string, commentId: number): string {
+  return `<!-- articlecheck:delivery_id=${deliveryId} comment_id=${commentId} -->`;
+}
+
+async function listIssueComments(opts: {
+  repoFullName: string;
+  issueNumber: number;
+  token: string;
+  perPage?: number;
+}): Promise<Array<{ id: number; body: string }>> {
+  const perPage = Math.min(Math.max(opts.perPage ?? 100, 1), 100);
+  return await githubRequestJson<Array<{ id: number; body: string }>>({
+    url: `https://api.github.com/repos/${opts.repoFullName}/issues/${opts.issueNumber}/comments?per_page=${perPage}`,
+    token: opts.token
+  });
+}
+
+async function listPullFiles(opts: {
+  repoFullName: string;
+  prNumber: number;
+  token: string;
+}): Promise<PullFile[]> {
+  const out: PullFile[] = [];
+  for (let page = 1; page <= 10; page++) {
+    const files = await githubRequestJson<PullFile[]>({
+      url: `https://api.github.com/repos/${opts.repoFullName}/pulls/${opts.prNumber}/files?per_page=100&page=${page}`,
+      token: opts.token
+    });
+    out.push(...files);
+    if (files.length < 100) break;
+  }
+  return out;
+}
+
+async function putDedupKeys(opts: {
+  kv: KVNamespace;
+  ttlSeconds: number;
+  deliveryId: string;
+  commentId: number;
+}): Promise<void> {
+  const ttl = { expirationTtl: opts.ttlSeconds };
+  await Promise.all([
+    opts.kv.put(`delivery:${opts.deliveryId}`, "1", ttl),
+    opts.kv.put(`comment:${opts.commentId}`, "1", ttl)
+  ]);
+}
+
+async function alreadyProcessed(opts: {
+  kv: KVNamespace;
+  deliveryId: string;
+  commentId: number;
+}): Promise<boolean> {
+  const [a, b] = await Promise.all([
+    opts.kv.get(`delivery:${opts.deliveryId}`),
+    opts.kv.get(`comment:${opts.commentId}`)
+  ]);
+  return a !== null || b !== null;
+}
+
+function buildArticleText(filePath: string, content: string, maxChars: number): string {
+  const prefix = `<!-- file_path: ${filePath} -->\n\n`;
+  const body = content.length > maxChars ? `${content.slice(0, maxChars)}\n\n<!-- truncated -->\n` : content;
+  return prefix + body;
+}
+
+async function runClaudeBravePipeline(opts: {
+  anthropicApiKey: string;
+  anthropicModel: string;
+  temperature: number;
+  braveApiKey: string;
+  maxStatements: number;
+  maxSearchResults: number;
+  articleText: string;
+}): Promise<{ markdown: string; debug: { statements: string[] } }> {
+  const extracted = await anthropicCreateMessage({
+    apiKey: opts.anthropicApiKey,
+    model: opts.anthropicModel,
+    system: EXTRACTING_PROMPT,
+    messages: [{ role: "user", content: `<text>${opts.articleText}</text>` }],
+    maxTokens: 1200,
+    temperature: 0
+  });
+
+  const statements = extractAllBetweenTags("statement", extracted).slice(0, opts.maxStatements);
+
+  const searches: Array<{ statement: string; formattedResults: string }> = [];
+  for (const statement of statements) {
+    const query = statement.length > 220 ? statement.slice(0, 220) : statement;
+    const results = await braveSearchWeb({
+      apiKey: opts.braveApiKey,
+      query,
+      count: opts.maxSearchResults
+    });
+    searches.push({ statement, formattedResults: formatBraveResults(results) });
+  }
+
+  const verifyInput = searches
+    .map((s) => `<statement>${s.statement}</statement>\n${s.formattedResults}`)
+    .join("\n\n");
+
+  const verdicts = await anthropicCreateMessage({
+    apiKey: opts.anthropicApiKey,
+    model: opts.anthropicModel,
+    system: VERDICT_PROMPT,
+    messages: [{ role: "user", content: verifyInput }],
+    maxTokens: 2200,
+    temperature: 0
+  });
+
+  const answerRaw = await anthropicCreateMessage({
+    apiKey: opts.anthropicApiKey,
+    model: opts.anthropicModel,
+    system: ANSWER_PROMPT,
+    messages: [
+      {
+        role: "user",
+        content: `<fact_checking_results>${verdicts}</fact_checking_results> <text>${opts.articleText}</text>`
+      }
+    ],
+    maxTokens: 4000,
+    temperature: opts.temperature
+  });
+
+  const answer = extractLastBetweenTags("answer", answerRaw) ?? answerRaw;
+  return { markdown: answer.trim(), debug: { statements } };
+}
+
+async function processJob(job: ArticleCheckJob, env: Env): Promise<void> {
+  const ttlSeconds = clampInt(env.DEDUP_TTL_SECONDS, 60 * 60 * 24 * 7, 60, 60 * 60 * 24 * 30);
+  const maxStatements = clampInt(env.MAX_STATEMENTS, 12, 1, 30);
+  const maxSearchResults = clampInt(env.MAX_SEARCH_RESULTS, 3, 1, 10);
+  const maxFiles = clampInt(env.MAX_FILES, 1, 1, 5);
+  const maxArticleChars = clampInt(env.MAX_ARTICLE_CHARS, 60_000, 5_000, 200_000);
+
+  const model = env.ANTHROPIC_MODEL?.trim() || "claude-3-opus-20240229";
+  const temperature = env.ANTHROPIC_TEMPERATURE ? Number(env.ANTHROPIC_TEMPERATURE) : 0;
+
+  if (!env.GITHUB_APP_ID) throw new Error("missing_env:GITHUB_APP_ID");
+  if (!env.GITHUB_APP_PRIVATE_KEY) throw new Error("missing_env:GITHUB_APP_PRIVATE_KEY");
+  if (!env.ANTHROPIC_API_KEY) throw new Error("missing_env:ANTHROPIC_API_KEY");
+  if (!env.BRAVE_API_KEY) throw new Error("missing_env:BRAVE_API_KEY");
+
+  if (await alreadyProcessed({ kv: env.ARTICLECHECK_DEDUP, deliveryId: job.delivery_id, commentId: job.comment_id })) {
+    logger.info("job_dedup_kv_hit", { delivery_id: job.delivery_id, comment_id: job.comment_id });
+    return;
+  }
+
+  const token = await getInstallationAccessToken({
+    installationId: job.installation_id,
+    app: { appId: env.GITHUB_APP_ID, privateKeyPem: env.GITHUB_APP_PRIVATE_KEY }
+  });
+
+  // Marker-based dedup for KV eviction / replays.
+  const m = marker(job.delivery_id, job.comment_id);
+  const existingComments = await listIssueComments({
+    repoFullName: job.repo_full_name,
+    issueNumber: job.pr_number,
+    token,
+    perPage: 100
+  });
+  if (existingComments.some((c) => c.body.includes(m))) {
+    logger.info("job_dedup_marker_hit", { delivery_id: job.delivery_id, comment_id: job.comment_id });
+    await putDedupKeys({
+      kv: env.ARTICLECHECK_DEDUP,
+      ttlSeconds,
+      deliveryId: job.delivery_id,
+      commentId: job.comment_id
+    });
+    return;
+  }
+
+  const pull = await githubRequestJson<PullResponse>({
+    url: `https://api.github.com/repos/${job.repo_full_name}/pulls/${job.pr_number}`,
+    token
+  });
+
+  const files = await listPullFiles({ repoFullName: job.repo_full_name, prNumber: job.pr_number, token });
+  const attackFiles = files
+    .map((f) => f.filename)
+    .filter((p) => p.startsWith("content/attacks/") && p.endsWith(".md"));
+
+  if (attackFiles.length === 0) {
+    const body = `${m}\n\nNo files under \`content/attacks/*.md\` were changed in this PR, so I did not run the article checker.\n`;
+    await githubRequestJson({
+      method: "POST",
+      url: `https://api.github.com/repos/${job.repo_full_name}/issues/${job.pr_number}/comments`,
+      token,
+      body: { body }
+    });
+    await putDedupKeys({ kv: env.ARTICLECHECK_DEDUP, ttlSeconds, deliveryId: job.delivery_id, commentId: job.comment_id });
+    return;
+  }
+
+  const selected = attackFiles.slice(0, maxFiles);
+  const extraCount = attackFiles.length - selected.length;
+
+  let commentBody = `${m}\n\n`;
+  if (extraCount > 0) commentBody += `Note: only checked the first ${selected.length} file(s); ${extraCount} additional matching file(s) were skipped for resource bounds.\n\n`;
+
+  for (const filePath of selected) {
+    const raw = await githubRequestText({
+      url: `https://api.github.com/repos/${job.repo_full_name}/contents/${filePath}?ref=${pull.head.sha}`,
+      token,
+      accept: "application/vnd.github.raw"
+    });
+    const articleText = buildArticleText(filePath, raw, maxArticleChars);
+
+    logger.info("running_pipeline", {
+      delivery_id: job.delivery_id,
+      repo: job.repo_full_name,
+      pr_number: job.pr_number,
+      file: filePath
+    });
+
+    const result = await runClaudeBravePipeline({
+      anthropicApiKey: env.ANTHROPIC_API_KEY,
+      anthropicModel: model,
+      temperature,
+      braveApiKey: env.BRAVE_API_KEY,
+      maxStatements,
+      maxSearchResults,
+      articleText
+    });
+
+    commentBody += `### ${filePath}\n\n${result.markdown}\n\n`;
+  }
+
+  // Post as a single comment to keep idempotency simple.
+  await githubRequestJson({
+    method: "POST",
+    url: `https://api.github.com/repos/${job.repo_full_name}/issues/${job.pr_number}/comments`,
+    token,
+    body: { body: commentBody }
+  });
+
+  await putDedupKeys({ kv: env.ARTICLECHECK_DEDUP, ttlSeconds, deliveryId: job.delivery_id, commentId: job.comment_id });
+  logger.info("job_completed", { delivery_id: job.delivery_id, repo: job.repo_full_name, pr_number: job.pr_number });
+}
+
+export default {
+  async queue(batch: MessageBatch<ArticleCheckJob>, env: Env, ctx: ExecutionContext): Promise<void> {
+    for (const message of batch.messages) {
+      ctx.waitUntil(
+        (async () => {
+          try {
+            await processJob(message.body, env);
+            message.ack();
+          } catch (err) {
+            logger.error("job_failed", {
+              delivery_id: message.body?.delivery_id,
+              repo: message.body?.repo_full_name,
+              pr_number: message.body?.pr_number,
+              err: String(err)
+            });
+            message.retry();
+          }
+        })()
+      );
+    }
+  }
+};
+

--- a/workers/articlecheck/consumer/wrangler.toml
+++ b/workers/articlecheck/consumer/wrangler.toml
@@ -1,0 +1,29 @@
+name = "dn-institute-articlecheck-consumer"
+main = "src/index.ts"
+compatibility_date = "2026-02-06"
+
+[[queues.consumers]]
+queue = "dn-institute-articlecheck"
+max_batch_size = 1
+max_batch_timeout = 5
+
+[[kv_namespaces]]
+binding = "ARTICLECHECK_DEDUP"
+# Set via: `wrangler kv namespace create ARTICLECHECK_DEDUP`
+id = "REPLACE_ME"
+
+# Secrets (set via `wrangler secret put ...`):
+# - GITHUB_APP_PRIVATE_KEY
+# - ANTHROPIC_API_KEY
+# - BRAVE_API_KEY
+#
+# Vars:
+# - GITHUB_APP_ID
+# - ANTHROPIC_MODEL (optional)
+# - ANTHROPIC_TEMPERATURE (optional, default 0)
+# - MAX_STATEMENTS (optional)
+# - MAX_SEARCH_RESULTS (optional)
+# - MAX_FILES (optional)
+# - MAX_ARTICLE_CHARS (optional)
+# - DEDUP_TTL_SECONDS (optional)
+

--- a/workers/articlecheck/package-lock.json
+++ b/workers/articlecheck/package-lock.json
@@ -1,0 +1,1460 @@
+{
+  "name": "dn-institute-articlecheck-workers",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dn-institute-articlecheck-workers",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260206.0",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.3",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260206.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260206.0.tgz",
+      "integrity": "sha512-rHbE1XM3mfwzoyOiKm1oFRTp00Cv4U5UiuMDQwmu/pc79yOA3nDiOC0lue8aOpobBrP4tPHQqsPcWG606Zrw/w==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
+      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/workers/articlecheck/package.json
+++ b/workers/articlecheck/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dn-institute-articlecheck-workers",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260206.0",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}
+

--- a/workers/articlecheck/producer/src/index.ts
+++ b/workers/articlecheck/producer/src/index.ts
@@ -1,0 +1,98 @@
+import { parseReviewerAllowlist } from "../../common/src/allowlist";
+import { logger } from "../../common/src/log";
+import type { IssueCommentCreatedEvent } from "../../common/src/github/events";
+import { readGitHubWebhookHeaders, verifyGitHubWebhookSignature } from "../../common/src/github/webhook";
+import type { ArticleCheckJob } from "../../common/src/job";
+
+export type Env = {
+  GITHUB_WEBHOOK_SECRET?: string;
+  WIKI_REVIEWERS?: string;
+  ARTICLECHECK_QUEUE: Queue<ArticleCheckJob>;
+};
+
+function isArticleCheckCommand(body: string): boolean {
+  return body.includes("/articlecheck");
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+
+    const headers = readGitHubWebhookHeaders(request.headers);
+    const rawBody = await request.arrayBuffer();
+
+    const sig = await verifyGitHubWebhookSignature({
+      headers,
+      secret: env.GITHUB_WEBHOOK_SECRET,
+      rawBody
+    });
+    if (!sig.ok) {
+      logger.warn("github_webhook_signature_rejected", {
+        reason: sig.reason,
+        delivery_id: headers.deliveryId,
+        event: headers.event
+      });
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    if (headers.event !== "issue_comment") return new Response("Ignored", { status: 200 });
+
+    let payload: IssueCommentCreatedEvent;
+    try {
+      payload = JSON.parse(new TextDecoder().decode(rawBody)) as IssueCommentCreatedEvent;
+    } catch (err) {
+      logger.warn("bad_json_payload", { delivery_id: headers.deliveryId, err: String(err) });
+      return new Response("Bad Request", { status: 400 });
+    }
+
+    const deliveryId = headers.deliveryId;
+    if (!deliveryId) {
+      // Not expected from GitHub, but keep behavior explicit.
+      logger.warn("missing_delivery_id");
+      return new Response("Bad Request", { status: 400 });
+    }
+
+    if (payload.action !== "created") return new Response("Ignored", { status: 200 });
+    if (!payload.issue.pull_request) return new Response("Ignored", { status: 200 });
+    if (!isArticleCheckCommand(payload.comment.body)) return new Response("Ignored", { status: 200 });
+
+    const allowlist = parseReviewerAllowlist(env.WIKI_REVIEWERS);
+    const actor = payload.sender.login.toLowerCase();
+    if (!allowlist.has(actor)) {
+      logger.info("actor_not_allowlisted", { actor, delivery_id: deliveryId });
+      return new Response("Ignored", { status: 200 });
+    }
+
+    const installationId = payload.installation?.id;
+    if (!installationId) {
+      // With GitHub App webhooks, this should be present. Fail closed (no expensive work).
+      logger.warn("missing_installation_id", { delivery_id: deliveryId, repo: payload.repository.full_name });
+      return new Response("Ignored", { status: 200 });
+    }
+
+    const job: ArticleCheckJob = {
+      delivery_id: deliveryId,
+      repo_full_name: payload.repository.full_name,
+      pr_number: payload.issue.number,
+      comment_id: payload.comment.id,
+      actor,
+      installation_id: installationId
+    };
+
+    ctx.waitUntil(
+      (async () => {
+        await env.ARTICLECHECK_QUEUE.send(job);
+        logger.info("queued_articlecheck_job", {
+          delivery_id: deliveryId,
+          repo: job.repo_full_name,
+          pr_number: job.pr_number,
+          comment_id: job.comment_id,
+          actor: job.actor
+        });
+      })()
+    );
+
+    // GitHub expects a response within ~10s. Queueing lets us return fast.
+    return new Response("Accepted", { status: 202 });
+  }
+};

--- a/workers/articlecheck/producer/wrangler.toml
+++ b/workers/articlecheck/producer/wrangler.toml
@@ -1,0 +1,15 @@
+name = "dn-institute-articlecheck-producer"
+main = "src/index.ts"
+compatibility_date = "2026-02-06"
+
+# Producer bindings
+[[queues.producers]]
+binding = "ARTICLECHECK_QUEUE"
+queue = "dn-institute-articlecheck"
+
+# Secrets (set via `wrangler secret put ...`):
+# - GITHUB_WEBHOOK_SECRET
+#
+# Vars:
+# - WIKI_REVIEWERS: JSON array (preferred) or newline-delimited list of GitHub usernames.
+

--- a/workers/articlecheck/test/allowlist.test.ts
+++ b/workers/articlecheck/test/allowlist.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseReviewerAllowlist } from "../common/src/allowlist";
+
+describe("parseReviewerAllowlist", () => {
+  it("parses JSON array (preferred format)", () => {
+    const s = parseReviewerAllowlist('["Alice","bob","  Carol  "]');
+    expect([...s].sort()).toEqual(["alice", "bob", "carol"]);
+  });
+
+  it("parses newline/comma separated list", () => {
+    const s = parseReviewerAllowlist("Alice\nbob,carol");
+    expect([...s].sort()).toEqual(["alice", "bob", "carol"]);
+  });
+
+  it("handles empty input", () => {
+    expect(parseReviewerAllowlist("").size).toBe(0);
+    expect(parseReviewerAllowlist(undefined).size).toBe(0);
+  });
+});
+

--- a/workers/articlecheck/test/jwt.test.ts
+++ b/workers/articlecheck/test/jwt.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { createGitHubAppJwt } from "../common/src/github/app";
+import { pemToDerBytes } from "../common/src/pem";
+
+function base64UrlToBytes(b64url: string): Uint8Array<ArrayBuffer> {
+  let s = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  while (s.length % 4) s += "=";
+  const bin = atob(s);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes as Uint8Array<ArrayBuffer>;
+}
+
+function base64UrlToJson(b64url: string): any {
+  const bytes = base64UrlToBytes(b64url);
+  const txt = new TextDecoder().decode(bytes);
+  return JSON.parse(txt);
+}
+
+describe("createGitHubAppJwt", () => {
+  it("creates a verifiable RS256 JWT", async () => {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" }
+    });
+
+    const jwt = await createGitHubAppJwt({ appId: "12345", privateKeyPem: privateKey });
+    const [h, p, s] = jwt.split(".");
+    expect(h).toBeTruthy();
+    expect(p).toBeTruthy();
+    expect(s).toBeTruthy();
+
+    const header = base64UrlToJson(h);
+    const payload = base64UrlToJson(p);
+    expect(header.alg).toBe("RS256");
+    expect(payload.iss).toBe("12345");
+    expect(typeof payload.iat).toBe("number");
+    expect(typeof payload.exp).toBe("number");
+
+    const verifyKey = await crypto.subtle.importKey(
+      "spki",
+      pemToDerBytes(publicKey),
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["verify"]
+    );
+
+    const signingInput = new TextEncoder().encode(`${h}.${p}`) as Uint8Array<ArrayBuffer>;
+    const sigBytes = base64UrlToBytes(s);
+    const ok = await crypto.subtle.verify({ name: "RSASSA-PKCS1-v1_5" }, verifyKey, sigBytes, signingInput);
+    expect(ok).toBe(true);
+  });
+});
+

--- a/workers/articlecheck/test/signature.test.ts
+++ b/workers/articlecheck/test/signature.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { verifyGitHubWebhookSignature } from "../common/src/github/webhook";
+
+async function hmacHex(secret: string, payload: ArrayBuffer): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, payload);
+  const bytes = new Uint8Array(mac);
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("verifyGitHubWebhookSignature", () => {
+  it("accepts a valid sha256 signature", async () => {
+    const secret = "test-secret";
+    const rawBody = new TextEncoder().encode(JSON.stringify({ hello: "world" })).buffer;
+    const digest = await hmacHex(secret, rawBody);
+
+    const res = await verifyGitHubWebhookSignature({
+      headers: { event: "issue_comment", deliveryId: "d1", signature256: `sha256=${digest}` },
+      secret,
+      rawBody
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects an invalid signature", async () => {
+    const secret = "test-secret";
+    const rawBody = new TextEncoder().encode("x").buffer;
+    const res = await verifyGitHubWebhookSignature({
+      headers: { event: "issue_comment", deliveryId: "d1", signature256: "sha256=deadbeef" },
+      secret,
+      rawBody
+    });
+    expect(res.ok).toBe(false);
+  });
+});
+

--- a/workers/articlecheck/test/tags.test.ts
+++ b/workers/articlecheck/test/tags.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { extractAllBetweenTags, extractLastBetweenTags } from "../common/src/tags";
+
+describe("tags", () => {
+  it("extracts all occurrences", () => {
+    const out = extractAllBetweenTags("statement", "<statement>a</statement> x <statement>b</statement>");
+    expect(out).toEqual(["a", "b"]);
+  });
+
+  it("extracts last occurrence", () => {
+    const out = extractLastBetweenTags("answer", "<answer>one</answer><answer>two</answer>");
+    expect(out).toBe("two");
+  });
+});
+

--- a/workers/articlecheck/tsconfig.json
+++ b/workers/articlecheck/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./**/*.ts"]
+}
+

--- a/workers/articlecheck/vitest.config.ts
+++ b/workers/articlecheck/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"]
+  }
+});
+


### PR DESCRIPTION
Implements issue #425 by migrating the /articlecheck QA bot from GitHub Actions to a webhook-based Cloudflare Workers solution.

Key points:
- Two-worker async architecture via Cloudflare Queues:
  - Producer worker: GitHub issue_comment webhook receiver, X-Hub-Signature-256 verification, reviewer allowlist gate, enqueue job, fast 202 response.
  - Consumer worker: GitHub App auth (installation token), fetch full content/attacks/*.md content at PR head SHA, run Claude + Brave pipeline, post PR comment.
- Idempotency:
  - KV-backed dedup on delivery_id + comment_id
  - Hidden HTML marker in posted comments
- TypeScript strict mode + unit tests for signature verification, allowlist parsing, tag extraction, and GitHub App JWT signing.

Docs:
- workers/articlecheck/README.md includes deployment steps (GitHub App, webhook, secrets, Queue, KV, wrangler deploy).

Notes:
- The legacy GitHub Actions workflow is retained but disabled (workflow_dispatch only) to avoid duplicate runs.
