### PR TITLE
Add integration tests for Similarity Search API

### DIFF
--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,122 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const VALID_HEADERS = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key",
+}
+
+function validBody(overrides?: Record<string, unknown>) {
+  return JSON.stringify({ text: "sample text", namespace: "test-ns", ...overrides })
+}
+
 describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
+  it.each([
+    { case: "missing", headers: { "Content-Type": "application/json" } },
+    { case: "invalid", headers: { "Content-Type": "application/json", "X-API-Key": "wrong-key" } },
+  ])("returns 401 when API key is $case", async ({ headers }) => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
+      headers,
+      body: validBody(),
     })
-
     expect(response.status).toBe(401)
-    expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("accepts requests with a valid API key", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: validBody(),
+    })
+    expect(response.status).toBe(200)
+  })
+})
+
+describe("Input Validation", () => {
+  it.each([
+    { case: "text is missing", body: { namespace: "ns" } },
+    { case: "namespace is missing", body: { text: "hello" } },
+    { case: "text is not a string", body: { text: 123, namespace: "ns" } },
+    { case: "namespace is not a string", body: { text: "hello", namespace: 42 } },
+    { case: "both fields are missing", body: {} },
+  ])("returns 400 when $case", async ({ body }) => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify(body),
+    })
+    expect(response.status).toBe(400)
+  })
+})
+
+describe("Routing", () => {
+  it("returns 404 for unregistered paths", async () => {
+    const response = await SELF.fetch("https://example.com/nonexistent", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: validBody(),
+    })
+    expect(response.status).toBe(404)
+  })
+
+  it("returns 404 for non-POST methods on /", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "GET",
+      headers: VALID_HEADERS,
+    })
+    expect(response.status).toBe(404)
+  })
+})
+
+describe("Similarity Search", () => {
+  it("returns 200 with a similarity_score for valid input", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: validBody(),
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json<{ similarity_score: number }>()
+    expect(data).toHaveProperty("similarity_score")
+    expect(typeof data.similarity_score).toBe("number")
+  })
+
+  it("returns the score produced by the Vectorize index", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: validBody(),
+    })
+    const data = await response.json<{ similarity_score: number }>()
+    expect(data.similarity_score).toBe(0.5678)
+  })
+
+  it("processes different text inputs without error", async () => {
+    const inputs = [
+      { text: "short", namespace: "ns" },
+      { text: "a longer piece of text that contains multiple words and phrases", namespace: "articles" },
+      { text: "Unicode: Ünîcödé テスト 你好", namespace: "multilingual" },
+    ]
+
+    for (const body of inputs) {
+      const response = await SELF.fetch("https://example.com/", {
+        method: "POST",
+        headers: VALID_HEADERS,
+        body: JSON.stringify(body),
+      })
+      expect(response.status).toBe(200)
+      const data = await response.json<{ similarity_score: number }>()
+      expect(typeof data.similarity_score).toBe("number")
+    }
+  })
+
+  it("returns JSON content type", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: validBody(),
+    })
+    expect(response.headers.get("content-type")).toContain("application/json")
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,9 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    const dim = 768;
+                    const vector = new Array(dim).fill(0).map((_, i) => Math.sin(i));
+                    return Promise.resolve({ data: [vector] });
                   }
                 };
               };`


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for the Similarity Search Cloudflare Worker, expanding from the single existing authentication test to 12 test cases organized into four groups.

### Test Coverage

**Authentication (2 tests)**
- Missing API key header returns 401
- Invalid API key header returns 401
- Valid API key proceeds to handler (tested implicitly)

**Input Validation (5 parameterized tests)**
- Missing `text` field returns 400
- Missing `namespace` field returns 400
- Non-string `text` field returns 400
- Non-string `namespace` field returns 400
- Empty body returns 400

**Routing (2 tests)**
- Unregistered paths return 404
- Non-POST methods on `/` return 404

**Core Functionality (4 tests)**
- Valid input returns 200 with `similarity_score` property
- Score matches Vectorize mock output (0.5678)
- Varied text inputs (short, long, Unicode) all process successfully
- Response has JSON content type

### Implementation Notes

- Uses `SELF.fetch` from `cloudflare:test` for integration-style testing
- Uses `it.each` for parameterized test cases
- Asserts only on status codes, not error message wording
- Fixed Workers AI mock to return a realistic 768-dimension embedding vector instead of `{ data: {} }`

Closes #430

cc @evgenydmitriev — requesting review per issue instructions.