### PR TITLE
🌰 feat: add batch message processing to Similarity Search API

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,14 @@ type TextEntry = {
   namespace: string
 }
 
+type BatchRequest = {
+  messages: TextEntry[]
+}
+
+// Cloudflare Workers subrequest limit is 50. Each Vectorize query is 1 subrequest,
+// plus 1 for the AI embedding call, leaving room for 48 batch items.
+const MAX_BATCH_SIZE = 48
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -27,6 +35,25 @@ app.use("*", async (c, next) => {
   return next()
 })
 
+async function embedTexts(ai: Ai, texts: string[]): Promise<number[][]> {
+  const modelResp = await ai.run("@cf/baai/bge-base-en-v1.5", {
+    text: texts
+  })
+  return modelResp.data
+}
+
+async function querySimilarity(
+  index: VectorizeIndex,
+  vector: number[],
+  namespace: string
+): Promise<number> {
+  const searchResponse = await index.query(vector, {
+    namespace,
+    topK: 1
+  })
+  return searchResponse.matches[0]?.score || 0
+}
+
 app.post("/", async (c) => {
   const data = await c.req.json<TextEntry>()
   const { text, namespace } = data
@@ -35,17 +62,44 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: [text]
-  })
-  const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
-    namespace,
-    topK: 1
-  })
-  const similarityScore = searchResponse.matches[0]?.score || 0
+  const vectors = await embedTexts(c.env.AI, [text])
+  const similarityScore = await querySimilarity(c.env.VECTORIZE_INDEX, vectors[0], namespace)
 
   return c.json({ similarity_score: similarityScore })
+})
+
+app.post("/batch", async (c) => {
+  const data = await c.req.json<BatchRequest>()
+  const { messages } = data
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return c.text("Invalid JSON format: expected non-empty 'messages' array", 400)
+  }
+
+  if (messages.length > MAX_BATCH_SIZE) {
+    return c.text(`Batch size exceeds maximum of ${MAX_BATCH_SIZE}`, 400)
+  }
+
+  for (const msg of messages) {
+    if (typeof msg.text !== "string" || typeof msg.namespace !== "string") {
+      return c.text("Invalid JSON format: each message must have 'text' and 'namespace' strings", 400)
+    }
+  }
+
+  // Single AI call for all texts — native batch support in the embedding model
+  const texts = messages.map((m) => m.text)
+  const vectors = await embedTexts(c.env.AI, texts)
+
+  // Parallel Vectorize queries for each vector
+  const scores = await Promise.all(
+    vectors.map((vector, i) =>
+      querySimilarity(c.env.VECTORIZE_INDEX, vector, messages[i].namespace)
+    )
+  )
+
+  const results = scores.map((score) => ({ similarity_score: score }))
+
+  return c.json({ results })
 })
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,126 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const VALID_API_KEY = "test-api-key"
+
+function makeHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" }
+  if (apiKey) {
+    headers["X-API-Key"] = apiKey
+  }
+  return headers
+}
+
 describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
+  it("returns 401 Unauthorized when API key is missing", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
+      headers: makeHeaders(),
+      body: JSON.stringify({ text: "Sample text", namespace: "test-namespace" })
     })
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 Unauthorized when API key is invalid", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: makeHeaders("wrong-key"),
+      body: JSON.stringify({ text: "Sample text", namespace: "test-namespace" })
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Single message endpoint: POST /", () => {
+  it("returns 400 for invalid JSON format", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: makeHeaders(VALID_API_KEY),
+      body: JSON.stringify({ text: 123, namespace: "test" })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is missing", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: makeHeaders(VALID_API_KEY),
+      body: JSON.stringify({ text: "hello" })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+})
+
+describe("Batch endpoint: POST /batch", () => {
+  it("returns 401 Unauthorized without API key", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: makeHeaders(),
+      body: JSON.stringify({ messages: [{ text: "hello", namespace: "test" }] })
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it("returns 400 for empty messages array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: makeHeaders(VALID_API_KEY),
+      body: JSON.stringify({ messages: [] })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("non-empty")
+  })
+
+  it("returns 400 when messages is not an array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: makeHeaders(VALID_API_KEY),
+      body: JSON.stringify({ messages: "not-an-array" })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("non-empty")
+  })
+
+  it("returns 400 when batch size exceeds maximum", async () => {
+    const messages = Array.from({ length: 49 }, (_, i) => ({
+      text: `message ${i}`,
+      namespace: "test"
+    }))
+
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: makeHeaders(VALID_API_KEY),
+      body: JSON.stringify({ messages })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("exceeds maximum")
+  })
+
+  it("returns 400 when a message has invalid format", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: makeHeaders(VALID_API_KEY),
+      body: JSON.stringify({
+        messages: [
+          { text: "valid", namespace: "test" },
+          { text: 123, namespace: "test" }
+        ]
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("each message")
   })
 })


### PR DESCRIPTION
Fixes #431

## 🌰 Summary

Adds a `/batch` endpoint to the Similarity Search API that processes multiple messages in a single request, optimizing for throughput while respecting Cloudflare Workers resource limits.

## 🌰 Design decisions

### Single embedding call for all texts
The `@cf/baai/bge-base-en-v1.5` model natively supports batch input (`text: string[]`). Instead of making N separate AI calls, the batch endpoint makes exactly 1 AI call regardless of batch size. This is the primary performance optimization — embedding is the most expensive operation, and batching it eliminates N-1 round trips.

### Parallel Vectorize queries
After embedding, each vector needs its own Vectorize query because messages can specify different namespaces. These queries run in parallel via `Promise.all`, minimizing wall-clock time.

### Batch size limit of 48
Cloudflare Workers have a 50-subrequest limit per invocation. The batch uses 1 subrequest for the AI embedding call + 1 subrequest per Vectorize query. Setting `MAX_BATCH_SIZE = 48` leaves headroom within the 50-subrequest budget.

### Shared helper functions
Extracted `embedTexts()` and `querySimilarity()` from the single-message endpoint so both endpoints share the same logic. The existing `/` endpoint still works identically — the refactor is non-breaking.

## 🌰 API

### `POST /batch`

Request:
```json
{
  "messages": [
    {"text": "first message", "namespace": "ns1"},
    {"text": "second message", "namespace": "ns2"}
  ]
}
```

Response:
```json
{
  "results": [
    {"similarity_score": 0.85},
    {"similarity_score": 0.42}
  ]
}
```

Error cases:
- `400` — empty array, non-array, batch size > 48, invalid message format
- `401` — missing/invalid API key (same auth as existing endpoint)

## 🌰 Tests

Added validation tests for the batch endpoint covering:
- Auth enforcement on `/batch`
- Empty messages array
- Non-array messages field
- Batch size exceeding maximum
- Invalid message format within batch

Existing auth test preserved and refactored with shared helper.

## 🌰 Cost and performance impact

| Scenario | Before (N single calls) | After (1 batch call) |
|----------|------------------------|---------------------|
| AI subrequests | N | 1 |
| Vectorize subrequests | N | N (parallel) |
| Total wall-clock time | N × (embed + query) | 1 × embed + max(queries) |
| Max messages per Worker invocation | 1 | 48 |

For a batch of 20 messages, this reduces AI embedding calls from 20 to 1 and runs all Vectorize queries in parallel instead of sequentially.

## 🌰 AI Disclosure

AI (Claude) was used as a coding assistant for implementation. The architectural decisions (batch size calculation from subrequest limits, single-embedding optimization, parallel query strategy) are based on Cloudflare Workers documentation and platform constraints.

🌰

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a batch endpoint for processing multiple similarity searches in a single request (supports up to 48 messages per batch).

* **Tests**
  * Expanded test coverage for authentication, input validation, and error responses across all endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/503)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->