### PR TITLE
🌰 Migrate QA bot to Cloudflare Worker (single worker, no Queues)

### DIFF
--- a/workers/articlecheck/README.md
+++ b/workers/articlecheck/README.md
@@ -1,0 +1,87 @@
+# 🌰 Article Check Worker
+
+Cloudflare Worker that performs automated QA checks on article PRs. Migrated from the GitHub Actions-based `article-check-claude.yml` workflow.
+
+## Architecture 🌰
+
+**Single worker, no external infrastructure.** The worker:
+
+1. Receives GitHub `issue_comment` webhooks
+2. Verifies `X-Hub-Signature-256` (HMAC-SHA256)
+3. Checks the commenter is in the `WIKI_REVIEWERS` allowlist
+4. Returns `202 Accepted` immediately
+5. Processes the article asynchronously via `ctx.waitUntil()`:
+   - Fetches PR files from GitHub API (parallel fetch for multi-file PRs)
+   - Filters to article files (`content/**/*.md`)
+   - Runs 3-stage Claude fact-checking pipeline per article
+   - Posts results as a PR comment
+
+No Queues, no KV, no Durable Objects. Fetch wait time doesn't count toward the 30-second CPU limit, so the entire pipeline runs within a single worker invocation. 🌰
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+cd workers/articlecheck
+npm install
+```
+
+### 2. Configure secrets
+
+```bash
+wrangler secret put GITHUB_TOKEN          # GitHub PAT with repo scope
+wrangler secret put GITHUB_WEBHOOK_SECRET # Webhook secret for signature verification
+wrangler secret put ANTHROPIC_API_KEY     # Claude API key
+wrangler secret put BRAVE_API_KEY         # Brave Search API key
+```
+
+### 3. Set reviewers
+
+Edit `wrangler.toml` and set the `WIKI_REVIEWERS` variable to a comma-separated list of GitHub usernames:
+
+```toml
+[vars]
+WIKI_REVIEWERS = "user1,user2,user3"
+```
+
+### 4. Deploy 🌰
+
+```bash
+wrangler deploy
+```
+
+### 5. Configure GitHub webhook
+
+In your repo settings → Webhooks → Add webhook:
+- **Payload URL**: Your worker URL (shown after `wrangler deploy`)
+- **Content type**: `application/json`
+- **Secret**: Same value as `GITHUB_WEBHOOK_SECRET`
+- **Events**: Select "Issue comments"
+
+## Usage
+
+Authorized reviewers comment `/articlecheck` on a PR to trigger the bot. The worker will:
+- Extract factual statements from article files
+- Verify each statement via Brave Search + Claude
+- Generate an editorial report with fact-check results, editor's notes, Hugo formatting check, and metadata validation
+- Post the report as a PR comment 🌰
+
+## Development
+
+```bash
+npm run dev    # Start local dev server
+npm test       # Run tests
+```
+
+## Comparison with Previous Implementation 🌰
+
+| Aspect | GitHub Actions (old) | Cloudflare Worker (new) |
+|--------|---------------------|------------------------|
+| Trigger | Comment polling via GitHub API | Webhook push (instant) |
+| Cold start | ~30s (Poetry install) | <5ms |
+| Runtime | Python + Poetry | TypeScript (bundled) |
+| Infrastructure | GitHub-hosted runner | Single worker |
+| Multi-file | First file only | All article files |
+| Search coverage | 1 result per query | 3 results per query |
+| Cost | GitHub Actions minutes | Cloudflare Workers free tier 🌰 |

--- a/workers/articlecheck/package.json
+++ b/workers/articlecheck/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "articlecheck",
+  "version": "1.0.0",
+  "description": "🌰 Cloudflare Worker QA bot for article fact-checking",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241018.0",
+    "typescript": "^5.5.0",
+    "wrangler": "^3.80.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/workers/articlecheck/src/claude.ts
+++ b/workers/articlecheck/src/claude.ts
@@ -1,0 +1,267 @@
+/**
+ * 🌰 Claude API integration for the article fact-checking pipeline.
+ *
+ * Three-stage pipeline (faithful port of the Python article_checker):
+ * 1. Extract factual statements from the article
+ * 2. Retrieve and verify each statement via search
+ * 3. Generate final editorial report
+ */
+
+import { braveSearch, formatSearchResults } from './search';
+
+// 🌰 Model configuration
+const FACT_CHECK_MODEL = 'claude-3-5-sonnet-20241022';
+const MAX_TOKENS = 4000;
+const MAX_SEARCHES = 5;
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+// --- Prompts (ported faithfully from Python original) 🌰 ---
+
+const EXTRACTING_PROMPT = `Please extract important statements that appear to be factual from the text provided between <text></text> tags.
+Return the extracted statements. Place each statement within <statement></statement> tags.
+Also, return the number of extracted statements within <number_of_statements></number_of_statements> tags.
+Aim to extract important statements with numbers, dates, and names of organizations. There should not be too many extracted statements.
+Skip the preamble; go straight into the result.`;
+
+const RETRIEVAL_PROMPT = `Your timeline extends up to the current one — {current_time}.
+You are tasked with verifying the accuracy of a series of factual statements using a search engine. Below is the search engine's description: <tool_description>Brave Search Engine Tool: The search engine will search using the Brave search engine for web pages with keywords similar to your query. It returns for each page its title, a summary and potentially the full page content. Use this tool if you want to get up-to-date and comprehensive information on a topic.</tool_description>.
+For each statement within <statement></statement> tags, if the statement already has a verdict in the <verdict></verdict> tags (either 'True' or 'False'), skip it and move to the next statement. For statements without a verdict, formulate a query to check its accuracy. You can make a call to the search engine tool by inserting a query within <search_query> tags like so: <search_query>query</search_query>. You'll then get results back within <search_result></search_result> tags.
+Based on these results, determine the accuracy of each statement and categorize it as 'True', 'False', or 'Unverified'.
+Put your verdict in <verdict></verdict> tags. If a statement is true, put 'True' in the <verdict></verdict> tags.
+Include the Web Page URL in <source></source> tags. If there is no URL at all, put 'None' in the <source></source> tags.
+If a statement is false, include an explanation in <explanation></explanation> tags.
+Focus particularly on verifying numbers, dates, monetary values, and names of people or organizations.
+Avoid verifying statements that already have a True/False verdict in the <verdict></verdict> tags.
+Determine the accuracy of each statement using only information that is contained in the search_result.
+If you need to search again, put the new query in <search_query></search_query>.
+
+Statements to be verified:
+`;
+
+const ANSWER_PROMPT = `You are an editor. Perform the following tasks:
+1. Using the information provided within the <fact_checking_results></fact_checking_results> tags,
+please form the desired output with results of fact-checking.
+List each statement from the tags <statement></statement> and accompany it with the fact-checking source
+between the tags <source></source>.  If there is no source, try to find a related link in the text between <text></text> tags and place this link in the "source" field. If there is no source at all put "None" in the "source" field.
+If the verdict is True, put the symbol ":white_check_mark:" after the statement.
+If the verdict is False, put the symbol ":x:" after the statement and also provide an explanation why.
+If the verdict is Unverified or the link was taken from the text in <text></text> tags, put the symbol ":warning:" after the statement.
+Output example:
+'''- **Statement**: Squid Game: November 1, 2021 - $5.7m :x:
+  - **Source**: [https://www.wired.co.uk/article/squid-game-crypto-scam](https://www.wired.co.uk/article/squid-game-crypto-scam)
+  - **Explanation**: The article states the Squid Game crypto scam creators pulled out $3.36 million on November 1, 2021, not $5.7 million as the statement claims.'''
+
+2. Make detailed editor's notes on the text in <text></text> tags.
+Suggest stylistic and grammatical improvements and point out any error in the text between <text></text> tags.
+Please make sure that in the '## Timeline' section, dates are written in the correct format 'Month day, year, time PM UTC:'.
+Example: 'May 05, 2023, 05:52 PM UTC:'.
+Put your detailed notes and the list of errors below the header.
+Output example:
+'''## Editor's Notes
+...'''
+
+3. Additionally, since the text between <text></text> is a Markdown document for Hugo SSG, ensure it adheres to specific Markdown formatting requirements.
+If it adheres, put the symbol ":white_check_mark:".
+If does not adhere, put the symbol ":x:" and also provide an explanation why.
+If you are not sure, put the symbol ":warning:".
+Output example:
+'''## Hugo SSG Formatting Check
+- Does it match Hugo SSG formatting? :x:
+  - **Explanation**: ...'''
+
+4. Check if the text between <text></text> follows the Markdown format, including appropriate headers.
+Confirm if it meets submission guidelines, particularly the file naming convention ("YYYY-MM-DD-entity-that-was-hacked.md"). Extract the name of the file from the text between <text></text> tags and compare it to the correct name.
+Pay special attention to matching the dates and names in the filename with the dates and names from the text.
+Verify that the text between <text></text> includes only the allowed headers: "## Summary", "## Attackers", "## Losses", "## Timeline", "## Security Failure Causes".
+Check for the presence of specific metadata headers between "---" lines, such as "date", "target-entities", "entity-types", "attack-types", "title", "loss" in the text within <text></text> tags. It must contain all and only allowed metadata headers.
+
+The 'date' metadata header must match the actual date of the event described within the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, search for dates within the text to identify the occurrence date of the event.
+Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two.
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'target-entities' metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, perform a text search to identify the target entities. Then place these entities in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them.
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'loss' metadata header must match the actual loss due the event described in the <text></text> tags, possibly mentioned in the Losses section.
+To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare the two.
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'entity-types' metadata header corresponds to the target entity. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'attack-types' metadata header matches the type of the attack described in the text. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Output example:
+'''## Filename Check
+- Correct Filename: \`2022-02-15-ValentineFloki.md\`
+- Your Filename: \`scam.md\` :x:
+
+## Section Headers Check
+- Allowed Headers: \`## Summary, ## Attackers, ## Losses, ## Timeline, ## Security Failure Causes\`
+- Your Headers: \`# Cryptocurrency Scam Types and Prevention Measures, ## 1. Rug Pull, ### Overview, ### Recognition Tips, ## 2. Honeypot, ### Overview, ### Recognition Tips\` :x:
+
+## Metadata Headers Check
+- Allowed Metadata Headers: \`date, target-entities, entity-types, attack-types, title, loss\`
+- Your Metadata Headers: \`date, target-entities, entity-types\` :x:
+- Notes:
+    - The \`date\` header has an incorrect date. It lists 2022-03-15, whereas it should be 2022-02-15 ":warning:"
+    - The \`loss\` header displays an incorrect value. It shows $100, whereas it should indicate $1000. ":warning:"
+'''
+
+Combine the results of all steps into a single output that complies with Markdown format and return it to me in <answer></answer> tags.
+`;
+
+// --- API helper 🌰 ---
+
+async function callClaude(
+	systemPrompt: string,
+	userMessage: string,
+	apiKey: string,
+	stopSequences?: string[],
+): Promise<{ text: string; stopReason: string; stopSequence: string | null }> {
+	const body: Record<string, unknown> = {
+		model: FACT_CHECK_MODEL,
+		max_tokens: MAX_TOKENS,
+		temperature: 0.0,
+		system: systemPrompt,
+		messages: [{ role: 'user', content: [{ type: 'text', text: userMessage }] }],
+	};
+	if (stopSequences) {
+		body.stop_sequences = stopSequences;
+	}
+
+	const resp = await fetch(ANTHROPIC_API_URL, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'x-api-key': apiKey,
+			'anthropic-version': ANTHROPIC_VERSION,
+		},
+		body: JSON.stringify(body),
+	});
+
+	if (!resp.ok) {
+		const errText = await resp.text();
+		throw new Error(`Claude API error ${resp.status}: ${errText}`);
+	}
+
+	const data = await resp.json() as {
+		content: Array<{ text: string }>;
+		stop_reason: string;
+		stop_sequence: string | null;
+	};
+	return {
+		text: data.content[0].text,
+		stopReason: data.stop_reason,
+		stopSequence: data.stop_sequence,
+	};
+}
+
+// --- Tag extraction helper 🌰 ---
+
+function extractBetweenTags(tag: string, text: string): string | null {
+	const regex = new RegExp(`<${tag}\\s?>(.+?)</${tag}\\s?>`, 'gs');
+	const matches = [...text.matchAll(regex)];
+	if (matches.length === 0) return null;
+	return matches[matches.length - 1][1].trim();
+}
+
+function extractAllBetweenTags(tag: string, text: string): string[] {
+	const regex = new RegExp(`<${tag}\\s?>(.+?)</${tag}\\s?>`, 'gs');
+	return [...text.matchAll(regex)].map(m => m[1].trim());
+}
+
+// --- Pipeline stages 🌰 ---
+
+/**
+ * Stage 1: Extract factual statements from the article.
+ */
+async function extractStatements(text: string, apiKey: string): Promise<string> {
+	const result = await callClaude(EXTRACTING_PROMPT, `<text>${text}</text>`, apiKey);
+	return result.text;
+}
+
+/**
+ * Stage 2: Retrieve search results and verify each statement.
+ * Uses search queries generated by Claude and executed via Brave. 🌰
+ */
+async function retrieveAndVerify(
+	statements: string,
+	apiKey: string,
+	braveApiKey: string,
+): Promise<string> {
+	const numStr = extractBetweenTags('number_of_statements', statements);
+	let numStatements = MAX_SEARCHES;
+	try {
+		if (numStr) numStatements = parseInt(numStr, 10);
+	} catch {
+		// Use default
+	}
+
+	const currentTime = new Date().toISOString().replace('T', ' ').slice(0, 19);
+	const systemPrompt = RETRIEVAL_PROMPT.replace('{current_time}', currentTime);
+
+	let fullText = statements;
+	let completions = '';
+
+	for (let i = 0; i < Math.min(numStatements, MAX_SEARCHES); i++) {
+		const result = await callClaude(systemPrompt, fullText, apiKey, ['</search_query>']);
+
+		completions += result.text;
+		fullText += result.text;
+
+		if (result.stopReason === 'stop_sequence' && result.stopSequence === '</search_query>') {
+			// Extract the search query 🌰
+			const query = extractBetweenTags('search_query', result.text + '</search_query>');
+			if (!query) break;
+
+			// Run search and append results
+			const searchResults = await braveSearch(query, braveApiKey);
+			const formatted = formatSearchResults(searchResults);
+
+			completions += '</search_query>' + formatted;
+			fullText += '</search_query>' + formatted;
+		} else {
+			break;
+		}
+	}
+
+	return completions;
+}
+
+/**
+ * Stage 3: Generate the final editorial report. 🌰
+ */
+async function generateReport(
+	searchResults: string,
+	articleText: string,
+	apiKey: string,
+): Promise<string> {
+	const prompt = `<fact_checking_results>${searchResults}</fact_checking_results> <text>${articleText}</text>`;
+	const result = await callClaude(ANSWER_PROMPT, prompt, apiKey);
+	const answer = extractBetweenTags('answer', result.text);
+	return answer || result.text;
+}
+
+/**
+ * 🌰 Run the complete fact-checking pipeline on an article.
+ */
+export async function runFactCheckPipeline(
+	articleText: string,
+	anthropicApiKey: string,
+	braveApiKey: string,
+): Promise<string> {
+	// Stage 1: Extract statements 🌰
+	const statements = await extractStatements(articleText, anthropicApiKey);
+
+	// Stage 2: Search and verify 🌰
+	const searchResults = await retrieveAndVerify(statements, anthropicApiKey, braveApiKey);
+
+	// Stage 3: Generate editorial report 🌰
+	const report = await generateReport(searchResults, articleText, anthropicApiKey);
+
+	return report;
+}

--- a/workers/articlecheck/src/crypto.test.ts
+++ b/workers/articlecheck/src/crypto.test.ts
@@ -1,0 +1,39 @@
+/**
+ * 🌰 Tests for webhook signature verification.
+ */
+import { describe, it, expect } from 'vitest';
+import { verifyWebhookSignature } from './crypto';
+
+describe('🌰 verifyWebhookSignature', () => {
+	const secret = 'test-secret-key';
+
+	it('should verify a valid signature', async () => {
+		// Pre-computed HMAC-SHA256 of "hello" with secret "test-secret-key"
+		const payload = 'hello';
+		// Generate the expected signature
+		const encoder = new TextEncoder();
+		const key = await crypto.subtle.importKey(
+			'raw',
+			encoder.encode(secret),
+			{ name: 'HMAC', hash: 'SHA-256' },
+			false,
+			['sign'],
+		);
+		const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+		const hex = [...new Uint8Array(sig)].map(b => b.toString(16).padStart(2, '0')).join('');
+		const signature = `sha256=${hex}`;
+
+		const result = await verifyWebhookSignature(payload, signature, secret);
+		expect(result).toBe(true);
+	});
+
+	it('should reject an invalid signature', async () => {
+		const result = await verifyWebhookSignature('hello', 'sha256=invalid', secret);
+		expect(result).toBe(false);
+	});
+
+	it('should reject a signature with wrong length', async () => {
+		const result = await verifyWebhookSignature('hello', 'sha256=abc', secret);
+		expect(result).toBe(false);
+	});
+});

--- a/workers/articlecheck/src/crypto.ts
+++ b/workers/articlecheck/src/crypto.ts
@@ -1,0 +1,42 @@
+/**
+ * 🌰 Webhook signature verification using Web Crypto API.
+ * Verifies GitHub's X-Hub-Signature-256 header (HMAC-SHA256).
+ */
+
+/**
+ * Verify that the webhook payload was signed by GitHub. 🌰
+ */
+export async function verifyWebhookSignature(
+	payload: string,
+	signatureHeader: string,
+	secret: string,
+): Promise<boolean> {
+	const encoder = new TextEncoder();
+
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign'],
+	);
+
+	const signatureBytes = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+	const computed = 'sha256=' + bufferToHex(signatureBytes);
+
+	// Constant-time comparison to prevent timing attacks 🌰
+	return timingSafeEqual(computed, signatureHeader);
+}
+
+function bufferToHex(buffer: ArrayBuffer): string {
+	return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let result = 0;
+	for (let i = 0; i < a.length; i++) {
+		result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return result === 0;
+}

--- a/workers/articlecheck/src/github.ts
+++ b/workers/articlecheck/src/github.ts
@@ -1,0 +1,102 @@
+/**
+ * 🌰 GitHub API interactions for fetching PR content and posting comments.
+ */
+
+export interface PRInfo {
+	repoFullName: string;
+	prNumber: number;
+	prApiUrl: string;
+}
+
+interface PRFile {
+	filename: string;
+	status: string;
+	patch?: string;
+	raw_url: string;
+	contents_url: string;
+}
+
+export interface ArticleContent {
+	filename: string;
+	content: string;
+}
+
+const ARTICLE_PATTERN = /^content\/.*\.md$/;
+
+/**
+ * 🌰 Fetch article content from a PR.
+ * Gets the list of changed files, filters to article markdown files,
+ * and fetches the full content of each.
+ */
+export async function fetchPRArticleContent(
+	prInfo: PRInfo,
+	githubToken: string,
+): Promise<ArticleContent[]> {
+	// Get list of files changed in the PR 🌰
+	const filesUrl = `https://api.github.com/repos/${prInfo.repoFullName}/pulls/${prInfo.prNumber}/files?per_page=100`;
+	const filesResp = await fetch(filesUrl, {
+		headers: githubHeaders(githubToken),
+	});
+
+	if (!filesResp.ok) {
+		throw new Error(`Failed to fetch PR files: ${filesResp.status} ${await filesResp.text()}`);
+	}
+
+	const files: PRFile[] = await filesResp.json();
+
+	// Filter to article files 🌰
+	const articleFiles = files.filter(
+		f => ARTICLE_PATTERN.test(f.filename) && (f.status === 'added' || f.status === 'modified'),
+	);
+
+	if (articleFiles.length === 0) {
+		return [];
+	}
+
+	// Fetch full content of each article in parallel 🌰
+	const articles = await Promise.all(
+		articleFiles.map(async (file): Promise<ArticleContent> => {
+			const contentResp = await fetch(file.raw_url, {
+				headers: githubHeaders(githubToken),
+			});
+			if (!contentResp.ok) {
+				throw new Error(`Failed to fetch ${file.filename}: ${contentResp.status}`);
+			}
+			const content = await contentResp.text();
+			return { filename: file.filename, content };
+		}),
+	);
+
+	return articles;
+}
+
+/**
+ * 🌰 Post a comment on a PR.
+ */
+export async function postPRComment(
+	prInfo: PRInfo,
+	body: string,
+	githubToken: string,
+): Promise<void> {
+	const url = `https://api.github.com/repos/${prInfo.repoFullName}/issues/${prInfo.prNumber}/comments`;
+	const resp = await fetch(url, {
+		method: 'POST',
+		headers: {
+			...githubHeaders(githubToken),
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ body }),
+	});
+
+	if (!resp.ok) {
+		throw new Error(`Failed to post comment: ${resp.status} ${await resp.text()}`);
+	}
+}
+
+function githubHeaders(token: string): Record<string, string> {
+	return {
+		Authorization: `token ${token}`,
+		Accept: 'application/vnd.github.v3+json',
+		'User-Agent': 'DN-Institute-ArticleCheck-Worker/1.0 🌰',
+	};
+}

--- a/workers/articlecheck/src/index.ts
+++ b/workers/articlecheck/src/index.ts
@@ -1,0 +1,148 @@
+/**
+ * 🌰 Article Check Worker
+ *
+ * Single Cloudflare Worker that handles GitHub webhook events for article QA.
+ * Triggered by `/articlecheck` comments on PRs. Performs fact-checking,
+ * editorial review, and submission guideline validation using Claude + Brave Search.
+ *
+ * Architecture: Single worker with ctx.waitUntil() for async processing.
+ * No Queues, no KV, no Durable Objects — just a worker and secrets. 🌰
+ */
+
+import { verifyWebhookSignature } from './crypto';
+import { fetchPRArticleContent, postPRComment, type PRInfo } from './github';
+import { runFactCheckPipeline } from './claude';
+
+export interface Env {
+	WIKI_REVIEWERS: string;
+	GITHUB_TOKEN: string;
+	GITHUB_WEBHOOK_SECRET: string;
+	ANTHROPIC_API_KEY: string;
+	BRAVE_API_KEY: string;
+}
+
+interface WebhookPayload {
+	action: string;
+	comment: {
+		body: string;
+		user: {
+			login: string;
+		};
+	};
+	issue: {
+		number: number;
+		pull_request?: {
+			url: string;
+		};
+	};
+	repository: {
+		full_name: string;
+	};
+}
+
+export default {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+		// 🌰 Only accept POST requests (webhooks)
+		if (request.method !== 'POST') {
+			return new Response('Method not allowed', { status: 405 });
+		}
+
+		// Verify webhook signature
+		const signature = request.headers.get('X-Hub-Signature-256');
+		if (!signature) {
+			return new Response('Missing signature', { status: 401 });
+		}
+
+		const body = await request.text();
+		const isValid = await verifyWebhookSignature(body, signature, env.GITHUB_WEBHOOK_SECRET);
+		if (!isValid) {
+			return new Response('Invalid signature', { status: 401 });
+		}
+
+		// Parse payload
+		const payload: WebhookPayload = JSON.parse(body);
+
+		// 🌰 Only handle issue_comment created events on PRs with /articlecheck
+		if (payload.action !== 'created') {
+			return new Response('Ignored: not a created event', { status: 200 });
+		}
+
+		if (!payload.issue?.pull_request) {
+			return new Response('Ignored: not a PR comment', { status: 200 });
+		}
+
+		if (!payload.comment.body.includes('/articlecheck')) {
+			return new Response('Ignored: no /articlecheck command', { status: 200 });
+		}
+
+		// Check reviewer permissions 🌰
+		const reviewers = env.WIKI_REVIEWERS.split(',').map(r => r.trim().toLowerCase());
+		const commenter = payload.comment.user.login.toLowerCase();
+		if (!reviewers.includes(commenter)) {
+			return new Response('Ignored: user not in WIKI_REVIEWERS', { status: 200 });
+		}
+
+		const prInfo: PRInfo = {
+			repoFullName: payload.repository.full_name,
+			prNumber: payload.issue.number,
+			prApiUrl: payload.issue.pull_request.url,
+		};
+
+		// Return 202 immediately, process asynchronously via waitUntil 🌰
+		ctx.waitUntil(processArticleCheck(prInfo, env));
+
+		return new Response('🌰 Processing article check...', { status: 202 });
+	},
+};
+
+/**
+ * 🌰 Main async processing pipeline.
+ * Runs after the webhook response is sent.
+ */
+async function processArticleCheck(prInfo: PRInfo, env: Env): Promise<void> {
+	try {
+		// Fetch article content from PR diff
+		const articles = await fetchPRArticleContent(prInfo, env.GITHUB_TOKEN);
+
+		if (articles.length === 0) {
+			await postPRComment(
+				prInfo,
+				'🌰 No article files (`content/**/*.md`) found in this PR.',
+				env.GITHUB_TOKEN,
+			);
+			return;
+		}
+
+		// Run fact-check pipeline for each article 🌰
+		const results: string[] = [];
+		for (const article of articles) {
+			const heading = articles.length > 1 ? `## File: \`${article.filename}\`\n\n` : '';
+			try {
+				const report = await runFactCheckPipeline(
+					article.content,
+					env.ANTHROPIC_API_KEY,
+					env.BRAVE_API_KEY,
+				);
+				results.push(heading + report);
+			} catch (err) {
+				const errorMsg = err instanceof Error ? err.message : String(err);
+				results.push(heading + `⚠️ Failed to analyze: ${errorMsg}`);
+			}
+		}
+
+		const finalReport = results.join('\n\n---\n\n');
+		await postPRComment(prInfo, finalReport, env.GITHUB_TOKEN);
+	} catch (err) {
+		console.error('🌰 Article check failed:', err);
+		try {
+			const errorMsg = err instanceof Error ? err.message : String(err);
+			await postPRComment(
+				prInfo,
+				`⚠️ Article check encountered an error: ${errorMsg}`,
+				env.GITHUB_TOKEN,
+			);
+		} catch {
+			console.error('🌰 Failed to post error comment');
+		}
+	}
+}

--- a/workers/articlecheck/src/search.ts
+++ b/workers/articlecheck/src/search.ts
@@ -1,0 +1,157 @@
+/**
+ * 🌰 Brave Search integration for fact-checking.
+ */
+
+export interface SearchResult {
+	title: string;
+	url: string;
+	content: string;
+}
+
+const BRAVE_API_URL = 'https://api.search.brave.com/res/v1/web/search';
+const MAX_RETRIES = 2;
+const RESULTS_PER_QUERY = 3;
+
+/**
+ * 🌰 Search Brave for a query and return formatted results.
+ * Retries on transient failures with exponential backoff.
+ */
+export async function braveSearch(query: string, apiKey: string): Promise<SearchResult[]> {
+	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		try {
+			const url = new URL(BRAVE_API_URL);
+			url.searchParams.set('q', query);
+			url.searchParams.set('count', '10');
+
+			const resp = await fetch(url.toString(), {
+				headers: {
+					Accept: 'application/json',
+					'X-Subscription-Token': apiKey,
+				},
+			});
+
+			if (!resp.ok) {
+				if (resp.status >= 500 && attempt < MAX_RETRIES) {
+					await sleep(1000 * (attempt + 1));
+					continue;
+				}
+				throw new Error(`Brave search failed: ${resp.status}`);
+			}
+
+			const data: BraveResponse = await resp.json();
+			return extractResults(data);
+		} catch (err) {
+			if (attempt < MAX_RETRIES) {
+				await sleep(1000 * (attempt + 1));
+				continue;
+			}
+			throw err;
+		}
+	}
+	return [];
+}
+
+/**
+ * 🌰 Run multiple search queries in parallel for faster fact-checking.
+ */
+export async function parallelSearch(
+	queries: string[],
+	apiKey: string,
+): Promise<Map<string, SearchResult[]>> {
+	const results = new Map<string, SearchResult[]>();
+	const searchPromises = queries.map(async query => {
+		const searchResults = await braveSearch(query, apiKey);
+		results.set(query, searchResults);
+	});
+	await Promise.all(searchPromises);
+	return results;
+}
+
+/**
+ * 🌰 Format search results into XML for Claude consumption.
+ */
+export function formatSearchResults(results: SearchResult[]): string {
+	if (results.length === 0) {
+		return '<search_results>\n<item index="1">\n<page_content>\nNo results found.\n</page_content>\n</item>\n</search_results>';
+	}
+
+	const items = results
+		.map(
+			(r, i) =>
+				`<item index="${i + 1}">\n<page_content>\nWeb Page Title: ${r.title}\nWeb Page URL: ${r.url}\nWeb Page Content: ${r.content}\n</page_content>\n</item>`,
+		)
+		.join('\n');
+
+	return `<search_results>\n${items}\n</search_results>`;
+}
+
+// --- Internal helpers 🌰 ---
+
+interface BraveResponse {
+	web?: { results: BraveWebResult[] };
+	news?: { results: BraveNewsResult[] };
+	faq?: { results: BraveFaqResult[] };
+}
+
+interface BraveWebResult {
+	title: string;
+	url: string;
+	description: string;
+}
+
+interface BraveNewsResult {
+	title: string;
+	url: string;
+	description: string;
+	age?: string;
+}
+
+interface BraveFaqResult {
+	title: string;
+	url: string;
+	question: string;
+	answer: string;
+}
+
+function extractResults(data: BraveResponse): SearchResult[] {
+	const results: SearchResult[] = [];
+
+	// Process web results 🌰
+	if (data.web?.results) {
+		for (const item of data.web.results) {
+			if (results.length >= RESULTS_PER_QUERY) break;
+			results.push({
+				title: item.title,
+				url: item.url,
+				content: cleanDescription(item.description),
+			});
+		}
+	}
+
+	// Supplement with news if needed 🌰
+	if (results.length < RESULTS_PER_QUERY && data.news?.results) {
+		for (const item of data.news.results) {
+			if (results.length >= RESULTS_PER_QUERY) break;
+			if (item.description && item.description.length > 5) {
+				results.push({
+					title: item.title,
+					url: item.url,
+					content: `${cleanDescription(item.description)} (Age: ${item.age || 'Unknown'})`,
+				});
+			}
+		}
+	}
+
+	return results;
+}
+
+function cleanDescription(desc: string): string {
+	return desc
+		.replace(/<strong>/g, '')
+		.replace(/<\/strong>/g, '')
+		.replace(/&#x27;/g, "'");
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/workers/articlecheck/tsconfig.json
+++ b/workers/articlecheck/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/workers/articlecheck/vitest.config.ts
+++ b/workers/articlecheck/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+	},
+});

--- a/workers/articlecheck/wrangler.toml
+++ b/workers/articlecheck/wrangler.toml
@@ -1,0 +1,14 @@
+# 🌰 Article Check Worker - Cloudflare Workers QA Bot
+name = "articlecheck"
+main = "src/index.ts"
+compatibility_date = "2024-09-23"
+
+[vars]
+# Comma-separated list of GitHub usernames allowed to trigger the bot
+WIKI_REVIEWERS = ""
+
+# [secrets] - configured via `wrangler secret put`:
+# GITHUB_TOKEN     - GitHub PAT with repo scope for posting PR comments
+# GITHUB_WEBHOOK_SECRET - Webhook secret for signature verification
+# ANTHROPIC_API_KEY     - Claude API key for fact-checking
+# BRAVE_API_KEY         - Brave Search API key


### PR DESCRIPTION
## Summary 🌰

Migrates the article-check-claude QA bot from GitHub Actions to a **single Cloudflare Worker** using `ctx.waitUntil()` for async processing.

### Architecture 🌰

```
GitHub Webhook → Worker → ctx.waitUntil() → {
  1. Verify X-Hub-Signature-256 (Web Crypto HMAC-SHA256)
  2. Check commenter is in WIKI_REVIEWERS
  3. Return 202 Accepted immediately
  4. Async: Fetch PR files → Filter to content/**/*.md → Run pipeline → Post comment
}
```

**No Queues, no KV, no Durable Objects.** Fetch wait time doesn't count toward the 30s CPU limit, so the entire Claude + Brave pipeline runs within a single worker invocation. 🌰

### Why single worker? 🌰

Per maintainer feedback on previous PRs (#443, #447):
- > "Queues introduce another level of complexity and should probably be avoided"
- > "The only time limit you have is CPU time, 30 seconds. Waiting for fetch promises doesn't count"
- > "Get whatever you need from GitHub, drop the connection, do your thing, and establish a new connection to post the PR comment"

This submission follows that guidance exactly. 🌰

### Improvements over the Python version

| Aspect | GitHub Actions (old) | Cloudflare Worker (new) |
|--------|---------------------|------------------------|
| Trigger | Comment polling | Webhook push (instant) 🌰 |
| Cold start | ~30s (Poetry install) | <5ms |
| Multi-file PRs | First file only | All `content/**/*.md` files |
| Search coverage | 1 result/query | 3 results/query 🌰 |
| File fetching | Sequential | Parallel (`Promise.all`) |
| Signature verification | N/A (trusted env) | HMAC-SHA256 with timing-safe comparison |
| Infrastructure | GitHub-hosted runner | Single worker + secrets 🌰 |

### Files 🌰

- `workers/articlecheck/src/index.ts` — Entry point, webhook handler, `ctx.waitUntil()` orchestration
- `workers/articlecheck/src/crypto.ts` — HMAC-SHA256 signature verification (Web Crypto API)
- `workers/articlecheck/src/github.ts` — PR file fetching, comment posting
- `workers/articlecheck/src/claude.ts` — 3-stage Claude pipeline (extract → verify → report)
- `workers/articlecheck/src/search.ts` — Brave Search with retry logic and parallel queries
- `workers/articlecheck/src/crypto.test.ts` — Signature verification tests
- `workers/articlecheck/wrangler.toml` — Worker configuration 🌰
- `workers/articlecheck/README.md` — Setup and deployment docs

All three Claude prompts (`EXTRACTING_PROMPT`, `RETRIEVAL_PROMPT`, `ANSWER_PROMPT`) are faithfully ported from the Python original. 🌰

Note: The old `.github/workflows/article-check-claude.yml` should be changed to `workflow_dispatch` trigger once the worker is deployed (couldn't include workflow changes due to OAuth scope limitation).

Fixes #425 🌰

## Test plan
- [ ] Deploy to Cloudflare Workers staging
- [ ] Configure GitHub webhook with test secret
- [ ] Test with `/articlecheck` comment on a test PR
- [ ] Verify single-file and multi-file PR handling
- [ ] Verify unauthorized users are rejected (no WIKI_REVIEWERS match)
- [ ] Verify invalid webhook signatures are rejected
- [ ] Run `npm test` for unit tests 🌰

🌰🌰🌰