### PR TITLE
🌰 Add hybrid RAG context retrieval for Market Health Reporter

### DIFF
--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -8,6 +8,7 @@ import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.rag_context import build_rag_context
 
 
 REPO_NAME = "1712n/dn-institute"
@@ -38,6 +39,10 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
+    )
+    parser.add_argument(
+        "--disable-web-search", dest="disable_web_search", action="store_true",
+        default=False, help="Disable web search for RAG context (local wiki only)"
     )
     return parser.parse_args()
 
@@ -126,11 +131,14 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, rag_context: str = "") -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, data, and optional RAG context.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    prompt = f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    if rag_context:
+        prompt += f"\n{rag_context}"
+    return prompt
 
 
 def main():
@@ -157,10 +165,20 @@ def main():
     try:
         data = fetch_or_load_market_data(querystring, headers, url, DATA_DIR, marketvenueid, pairid, start, end)
 
-        encoding = encoding_for_model("gpt-4")     
+        encoding = encoding_for_model("gpt-4")
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        rag_context = build_rag_context(
+            exchange=marketvenueid,
+            pair=pairid,
+            include_web_search=not args.disable_web_search,
+        )
+        if rag_context:
+            print(f"RAG context retrieved ({len(rag_context)} chars)")
+        else:
+            print("No RAG context found for this exchange")
+
+        prompt = create_prompt(article_example, data, human_prompt_content, rag_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:

--- a/tools/market_health_reporter/rag_context.py
+++ b/tools/market_health_reporter/rag_context.py
@@ -1,0 +1,274 @@
+"""
+RAG context retrieval for Market Health Reporter.
+
+Retrieves relevant context from two sources:
+1. Local wiki articles in the repository (no API key required)
+2. Web search via DuckDuckGo for real-time news (no API key required)
+"""
+
+import os
+import re
+import yaml
+import logging
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+import bleach
+
+logger = logging.getLogger(__name__)
+
+WIKI_POSTS_DIR = "content/research/market-health/posts"
+
+
+def load_wiki_articles(exchange: str, repo_root: str = ".") -> list[dict]:
+    """
+    Search local wiki articles for content relevant to the given exchange.
+    Returns a list of dicts with 'title', 'content', and 'source' keys.
+    """
+    posts_dir = os.path.join(repo_root, WIKI_POSTS_DIR)
+    if not os.path.isdir(posts_dir):
+        logger.warning(f"Wiki posts directory not found: {posts_dir}")
+        return []
+
+    articles = []
+    exchange_lower = exchange.lower().replace(".", "").replace("-", "").replace(" ", "")
+
+    for entry in os.listdir(posts_dir):
+        entry_path = os.path.join(posts_dir, entry)
+        if not os.path.isdir(entry_path):
+            continue
+
+        index_file = os.path.join(entry_path, "index.md")
+        if not os.path.isfile(index_file):
+            continue
+
+        with open(index_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        frontmatter, body = _parse_frontmatter(content)
+        if not frontmatter:
+            continue
+
+        entities = frontmatter.get("entities", [])
+        title = frontmatter.get("title", "")
+
+        # Check if exchange matches any entity or appears in directory name
+        dir_lower = entry.lower().replace(".", "").replace("-", "").replace(" ", "")
+        entity_match = any(
+            exchange_lower in str(e).lower().replace(".", "").replace("-", "").replace(" ", "")
+            or str(e).lower().replace(".", "").replace("-", "").replace(" ", "") in exchange_lower
+            for e in entities
+        )
+
+        if entity_match or exchange_lower in dir_lower:
+            # Truncate to essential sections (Summary + key evidence)
+            trimmed = _trim_article(body)
+            articles.append({
+                "title": title,
+                "content": trimmed,
+                "source": f"wiki:{entry}",
+            })
+
+    logger.info(f"Found {len(articles)} local wiki article(s) for '{exchange}'")
+    return articles
+
+
+def search_web(exchange: str, pair: str, max_results: int = 5) -> list[dict]:
+    """
+    Search the web for recent news about the exchange using DuckDuckGo.
+    Returns a list of dicts with 'title', 'content', and 'source' keys.
+    No API key required.
+    """
+    results = []
+    queries = [
+        f"{exchange} cryptocurrency wash trading manipulation",
+        f"{exchange} {pair} trading volume anomaly",
+    ]
+
+    for query in queries:
+        try:
+            fetched = _duckduckgo_search(query, max_results=3)
+            results.extend(fetched)
+        except Exception as e:
+            logger.warning(f"Web search failed for query '{query}': {e}")
+
+    # Deduplicate by URL
+    seen_urls = set()
+    unique = []
+    for r in results:
+        if r["source"] not in seen_urls:
+            seen_urls.add(r["source"])
+            unique.append(r)
+
+    return unique[:max_results]
+
+
+def build_rag_context(
+    exchange: str,
+    pair: str,
+    repo_root: str = ".",
+    include_web_search: bool = True,
+    max_context_chars: int = 8000,
+) -> str:
+    """
+    Build a formatted RAG context string for injection into the LLM prompt.
+
+    Args:
+        exchange: Exchange name (e.g., "huobi", "binance")
+        pair: Trading pair (e.g., "btc-usdt")
+        repo_root: Path to the repository root
+        include_web_search: Whether to include web search results
+        max_context_chars: Maximum characters for the context block
+
+    Returns:
+        Formatted context string ready for prompt injection, or empty string
+        if no relevant context found.
+    """
+    sections = []
+    char_count = 0
+
+    # 1. Local wiki articles (highest quality, always available)
+    wiki_articles = load_wiki_articles(exchange, repo_root)
+    for article in wiki_articles:
+        section = f"### {article['title']}\nSource: {article['source']}\n\n{article['content']}"
+        if char_count + len(section) > max_context_chars:
+            break
+        sections.append(section)
+        char_count += len(section)
+
+    # 2. Web search results (real-time, if enabled)
+    if include_web_search:
+        web_results = search_web(exchange, pair)
+        for result in web_results:
+            section = f"### {result['title']}\nSource: {result['source']}\n\n{result['content']}"
+            if char_count + len(section) > max_context_chars:
+                break
+            sections.append(section)
+            char_count += len(section)
+
+    if not sections:
+        return ""
+
+    context = "\n\n---\n\n".join(sections)
+    return (
+        f"<external_context>\n"
+        f"The following is additional context about {exchange} from wiki articles and recent news. "
+        f"Reference specific events or findings from this context only where they help explain "
+        f"anomalies detected in the data. Do not fabricate information beyond what is provided.\n\n"
+        f"{context}\n"
+        f"</external_context>"
+    )
+
+
+def _parse_frontmatter(content: str) -> tuple[Optional[dict], str]:
+    """Parse YAML frontmatter from markdown content."""
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", content, re.DOTALL)
+    if not match:
+        return None, content
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+        body = match.group(2)
+        return frontmatter, body
+    except yaml.YAMLError:
+        return None, content
+
+
+def _trim_article(body: str, max_chars: int = 2000) -> str:
+    """
+    Trim article to essential sections: Summary and first evidence section.
+    Strips Hugo shortcodes and image references.
+    """
+    # Remove Hugo figure shortcodes
+    body = re.sub(r"\{\{<.*?>}}", "", body)
+    # Remove image markdown
+    body = re.sub(r"!\[.*?\]\(.*?\)", "", body)
+    # Collapse multiple blank lines
+    body = re.sub(r"\n{3,}", "\n\n", body)
+
+    if len(body) <= max_chars:
+        return body.strip()
+
+    # Try to capture Summary section at minimum
+    summary_match = re.search(r"(## Summary.*?)(?=\n## |\Z)", body, re.DOTALL)
+    if summary_match:
+        result = summary_match.group(1).strip()
+        if len(result) <= max_chars:
+            return result
+
+    return body[:max_chars].strip()
+
+
+def _duckduckgo_search(query: str, max_results: int = 3) -> list[dict]:
+    """
+    Search DuckDuckGo using the duckduckgo-search package.
+    Falls back to a simple HTML scrape if the package API changes.
+    """
+    results = []
+
+    try:
+        from duckduckgo_search import DDGS
+        with DDGS() as ddgs:
+            for r in ddgs.text(query, max_results=max_results):
+                title = _clean_text(r.get("title", ""))
+                body = _clean_text(r.get("body", ""))
+                url = r.get("href", r.get("link", ""))
+                if title and body:
+                    results.append({
+                        "title": title,
+                        "content": body,
+                        "source": url,
+                    })
+    except ImportError:
+        logger.warning("duckduckgo-search package not available, skipping web search")
+    except Exception as e:
+        logger.warning(f"DuckDuckGo search failed: {e}")
+        # Fallback: try DuckDuckGo lite HTML
+        try:
+            results = _ddg_lite_fallback(query, max_results)
+        except Exception as e2:
+            logger.warning(f"DuckDuckGo lite fallback also failed: {e2}")
+
+    return results
+
+
+def _ddg_lite_fallback(query: str, max_results: int = 3) -> list[dict]:
+    """Fallback: scrape DuckDuckGo lite for search results."""
+    resp = requests.get(
+        "https://lite.duckduckgo.com/lite/",
+        params={"q": query},
+        headers={"User-Agent": "Mozilla/5.0"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    results = []
+
+    for link in soup.find_all("a", class_="result-link"):
+        title = _clean_text(link.get_text())
+        url = link.get("href", "")
+        snippet_td = link.find_parent("tr")
+        snippet = ""
+        if snippet_td:
+            next_tr = snippet_td.find_next_sibling("tr")
+            if next_tr:
+                snippet = _clean_text(next_tr.get_text())
+        if title and url:
+            results.append({
+                "title": title,
+                "content": snippet,
+                "source": url,
+            })
+            if len(results) >= max_results:
+                break
+
+    return results
+
+
+def _clean_text(text: str) -> str:
+    """Clean text by stripping HTML tags and normalizing whitespace."""
+    text = bleach.clean(text, tags=[], strip=True)
+    text = BeautifulSoup(text, "html.parser").get_text()
+    text = re.sub(r"\s+", " ", text).strip()
+    return text

--- a/tools/market_health_reporter/tests/test_rag_context.py
+++ b/tools/market_health_reporter/tests/test_rag_context.py
@@ -1,0 +1,207 @@
+"""Tests for the RAG context retrieval module."""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.market_health_reporter.rag_context import (
+    load_wiki_articles,
+    build_rag_context,
+    _parse_frontmatter,
+    _trim_article,
+    _clean_text,
+)
+
+
+SAMPLE_ARTICLE = """---
+title: "Wash Trading on TestExchange"
+date: 2024-01-01
+entities:
+  - TestExchange
+  - BTC
+---
+
+## Summary
+
+1. **90% fake volume**: TestExchange was found to have 90% fabricated volume.
+2. **Regulatory action**: Fined $10 million.
+
+## Evidence
+
+Detailed evidence section with lots of text about manipulation patterns.
+"""
+
+SAMPLE_ARTICLE_HUOBI = """---
+title: "Uncovering Wash Trading on Huobi"
+date: 2023-08-14
+entities:
+  - Huobi
+  - HT
+  - TRX
+---
+
+## Summary
+
+1. Recent data reveals a **surge in manipulative practices**.
+
+## Metrics used
+
+{{< figure src="chart.png" alt="chart" >}}
+
+Long analysis section here.
+"""
+
+
+@pytest.fixture
+def wiki_dir(tmp_path):
+    """Create a temporary wiki directory with sample articles."""
+    posts_dir = tmp_path / "content" / "research" / "market-health" / "posts"
+
+    # TestExchange article
+    exchange_dir = posts_dir / "2024-01-01-testexchange"
+    exchange_dir.mkdir(parents=True)
+    (exchange_dir / "index.md").write_text(SAMPLE_ARTICLE)
+
+    # Huobi article
+    huobi_dir = posts_dir / "2023-08-14-huobi"
+    huobi_dir.mkdir(parents=True)
+    (huobi_dir / "index.md").write_text(SAMPLE_ARTICLE_HUOBI)
+
+    # Non-matching article
+    other_dir = posts_dir / "2024-01-01-other"
+    other_dir.mkdir(parents=True)
+    (other_dir / "index.md").write_text(
+        "---\ntitle: Other\ndate: 2024-01-01\nentities:\n  - OtherExchange\n---\n\nContent."
+    )
+
+    return tmp_path
+
+
+class TestParseFrontmatter:
+    def test_valid_frontmatter(self):
+        fm, body = _parse_frontmatter(SAMPLE_ARTICLE)
+        assert fm is not None
+        assert fm["title"] == "Wash Trading on TestExchange"
+        assert "TestExchange" in fm["entities"]
+        assert "## Summary" in body
+
+    def test_no_frontmatter(self):
+        fm, body = _parse_frontmatter("Just some text without frontmatter")
+        assert fm is None
+        assert body == "Just some text without frontmatter"
+
+    def test_invalid_yaml(self):
+        fm, body = _parse_frontmatter("---\n[invalid: yaml: :\n---\nBody")
+        assert fm is None
+
+
+class TestTrimArticle:
+    def test_short_article_unchanged(self):
+        body = "## Summary\n\nShort content."
+        assert _trim_article(body) == body
+
+    def test_removes_hugo_shortcodes(self):
+        body = '## Summary\n\n{{< figure src="chart.png" >}}\n\nText here.'
+        result = _trim_article(body)
+        assert "{{<" not in result
+        assert "Text here." in result
+
+    def test_long_article_trimmed_to_summary(self):
+        body = "## Summary\n\nShort summary.\n\n## Long Section\n\n" + "x" * 5000
+        result = _trim_article(body, max_chars=200)
+        assert "Short summary" in result
+        assert len(result) <= 200
+
+
+class TestCleanText:
+    def test_strips_html(self):
+        assert _clean_text("<b>bold</b> text") == "bold text"
+
+    def test_normalizes_whitespace(self):
+        assert _clean_text("hello   world\n\ntest") == "hello world test"
+
+    def test_empty_string(self):
+        assert _clean_text("") == ""
+
+
+class TestLoadWikiArticles:
+    def test_finds_matching_exchange(self, wiki_dir):
+        articles = load_wiki_articles("testexchange", str(wiki_dir))
+        assert len(articles) == 1
+        assert "TestExchange" in articles[0]["title"]
+
+    def test_case_insensitive_match(self, wiki_dir):
+        articles = load_wiki_articles("TestExchange", str(wiki_dir))
+        assert len(articles) == 1
+
+    def test_finds_huobi(self, wiki_dir):
+        articles = load_wiki_articles("huobi", str(wiki_dir))
+        assert len(articles) == 1
+        assert "Huobi" in articles[0]["title"]
+
+    def test_no_match_returns_empty(self, wiki_dir):
+        articles = load_wiki_articles("nonexistent", str(wiki_dir))
+        assert len(articles) == 0
+
+    def test_does_not_match_unrelated(self, wiki_dir):
+        articles = load_wiki_articles("testexchange", str(wiki_dir))
+        assert all("Other" not in a["title"] for a in articles)
+
+    def test_missing_directory(self):
+        articles = load_wiki_articles("test", "/nonexistent/path")
+        assert articles == []
+
+
+class TestBuildRagContext:
+    def test_returns_formatted_context(self, wiki_dir):
+        context = build_rag_context(
+            "testexchange", "btc-usdt",
+            repo_root=str(wiki_dir),
+            include_web_search=False,
+        )
+        assert "<external_context>" in context
+        assert "</external_context>" in context
+        assert "TestExchange" in context
+
+    def test_empty_when_no_match(self, wiki_dir):
+        context = build_rag_context(
+            "nonexistent", "btc-usdt",
+            repo_root=str(wiki_dir),
+            include_web_search=False,
+        )
+        assert context == ""
+
+    def test_respects_max_context_chars(self, wiki_dir):
+        context = build_rag_context(
+            "testexchange", "btc-usdt",
+            repo_root=str(wiki_dir),
+            include_web_search=False,
+            max_context_chars=100,
+        )
+        # Should still produce output if at least one article fits
+        # The first article content should be truncated or at least bounded
+        if context:
+            assert len(context) < 1000  # bounded
+
+    @patch("tools.market_health_reporter.rag_context.search_web")
+    def test_includes_web_search(self, mock_search, wiki_dir):
+        mock_search.return_value = [
+            {"title": "News Article", "content": "Exchange in trouble", "source": "https://example.com"}
+        ]
+        context = build_rag_context(
+            "testexchange", "btc-usdt",
+            repo_root=str(wiki_dir),
+            include_web_search=True,
+        )
+        assert "News Article" in context
+        mock_search.assert_called_once()
+
+    @patch("tools.market_health_reporter.rag_context.search_web")
+    def test_skips_web_search_when_disabled(self, mock_search, wiki_dir):
+        build_rag_context(
+            "testexchange", "btc-usdt",
+            repo_root=str(wiki_dir),
+            include_web_search=False,
+        )
+        mock_search.assert_not_called()


### PR DESCRIPTION
## 🌰 Summary

Adds a RAG (Retrieval-Augmented Generation) module to the Market Health Reporter that enriches LLM prompts with relevant context from two complementary sources:

1. **Local wiki articles** — Searches the repository's own `content/research/market-health/posts/` for articles matching the exchange being analyzed. This provides curated, high-quality context about known manipulation patterns without any external API dependency.

2. **Web search via DuckDuckGo** — Fetches real-time news and reports about the exchange. Uses `duckduckgo-search` which is already a project dependency — **no additional API key or secret configuration required**.

Closes #428

## 🌰 Architecture

```
Issue Comment (exchange, pair, dates)
        |
        v
+--------------------+
| Market Data API    |  (existing - unchanged)
+--------------------+
        |
        v
+--------------------+
| RAG Context        |  <-- NEW: rag_context.py
| Retrieval          |
|                    |
| 1. Search local    |
|    wiki articles   |
|    (by entity)     |
| 2. DuckDuckGo      |
|    web search      |
| 3. Clean & trim    |
| 4. Format context  |
+--------------------+
        |
        v
+--------------------+
| Prompt Assembly    |  (augmented)
| <example>          |
| <instructions>     |
| <data>             |
| <external_context> |  <-- NEW: injected context
+--------------------+
        |
        v
+--------------------+
| GPT-4 Generation   |  (existing - unchanged)
+--------------------+
```

## 🌰 Key design decisions

- **Local wiki as primary context**: The repository already contains curated market manipulation articles with verified evidence. When the reporter analyzes an exchange like Huobi, it automatically retrieves the existing wiki article about Huobi — providing specific facts about wash trading patterns, volume metrics, and regulatory actions that help the LLM produce more accurate and evidence-backed reports.

- **Zero-config operation**: Unlike approaches that require adding new API keys as repository secrets, this implementation works out of the box. Both the local wiki search and DuckDuckGo search require no API keys. The `--disable-web-search` flag allows running with local wiki context only.

- **No new dependencies**: Uses `pyyaml`, `bs4`, `bleach`, `requests`, and `duckduckgo-search` — all already listed in `pyproject.toml`.

- **Backward compatible**: Without wiki articles matching the exchange, the reporter produces identical output to before. RAG context is only injected when relevant content is found.

- **Clean data processing**: All text is cleaned with BeautifulSoup and bleach (no raw HTML in prompts). Hugo shortcodes are stripped. Articles are trimmed to Summary + key evidence sections to stay within token budgets.

## 🌰 Files changed

| File | Change |
|------|--------|
| `tools/market_health_reporter/rag_context.py` | **New** — RAG context retrieval module (local wiki + web search) |
| `tools/market_health_reporter/market_health_reporter.py` | Import RAG module, add `--disable-web-search` flag, fetch & inject context |
| `tools/market_health_reporter/tests/test_rag_context.py` | **New** — 20 unit tests covering frontmatter parsing, article trimming, text cleaning, wiki loading, context building |
| `tools/market_health_reporter/tests/__init__.py` | **New** — Package init |

## 🌰 Test plan

- [x] All 20 unit tests pass (`pytest tools/market_health_reporter/tests/ -v`)
- [ ] Reporter produces enriched output when wiki articles exist for the target exchange
- [ ] Reporter produces identical output when no wiki articles match (backward compatibility)
- [ ] `--disable-web-search` flag correctly skips web search while still using local wiki
- [ ] Context respects `max_context_chars` limit to avoid exceeding token budget

🌰