### PR TITLE
Add RAG context retrieval with TF-IDF ranking for Market Health Reporter

### DIFF
--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -3,12 +3,15 @@ from tiktoken import encoding_for_model
 import argparse
 import json
 import os
+import logging
 import requests
 import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.rag_context import build_rag_context
 
+logger = logging.getLogger(__name__)
 
 REPO_NAME = "1712n/dn-institute"
 SYSTEM_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/system_prompt.txt'
@@ -38,6 +41,20 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
+    )
+    parser.add_argument(
+        "--disable-web-search",
+        dest="disable_web_search",
+        action="store_true",
+        default=False,
+        help="Disable web search in RAG context retrieval (local wiki only)",
+    )
+    parser.add_argument(
+        "--disable-rag",
+        dest="disable_rag",
+        action="store_true",
+        default=False,
+        help="Disable RAG context retrieval entirely",
     )
     return parser.parse_args()
 
@@ -126,11 +143,14 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, rag_context: str = "") -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, data, and optional RAG context.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    prompt = f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    if rag_context:
+        prompt += f"\n\n{rag_context}"
+    return prompt
 
 
 def main():
@@ -160,7 +180,24 @@ def main():
         encoding = encoding_for_model("gpt-4")     
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        # Fetch RAG context unless disabled
+        rag_context = ""
+        if not args.disable_rag:
+            logger.info("Fetching RAG context for %s %s...", marketvenueid, pairid)
+            rag_context = build_rag_context(
+                exchange=marketvenueid,
+                pair=pairid,
+                start=start,
+                end=end,
+                repo_root=".",
+                include_web_search=not args.disable_web_search,
+            )
+            if rag_context:
+                logger.info("RAG context retrieved (%d chars)", len(rag_context))
+            else:
+                logger.info("No RAG context found, proceeding without it")
+
+        prompt = create_prompt(article_example, data, human_prompt_content, rag_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:

--- a/tools/market_health_reporter/rag_context.py
+++ b/tools/market_health_reporter/rag_context.py
@@ -1,0 +1,403 @@
+"""
+RAG (Retrieval-Augmented Generation) context module for Market Health Reporter.
+
+Retrieves and ranks relevant context from multiple sources:
+1. Local wiki articles in the repository (zero-config, highest quality)
+2. Web search via DuckDuckGo (real-time news, no API key required)
+3. Full article extraction from search result URLs for deeper context
+
+Retrieved content is cleaned, chunked, scored by relevance using TF-IDF,
+and formatted for injection into the LLM prompt.
+"""
+
+import os
+import re
+import math
+import logging
+from collections import Counter
+from typing import Optional
+
+import yaml
+import requests
+import bleach
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+WIKI_POSTS_DIR = "content/research/market-health/posts"
+
+# ---------------------------------------------------------------------------
+# Text cleaning
+# ---------------------------------------------------------------------------
+
+
+def clean_text(raw: str) -> str:
+    """Strip HTML tags, entities, and normalize whitespace."""
+    import html as html_mod
+    soup = BeautifulSoup(raw, "html.parser")
+    text = soup.get_text(separator=" ", strip=True)
+    text = bleach.clean(text, tags=[], attributes={}, strip=True)
+    text = html_mod.unescape(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+# ---------------------------------------------------------------------------
+# TF-IDF relevance scoring
+# ---------------------------------------------------------------------------
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase tokenization, letters and digits only."""
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def _term_freq(tokens: list[str]) -> dict[str, float]:
+    counts = Counter(tokens)
+    total = len(tokens) or 1
+    return {t: c / total for t, c in counts.items()}
+
+
+def _idf(documents: list[list[str]]) -> dict[str, float]:
+    n = len(documents) or 1
+    df: dict[str, int] = {}
+    for doc in documents:
+        for term in set(doc):
+            df[term] = df.get(term, 0) + 1
+    return {t: math.log(n / d) for t, d in df.items()}
+
+
+def score_relevance(query_tokens: list[str], text: str, idf_map: dict[str, float]) -> float:
+    """Score a text block against query tokens using TF-IDF cosine-like scoring."""
+    doc_tokens = _tokenize(text)
+    if not doc_tokens or not query_tokens:
+        return 0.0
+    tf = _term_freq(doc_tokens)
+    score = 0.0
+    for qt in query_tokens:
+        score += tf.get(qt, 0.0) * idf_map.get(qt, 1.0)
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Text chunking
+# ---------------------------------------------------------------------------
+
+
+def chunk_text(text: str, max_chars: int = 1500, overlap: int = 200) -> list[str]:
+    """Split text into overlapping chunks at sentence boundaries."""
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    chunks = []
+    current = ""
+    for sent in sentences:
+        if len(current) + len(sent) > max_chars and current:
+            chunks.append(current.strip())
+            # Keep overlap from end of previous chunk
+            current = current[-overlap:] + " " + sent if overlap else sent
+        else:
+            current = (current + " " + sent).strip()
+    if current.strip():
+        chunks.append(current.strip())
+    return chunks if chunks else [text[:max_chars]]
+
+
+# ---------------------------------------------------------------------------
+# Local wiki retrieval
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(content: str) -> tuple[Optional[dict], str]:
+    """Parse YAML frontmatter from markdown content."""
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", content, re.DOTALL)
+    if not match:
+        return None, content
+    try:
+        fm = yaml.safe_load(match.group(1))
+        return fm, match.group(2)
+    except yaml.YAMLError:
+        return None, content
+
+
+def _strip_hugo(body: str) -> str:
+    """Remove Hugo shortcodes and image markdown."""
+    body = re.sub(r"\{\{<.*?>}}", "", body)
+    body = re.sub(r"!\[.*?\]\(.*?\)", "", body)
+    body = re.sub(r"\n{3,}", "\n\n", body)
+    return body.strip()
+
+
+def load_wiki_articles(exchange: str, repo_root: str = ".") -> list[dict]:
+    """
+    Search local wiki articles for content relevant to the given exchange.
+
+    Returns a list of dicts with 'title', 'content', and 'source' keys.
+    """
+    posts_dir = os.path.join(repo_root, WIKI_POSTS_DIR)
+    if not os.path.isdir(posts_dir):
+        logger.warning(f"Wiki posts directory not found: {posts_dir}")
+        return []
+
+    exchange_norm = exchange.lower().replace(".", "").replace("-", "").replace(" ", "")
+    articles = []
+
+    for entry in sorted(os.listdir(posts_dir)):
+        entry_path = os.path.join(posts_dir, entry)
+        if not os.path.isdir(entry_path):
+            continue
+        index_file = os.path.join(entry_path, "index.md")
+        if not os.path.isfile(index_file):
+            continue
+
+        with open(index_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        fm, body = _parse_frontmatter(content)
+        if not fm:
+            continue
+
+        entities = fm.get("entities", [])
+        dir_norm = entry.lower().replace(".", "").replace("-", "").replace(" ", "")
+
+        entity_match = any(
+            exchange_norm in str(e).lower().replace(".", "").replace("-", "").replace(" ", "")
+            or str(e).lower().replace(".", "").replace("-", "").replace(" ", "") in exchange_norm
+            for e in entities
+        )
+
+        if entity_match or exchange_norm in dir_norm:
+            cleaned = _strip_hugo(body)
+            articles.append({
+                "title": fm.get("title", entry),
+                "content": cleaned,
+                "source": f"wiki:{entry}",
+            })
+
+    logger.info(f"Found {len(articles)} local wiki article(s) for '{exchange}'")
+    return articles
+
+
+# ---------------------------------------------------------------------------
+# Web search via DuckDuckGo
+# ---------------------------------------------------------------------------
+
+
+def _duckduckgo_search(query: str, max_results: int = 5) -> list[dict]:
+    """Search DuckDuckGo. Returns list of dicts with title, snippet, url."""
+    results = []
+    try:
+        from duckduckgo_search import DDGS
+        with DDGS() as ddgs:
+            for r in ddgs.text(query, max_results=max_results):
+                title = clean_text(r.get("title", ""))
+                snippet = clean_text(r.get("body", ""))
+                url = r.get("href", r.get("link", ""))
+                if title and snippet:
+                    results.append({"title": title, "snippet": snippet, "url": url})
+    except ImportError:
+        logger.warning("duckduckgo-search not available, skipping web search")
+    except Exception as e:
+        logger.warning(f"DuckDuckGo search failed: {e}")
+    return results
+
+
+def search_web(exchange: str, pair: str, start: str = "", end: str = "") -> list[dict]:
+    """
+    Run targeted web searches for the exchange and pair.
+
+    Returns deduplicated list of dicts with 'title', 'snippet', 'url'.
+    """
+    base_token = pair.split("-")[0].upper() if "-" in pair else pair.upper()
+    queries = [
+        f"{exchange} {base_token} wash trading manipulation",
+        f"{exchange} cryptocurrency trading volume anomaly",
+        f"{exchange} exchange regulatory news",
+    ]
+
+    seen_urls: set[str] = set()
+    results = []
+    for q in queries:
+        for item in _duckduckgo_search(q, max_results=3):
+            if item["url"] not in seen_urls:
+                seen_urls.add(item["url"])
+                results.append(item)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Full article extraction from URLs
+# ---------------------------------------------------------------------------
+
+
+def fetch_article_text(url: str, timeout: int = 10, max_chars: int = 5000) -> Optional[str]:
+    """
+    Fetch a URL and extract the main article text.
+
+    Returns cleaned text or None on failure.
+    """
+    try:
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; MarketHealthReporter/1.0)"},
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.debug(f"Failed to fetch {url}: {e}")
+        return None
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    # Remove noise elements
+    for tag in soup(["script", "style", "nav", "footer", "header", "aside", "form"]):
+        tag.decompose()
+
+    # Try <article> first, then <main>, then <body>
+    main = soup.find("article") or soup.find("main") or soup.find("body")
+    if not main:
+        return None
+
+    text = main.get_text(separator=" ", strip=True)
+    text = re.sub(r"\s+", " ", text).strip()
+
+    if len(text) < 100:
+        return None
+
+    return text[:max_chars]
+
+
+# ---------------------------------------------------------------------------
+# Build RAG context
+# ---------------------------------------------------------------------------
+
+
+def build_rag_context(
+    exchange: str,
+    pair: str,
+    start: str = "",
+    end: str = "",
+    repo_root: str = ".",
+    include_web_search: bool = True,
+    fetch_full_articles: bool = True,
+    max_context_chars: int = 8000,
+) -> str:
+    """
+    Build a ranked RAG context string for injection into the LLM prompt.
+
+    Retrieves content from local wiki and web search, scores chunks by
+    relevance using TF-IDF, and returns the top-ranked content formatted
+    for prompt injection.
+
+    Args:
+        exchange: Exchange name (e.g., "huobi").
+        pair: Trading pair (e.g., "btc-usdt").
+        start: Analysis period start date.
+        end: Analysis period end date.
+        repo_root: Path to the repository root.
+        include_web_search: Whether to include web search results.
+        fetch_full_articles: Whether to fetch full article text from URLs.
+        max_context_chars: Maximum characters for the context block.
+
+    Returns:
+        Formatted context string, or empty string if nothing found.
+    """
+    base_token = pair.split("-")[0] if "-" in pair else pair
+    query_tokens = _tokenize(f"{exchange} {base_token} wash trading manipulation volume anomaly")
+
+    # Collect all text chunks with their sources
+    all_chunks: list[dict] = []  # {"text": ..., "source": ..., "title": ...}
+
+    # 1. Local wiki articles (highest quality)
+    wiki_articles = load_wiki_articles(exchange, repo_root)
+    for article in wiki_articles:
+        chunks = chunk_text(article["content"], max_chars=1500)
+        for chunk in chunks:
+            all_chunks.append({
+                "text": chunk,
+                "source": article["source"],
+                "title": article["title"],
+                "origin": "wiki",
+            })
+
+    # 2. Web search
+    web_results = []
+    if include_web_search:
+        web_results = search_web(exchange, pair, start, end)
+        for item in web_results:
+            all_chunks.append({
+                "text": item["snippet"],
+                "source": item["url"],
+                "title": item["title"],
+                "origin": "web_snippet",
+            })
+
+    # 3. Full article extraction from top web results
+    if fetch_full_articles and web_results:
+        for item in web_results[:5]:
+            article_text = fetch_article_text(item["url"])
+            if article_text:
+                chunks = chunk_text(article_text, max_chars=1500)
+                for chunk in chunks:
+                    all_chunks.append({
+                        "text": chunk,
+                        "source": item["url"],
+                        "title": item["title"],
+                        "origin": "web_article",
+                    })
+
+    if not all_chunks:
+        logger.warning("No relevant context found from any source.")
+        return ""
+
+    # Score and rank all chunks
+    all_doc_tokens = [_tokenize(c["text"]) for c in all_chunks]
+    idf_map = _idf(all_doc_tokens)
+
+    for chunk in all_chunks:
+        base_score = score_relevance(query_tokens, chunk["text"], idf_map)
+        # Boost wiki content (curated, high quality)
+        if chunk["origin"] == "wiki":
+            base_score *= 1.5
+        # Boost full articles over snippets
+        elif chunk["origin"] == "web_article":
+            base_score *= 1.2
+        chunk["score"] = base_score
+
+    # Sort by score descending, deduplicate similar content
+    all_chunks.sort(key=lambda c: c["score"], reverse=True)
+
+    # Select top chunks within budget
+    selected: list[dict] = []
+    char_count = 0
+    seen_texts: set[str] = set()
+
+    for chunk in all_chunks:
+        # Simple dedup: skip if first 100 chars match something already selected
+        sig = chunk["text"][:100]
+        if sig in seen_texts:
+            continue
+        if char_count + len(chunk["text"]) > max_context_chars:
+            continue
+        seen_texts.add(sig)
+        selected.append(chunk)
+        char_count += len(chunk["text"])
+
+    if not selected:
+        return ""
+
+    # Format output
+    sections = []
+    for chunk in selected:
+        section = f"### {chunk['title']}\nSource: {chunk['source']}\n\n{chunk['text']}"
+        sections.append(section)
+
+    context_body = "\n\n---\n\n".join(sections)
+
+    return (
+        f"<external_context>\n"
+        f"The following is additional context about {exchange} retrieved from wiki articles "
+        f"and recent web sources. Reference specific events or findings from this context "
+        f"only where they help explain anomalies detected in the market data. "
+        f"Do not fabricate information beyond what is provided.\n\n"
+        f"{context_body}\n"
+        f"</external_context>"
+    )

--- a/tools/market_health_reporter/tests/test_rag_context.py
+++ b/tools/market_health_reporter/tests/test_rag_context.py
@@ -1,0 +1,358 @@
+"""Tests for the RAG context retrieval module."""
+
+import os
+import tempfile
+import requests
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.market_health_reporter.rag_context import (
+    clean_text,
+    chunk_text,
+    score_relevance,
+    load_wiki_articles,
+    search_web,
+    fetch_article_text,
+    build_rag_context,
+    _tokenize,
+    _term_freq,
+    _idf,
+    _parse_frontmatter,
+    _strip_hugo,
+)
+
+
+# ---------------------------------------------------------------------------
+# clean_text
+# ---------------------------------------------------------------------------
+
+
+class TestCleanText:
+    def test_strips_html_tags(self):
+        assert clean_text("<b>bold</b> text") == "bold text"
+
+    def test_strips_html_entities(self):
+        result = clean_text("hello&amp;world")
+        assert "&amp;" not in result
+
+    def test_normalizes_whitespace(self):
+        assert clean_text("hello   \n\t  world") == "hello world"
+
+    def test_empty_string(self):
+        assert clean_text("") == ""
+
+    def test_nested_html(self):
+        result = clean_text("<div><p>nested <b>content</b></p></div>")
+        assert result == "nested content"
+
+
+# ---------------------------------------------------------------------------
+# Tokenization and TF-IDF
+# ---------------------------------------------------------------------------
+
+
+class TestTokenize:
+    def test_basic(self):
+        assert _tokenize("Hello World 123") == ["hello", "world", "123"]
+
+    def test_strips_punctuation(self):
+        tokens = _tokenize("wash-trading, manipulation!")
+        assert "wash" in tokens
+        assert "trading" in tokens
+        assert "manipulation" in tokens
+
+    def test_empty(self):
+        assert _tokenize("") == []
+
+
+class TestTermFreq:
+    def test_basic(self):
+        tf = _term_freq(["a", "b", "a"])
+        assert abs(tf["a"] - 2 / 3) < 0.01
+        assert abs(tf["b"] - 1 / 3) < 0.01
+
+    def test_empty(self):
+        tf = _term_freq([])
+        assert tf == {}
+
+
+class TestIdf:
+    def test_basic(self):
+        docs = [["a", "b"], ["a", "c"], ["b", "c"]]
+        idf_map = _idf(docs)
+        # "a" appears in 2/3 docs, "b" in 2/3, "c" in 2/3
+        assert idf_map["a"] == idf_map["b"] == idf_map["c"]
+
+    def test_rare_term_higher_idf(self):
+        docs = [["a", "b"], ["a", "c"], ["a", "d"]]
+        idf_map = _idf(docs)
+        # "a" in all 3, "b" in 1 — b should have higher IDF
+        assert idf_map["b"] > idf_map["a"]
+
+
+class TestScoreRelevance:
+    def test_relevant_text_scores_higher(self):
+        idf_map = {"huobi": 2.0, "wash": 1.5, "trading": 1.0, "weather": 0.5}
+        query = ["huobi", "wash", "trading"]
+        relevant = "Huobi wash trading volume manipulation detected"
+        irrelevant = "The weather today is sunny and warm"
+        assert score_relevance(query, relevant, idf_map) > score_relevance(query, irrelevant, idf_map)
+
+    def test_empty_query(self):
+        assert score_relevance([], "some text", {"some": 1.0}) == 0.0
+
+    def test_empty_text(self):
+        assert score_relevance(["huobi"], "", {"huobi": 1.0}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chunking
+# ---------------------------------------------------------------------------
+
+
+class TestChunkText:
+    def test_short_text_single_chunk(self):
+        chunks = chunk_text("Short text.", max_chars=100)
+        assert len(chunks) == 1
+        assert chunks[0] == "Short text."
+
+    def test_splits_long_text(self):
+        text = "First sentence. " * 50 + "Last sentence."
+        chunks = chunk_text(text, max_chars=200, overlap=0)
+        assert len(chunks) > 1
+
+    def test_overlap(self):
+        text = "A. B. C. D. E. F. G. H. I. J. K. L. M. N. O. P. Q. R. S. T."
+        chunks = chunk_text(text, max_chars=30, overlap=10)
+        assert len(chunks) > 1
+
+    def test_empty_text(self):
+        chunks = chunk_text("", max_chars=100)
+        assert len(chunks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    def test_valid_frontmatter(self):
+        content = "---\ntitle: Test\nentities:\n  - Huobi\n---\nBody text"
+        fm, body = _parse_frontmatter(content)
+        assert fm["title"] == "Test"
+        assert "Huobi" in fm["entities"]
+        assert body == "Body text"
+
+    def test_no_frontmatter(self):
+        content = "Just body text"
+        fm, body = _parse_frontmatter(content)
+        assert fm is None
+        assert body == "Just body text"
+
+    def test_invalid_yaml(self):
+        content = "---\n: invalid: yaml: [[\n---\nBody"
+        fm, body = _parse_frontmatter(content)
+        assert fm is None
+
+
+# ---------------------------------------------------------------------------
+# Hugo stripping
+# ---------------------------------------------------------------------------
+
+
+class TestStripHugo:
+    def test_strips_figure_shortcodes(self):
+        text = 'Some text {{< figure src="img.png" >}} more text'
+        result = _strip_hugo(text)
+        assert "{{<" not in result
+        assert "Some text" in result
+        assert "more text" in result
+
+    def test_strips_image_markdown(self):
+        text = "Before ![alt](image.png) after"
+        result = _strip_hugo(text)
+        assert "![" not in result
+
+    def test_collapses_blank_lines(self):
+        text = "Line 1\n\n\n\n\nLine 2"
+        result = _strip_hugo(text)
+        assert "\n\n\n" not in result
+
+
+# ---------------------------------------------------------------------------
+# Wiki loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadWikiArticles:
+    def test_finds_matching_article(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            posts = os.path.join(tmpdir, "content", "research", "market-health", "posts")
+            article_dir = os.path.join(posts, "2023-08-14-huobi")
+            os.makedirs(article_dir)
+            with open(os.path.join(article_dir, "index.md"), "w") as f:
+                f.write("---\ntitle: Huobi Analysis\nentities:\n  - Huobi\n---\nWash trading detected.")
+
+            articles = load_wiki_articles("huobi", repo_root=tmpdir)
+            assert len(articles) == 1
+            assert "Huobi" in articles[0]["title"]
+            assert "Wash trading" in articles[0]["content"]
+
+    def test_no_match(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            posts = os.path.join(tmpdir, "content", "research", "market-health", "posts")
+            article_dir = os.path.join(posts, "2023-01-01-binance")
+            os.makedirs(article_dir)
+            with open(os.path.join(article_dir, "index.md"), "w") as f:
+                f.write("---\ntitle: Binance\nentities:\n  - Binance\n---\nContent.")
+
+            articles = load_wiki_articles("huobi", repo_root=tmpdir)
+            assert len(articles) == 0
+
+    def test_missing_directory(self):
+        articles = load_wiki_articles("huobi", repo_root="/nonexistent/path")
+        assert articles == []
+
+
+# ---------------------------------------------------------------------------
+# Web search (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchWeb:
+    @patch("tools.market_health_reporter.rag_context._duckduckgo_search")
+    def test_deduplicates_urls(self, mock_search):
+        mock_search.return_value = [
+            {"title": "Article 1", "snippet": "Content 1", "url": "https://example.com/1"},
+            {"title": "Article 2", "snippet": "Content 2", "url": "https://example.com/1"},  # duplicate
+        ]
+        results = search_web("huobi", "btc-usdt")
+        urls = [r["url"] for r in results]
+        assert len(urls) == len(set(urls))
+
+    @patch("tools.market_health_reporter.rag_context._duckduckgo_search")
+    def test_returns_results(self, mock_search):
+        mock_search.return_value = [
+            {"title": "News", "snippet": "Huobi wash trading", "url": "https://example.com/news"},
+        ]
+        results = search_web("huobi", "ht-usdt")
+        assert len(results) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Article fetching (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchArticleText:
+    @patch("tools.market_health_reporter.rag_context.requests.get")
+    def test_extracts_article_text(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = """
+        <html><body>
+        <nav>Navigation</nav>
+        <article><p>Huobi has been accused of wash trading. Volume anomalies were detected across multiple trading pairs including HT-USDT and BTC-USDT. Investigators found significant deviations from expected market behavior patterns.</p></article>
+        <footer>Footer</footer>
+        </body></html>
+        """
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        text = fetch_article_text("https://example.com/article")
+        assert text is not None
+        assert "wash trading" in text.lower()
+        assert "Navigation" not in text
+        assert "Footer" not in text
+
+    @patch("tools.market_health_reporter.rag_context.requests.get")
+    def test_returns_none_on_failure(self, mock_get):
+        mock_get.side_effect = requests.exceptions.Timeout()
+        assert fetch_article_text("https://example.com/timeout") is None
+
+    @patch("tools.market_health_reporter.rag_context.requests.get")
+    def test_returns_none_for_short_content(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = "<html><body><article>Short</article></body></html>"
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        assert fetch_article_text("https://example.com/short") is None
+
+
+# ---------------------------------------------------------------------------
+# build_rag_context (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRagContext:
+    def test_with_wiki_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            posts = os.path.join(tmpdir, "content", "research", "market-health", "posts")
+            article_dir = os.path.join(posts, "2023-08-14-huobi")
+            os.makedirs(article_dir)
+            with open(os.path.join(article_dir, "index.md"), "w") as f:
+                f.write(
+                    "---\ntitle: Huobi Wash Trading\nentities:\n  - Huobi\n---\n"
+                    "## Summary\nWash trading detected on Huobi with volume anomalies."
+                )
+
+            context = build_rag_context(
+                exchange="huobi",
+                pair="ht-usdt",
+                repo_root=tmpdir,
+                include_web_search=False,
+                fetch_full_articles=False,
+            )
+            assert "<external_context>" in context
+            assert "Huobi" in context
+            assert "</external_context>" in context
+
+    def test_empty_when_no_sources(self):
+        context = build_rag_context(
+            exchange="nonexistent_exchange_xyz",
+            pair="abc-usdt",
+            repo_root="/nonexistent",
+            include_web_search=False,
+            fetch_full_articles=False,
+        )
+        assert context == ""
+
+    def test_respects_max_context_chars(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            posts = os.path.join(tmpdir, "content", "research", "market-health", "posts")
+            article_dir = os.path.join(posts, "2023-08-14-huobi")
+            os.makedirs(article_dir)
+            with open(os.path.join(article_dir, "index.md"), "w") as f:
+                f.write(
+                    "---\ntitle: Huobi\nentities:\n  - Huobi\n---\n"
+                    + "Wash trading content. " * 500
+                )
+
+            context = build_rag_context(
+                exchange="huobi",
+                pair="ht-usdt",
+                repo_root=tmpdir,
+                include_web_search=False,
+                fetch_full_articles=False,
+                max_context_chars=500,
+            )
+            # The wrapper tags add some overhead, but inner content should be bounded
+            assert len(context) < 1500  # generous upper bound including tags
+
+    @patch("tools.market_health_reporter.rag_context.search_web")
+    def test_with_web_search(self, mock_search):
+        mock_search.return_value = [
+            {"title": "Huobi News", "snippet": "Huobi wash trading volume spike detected", "url": "https://example.com/1"},
+        ]
+        context = build_rag_context(
+            exchange="huobi",
+            pair="ht-usdt",
+            repo_root="/nonexistent",
+            include_web_search=True,
+            fetch_full_articles=False,
+        )
+        assert "<external_context>" in context
+        assert "Huobi" in context


### PR DESCRIPTION
## Summary

Adds a Retrieval-Augmented Generation (RAG) module to the Market Health Reporter that enriches LLM prompts with relevant external context, improving report quality by grounding analysis in real-world events and prior findings.

Closes #428

## Architecture

```
Issue Comment (exchange, pair, dates)
         |
         v
+--------------------+
| Market Data API    | (existing - unchanged)
+--------------------+
         |
         v
+--------------------+
| RAG Context        | <-- NEW: rag_context.py
| Retrieval          |
|                    |
| 1. Local wiki      |
|    articles        |
| 2. DuckDuckGo      |
|    web search      |
| 3. Full article    |
|    extraction      |
| 4. TF-IDF chunk    |
|    ranking         |
+--------------------+
         |
         v
+--------------------+
| Prompt Assembly    | (augmented)
| <example>          |
| <instructions>     |
| <data>             |
| <external_context> | <-- NEW: ranked context
+--------------------+
         |
         v
+--------------------+
| GPT-4 Generation   | (existing - unchanged)
+--------------------+
```

## How it works

The module retrieves context from three complementary sources, then ranks everything by relevance:

1. **Local wiki articles** — Searches `content/research/market-health/posts/` for articles matching the exchange being analyzed. Provides curated, high-quality context about known manipulation patterns. Zero-config, always available.

2. **Web search via DuckDuckGo** — Fetches real-time news and reports using targeted queries covering exchange news, wash trading reports, and regulatory developments. No API key required.

3. **Full article extraction** — Goes beyond search snippets by fetching and extracting the main text content from top search result URLs. Strips navigation, footers, scripts, and other noise using BeautifulSoup.

4. **TF-IDF relevance ranking** — All retrieved content is chunked (with overlap for context continuity), then scored against query terms using TF-IDF. Wiki content gets a 1.5x boost (curated quality), full articles get 1.2x over snippets. Only the highest-ranked chunks are selected within the token budget.

All text passes through a three-stage cleaning pipeline: BeautifulSoup HTML parsing → bleach sanitization → `html.unescape` for entities. This directly addresses the maintainer feedback on PR #480 about raw HTML in prompts.

## Key design decisions

- **Relevance ranking over dump**: Unlike approaches that inject all retrieved content, this implementation scores and ranks chunks by relevance using TF-IDF, ensuring only the most useful context reaches the LLM.
- **Deep content extraction**: Fetches full article text from URLs rather than relying solely on search snippets, providing richer context for the LLM.
- **Zero-config operation**: Both local wiki search and DuckDuckGo require no API keys. Works out of the box.
- **No new dependencies**: Uses pyyaml, bs4, bleach, requests, and duckduckgo-search — all already in pyproject.toml.
- **Backward compatible**: `--disable-rag` skips RAG entirely (identical output to before). `--disable-web-search` uses local wiki only.
- **Token budget aware**: `max_context_chars` parameter caps total context size to avoid exceeding token limits.

## Files changed

| File | Change |
|------|--------|
| `tools/market_health_reporter/rag_context.py` | New — RAG module with wiki search, web search, article extraction, TF-IDF ranking |
| `tools/market_health_reporter/market_health_reporter.py` | Import RAG module, add `--disable-rag` and `--disable-web-search` flags, fetch & inject context |
| `tools/market_health_reporter/tests/test_rag_context.py` | New — 37 unit tests covering all components |
| `tools/market_health_reporter/tests/__init__.py` | New — Package init |

## Test plan

- All 37 unit tests pass (`pytest tools/market_health_reporter/tests/ -v`)
- Tests cover: text cleaning, tokenization, TF-IDF scoring, chunking, frontmatter parsing, Hugo shortcode stripping, wiki loading, web search deduplication, article extraction, and full context building
- Reporter runs with `--disable-rag` producing identical output (backward compatibility)
- Reporter runs with `--disable-web-search` using local wiki only
- Context respects `max_context_chars` limit