### PR TITLE
refactor: improve Market Health Reporter prompts for structured, evidence-based analysis

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -1,82 +1,163 @@
-There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny. 
-Here is some basic procedure of the market surveillance analysis:
+There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny.
 
-1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio and time-of-trade. It is crucial to observe these metrics over time. 
-2. Identify anomalies using specific criteria, such as sudden spikes or significantly unusual trading volumes. The anomalous patterns and benchmarkes are provided below. Analyze metrics over time to identify trends and patterns. 
-3. Construct a coherent and convincing report, beginning with the metric that shows significant deviation and has a noticeable impact on other metrics. Ensure the report accurately captures market abnormalities that occurred concurrently. Include specific timestamps and quantitative values as evidence.
-4. If the data does not indicate any significant and clear anomalous patterns, avoid over-interpreting the datasets. If no signs of fraud or manipulation are evident, concisely report this absence and attach supporting evidence.
+## Analytical Procedure
 
-- Volume-Volatility Correlation.
-    Description: It is a statistical measure that identifies the relationship between trading volume and market volatility in cryptocurrency exchanges. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `vvcorrelation`.
-    Anomalous Pattern: A consistently low correlation (significantly below 0.4) between volume and volatility over extended periods. This might suggest artificial trading volume, as real market trades typically correlate with price volatility.
-    Benchmark: A normal range might vary, but a correlation coefficient consistently below 0.4 can be considered suspicious.
+Follow this procedure for the market surveillance analysis:
 
-- First-Digit Distribution. 
-    Description: In the context of cryptocurrency trading, adherence of the first-digit distribution to Benford’s Law can be used to scrutinize trading data for inconsistencies or abnormalities. Non-conformity to the expected digit distribution could suggest manipulation, such as wash trading or massive sell-offs, warranting further investigation. 
-    Name of the metric: This value is stored in the key `firstdigitdist`.
-    Anomalous Pattern: Significant deviation from Benford's expected distribution in leading digits of trading data. For instance, if numbers begin disproportionately with higher digits (like 8 or 9) instead of lower digits (like 1, 2, or 3).
-    Benchmark: Normally, the empirical first-digit distribution converges with the Benford's Law.      
+1. **Scan all metrics** — Examine volume distribution, first-digit distribution (Benford's Law), volume-volatility correlation, buy-sell ratio, time-of-trade, VWAP, and average transaction size. Observe each metric over time to establish a baseline before identifying deviations.
+2. **Identify anomalies with evidence** — Flag deviations using the specific thresholds and benchmarks provided below. Record the exact timestamps, metric values, and how they compare to the benchmark. Prioritize anomalies that are sustained over multiple consecutive time windows rather than isolated single-point spikes.
+3. **Assess severity through cross-metric corroboration**:
+   - **Strong evidence** (lead with this in the report): Three or more metrics deviate simultaneously in the same time window, or two metrics show a correlated pattern described in the cross-metric section below.
+   - **Moderate evidence**: Two metrics deviate in overlapping time windows, but the correlation is not one of the documented patterns.
+   - **Weak evidence** (mention as observation, not conclusion): A single metric deviates in isolation, which may reflect normal market volatility, whale activity, or a market-wide event rather than manipulation.
+4. **Construct the report** — Begin with the strongest evidence. Include specific timestamps and quantitative values. If the data does not indicate significant anomalous patterns, report this absence concisely with supporting evidence.
 
-- Kolmogorov-Smirnov (K-S) Test for the First-Digit Distribution.
-    Description: The Kolmogorov-Smirnov test is used to compare a sample with Benford's law. 
-    Name of the metrics: This value is stored in the key `benfordlawtest`.
-    Anomalous Pattern: A larger test value suggests a greater discrepancy between your dataset's distribution and Benford's Law.
-    Benchmark: The K-S test is sensitive to sample size. Sample size is stored in the key `tradecount`. It's necessary for the critical and the test values comparison.   
-    If test value > critical value, then you reject the null hypothesis. This suggests that your data does not conform to Benford's Law at the chosen significance level.
-    If test value ≤ critical value, then you do not reject the null hypothesis. This suggests that there is not enough evidence to conclude that your data deviates from Benford's Law at the chosen significance level.
-    The critical value is a ratio of 1.36 and a square root of `tradecount`. 
-    
-- Volume distribution. 
-    Description: Volume distribution is a graphical representation that shows how frequently different sizes of transactions occur within a time range. 
-    Name of the metric: This value is stored in the key `volumedist`.
-    Anomalous Pattern: A distribution that significantly deviates from the power law, such as an unusually high number of large (whale) trades or a lack of small/medium trades requires closer inspection.
-    Benchmark: The volume distribution is expected to follow the power law. The power law describes a phenomenon where a small number of items are concentrated at the top of a distribution. In simpler terms, this suggests that medium to small retail transactions are frequent, while large “whale” orders are rare.
-    The histogram of a power law distribution is not symmetric. It typically shows a steep drop-off at the beginning (for smaller values) and then a long tail that gradually descends but never really touches the x-axis.
+## Metric Definitions and Anomaly Criteria
 
-- Time-of-trade.
-    Description: This metric is designed to analyze trading activity distribution within each minute of an hour/each second of a minute, irrespective of the day/hour/minute in which the trades occur. By focusing solely on the minute/second of trade execution (ranging from 0 to 59), it provides a unique perspective on trading patterns and frequencies that occur at specific minute/second intervals. This approach aggregates transaction data from various time periods into a consolidated array of 60 items, each representing a distinct minute/second within an hour.
-    Name of the metrics: This value is stored in the key `timeoftrade`.
-    Anomalous Pattern: The Time-of-Trade metric detects a two-sided pattern. This means it flags both a high frequency of trades executed at the same time (second or minute) and an almost even distribution of trade counts across seconds or minutes. Such patterns suggest the presence of bot activity or automated trading systems.
-    Benchmark: No specific benchmark exists for this metric. However, trading patterns that significantly deviate from typical human trading behaviors, such as consistent trade spikes every minute or second, or evenly distributed trading activity across seconds or minutes, are considered suspect.
-    
-- Buy/sell ratio.
-    Description: The proportion of buy to sell market orders in a given time period. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `buysellratio` and `buysellratioabs`. 
-    Anomalous Pattern: Ratios that significantly deviate from the norm (0.4-0.6 range) or display unnatural steadiness during the periods of high volatility.
-    Benchmark: A balanced market should have a buy/sell ratio around 0.4-0.6. A buy/sell ratio significantly higher than 0.5 suggests a market bias towards buying. Such a scenario could lead to a price increase. A buy/sell ratio significantly lower than 0.5 indicates a market bias towards selling, possibly leading to a price decrease. 
-    
- 
-    Depending on the market context, both irregular and steady fluctuations in this ratio can be indicative of automated trading systems operating to influence the market. 
+- **Volume-Volatility Correlation**
+    Description: A statistical measure that identifies the relationship between trading volume and market volatility. In organic markets, higher volume accompanies higher volatility because real trades move prices.
+    Metric key: `vvcorrelation`.
+    Anomalous pattern: A consistently low correlation (below 0.4) over extended periods suggests artificial trading volume, since real market trades typically correlate with price volatility.
+    Benchmark: A correlation coefficient consistently below 0.4 is considered suspicious. Examine the trend — a sudden drop from a previously normal range is more concerning than a persistently low value that may reflect the pair's liquidity characteristics.
 
-- Volume Weighted Average Price (VWAP).
-    Description: A trading benchmark that calculates the average price of a cryptocurrency, weighted by its volume traded over a specific time period - more weight is given to the price levels where a lot of trading activity has occurred.
-    Name of the metric: This value is stored in the key `vwap`.
-    Anomalous Pattern: A significant and consistent difference between the VWAP and the actual trading price, particularly if the trading price is much higher or lower than the VWAP.
-    Benchmark: While there's no specific numerical benchmark, a deviation that's outside normal trading fluctuations could be a red flag.
+- **First-Digit Distribution (Benford's Law)**
+    Description: Adherence of the first-digit distribution to Benford's Law can scrutinize trading data for inconsistencies. Non-conformity could suggest manipulation such as wash trading or massive sell-offs.
+    Metric key: `firstdigitdist` (object with digits 1-9 as keys and occurrence counts as values).
+    Expected frequencies per Benford's Law:
+    | Digit | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+    |-------|------|------|------|------|------|------|------|------|------|
+    | Freq  | 30.1% | 17.6% | 12.5% | 9.7% | 7.9% | 6.7% | 5.8% | 5.1% | 4.6% |
+    Anomalous pattern: Significant deviation from the expected distribution, particularly if higher digits (8, 9) appear disproportionately often or if digit 1 is substantially underrepresented.
+    Benchmark: Compare observed frequencies against the table above. Deviations exceeding 5 percentage points for multiple digits simultaneously warrant concern.
 
-To enhance the analysis, here are some tips regarding simultaneous anomalous deviations of these metrics which can be indicative of market anomalies:
+- **Kolmogorov-Smirnov (K-S) Test for First-Digit Distribution**
+    Description: Quantifies the discrepancy between the dataset's first-digit distribution and Benford's Law.
+    Metric key: `benfordlawtest`.
+    Anomalous pattern: A larger test value indicates greater discrepancy from Benford's Law.
+    Benchmark: The K-S test is sensitive to sample size. Sample size is stored in the key `tradecount`.
+    Critical value = 1.36 / sqrt(`tradecount`).
+    - If test value > critical value → reject null hypothesis (data does not conform to Benford's Law).
+    - If test value ≤ critical value → do not reject null hypothesis (insufficient evidence of deviation).
+    P-value interpretation (from the project's documentation):
+    - p > 0.01: Good fit — data conforms to Benford's Law.
+    - 0.005 < p ≤ 0.01: Moderate concern.
+    - p ≤ 0.005: High concern — potential manipulation.
+    Important: A single time window exceeding the critical value may be random noise. Flag Benford's Law violations only when the K-S test exceeds the critical value across multiple consecutive time windows.
 
-Volume Distribution and Volume-Volatility Correlation: A volume distribution that deviates from the power law, especially with an unusual number of large trades, coupled with a low volume-volatility correlation, can suggest market manipulation. Large trades should typically introduce volatility, and a lack of this correlation might indicate that these large trades are not impacting the market as expected.
-Concurrent Irregularities in First-Digit Distribution and K-S Test: Significant deviations from Benford's Law in First-Digit Distribution, coupled with a K-S Test value greater than the critical value, strongly indicate data manipulation. This could be a sign of practices like wash trading, where large volumes of trades are artificially created to mislead the market.
-Inconsistencies in VWAP and Buy/Sell Ratio: A substantial difference between VWAP and market prices, along with abnormal Buy/Sell Ratios, could signify price manipulation. Traders might be attempting to influence the perceived average price through strategic buying or selling.
-Correlation between Time-of-Trade and Buy/Sell Ratio Anomalies: If the Time-of-Trade metric shows high frequency or evenly distributed trades, and the Buy/Sell Ratio deviates significantly from the 0.4-0.6 range, this might suggest automated trading systems are in play. This could be an attempt to influence market prices or create false market sentiment.
+- **Volume Distribution**
+    Description: Shows how frequently different sizes of transactions occur within a time range.
+    Metric key: `volumedist` (histogram with 100 bins).
+    Anomalous pattern: A distribution that significantly deviates from the power law — for example, an unusually high number of large trades or a lack of small/medium trades.
+    Benchmark: A healthy volume distribution follows the power law: small retail transactions are frequent, large "whale" orders are rare. The histogram should be asymmetric with a steep drop-off for smaller values and a long tail for larger values.
+    Skewness analysis: In healthy markets, volume distribution skewness should be greater than 1 (right-skewed). Skewness near zero or negative indicates unnaturally uniform trade sizes, suggesting order-printing bots. When skewness drops below zero across multiple trading pairs on the same exchange simultaneously, this is a strong indicator of exchange-wide wash trading programs.
 
-Create an article with the results of your analysis. The article should include:
-- Fields between --- and ---:
-    - 'date'
-        The content of this field must match the format YYYY-MM-DD — YYYY-MM-DD, where the first date is the start of the analysis period, and the second date is the end of the analysis period.
-        Example: '2023-10-02 — 2023-10-08'
-    - 'entities'
-        The content of this field should include entities implicated in wash trading. Example: 'Huobi, HT, TRX, DOGE'
-    - 'title'
-        The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
+- **Time-of-Trade**
+    Description: Analyzes trading activity distribution within each second of a minute (or minute of an hour), aggregated across all time periods into a 60-item array.
+    Metric key: `timeoftrade` (array of 60 values).
+    Anomalous pattern: This metric detects two patterns:
+    1. High-frequency spikes at fixed intervals (e.g., every 5 seconds) — indicates scheduled bot execution.
+    2. An almost perfectly even distribution across all seconds/minutes — suggests algorithmic randomization designed to appear organic but lacking the natural burstiness of human trading.
+    Benchmark: Calculate the coefficient of variation (CV = standard deviation / mean) of the 60 values:
+    - CV < 0.3: Suspiciously uniform — likely algorithmic distribution.
+    - CV between 0.3 and 1.0: Normal range — typical human trading patterns.
+    - CV > 1.0: Highly bursty — organic or event-driven. May contain periodic spikes if bot-driven.
+    Also inspect for periodic patterns: if values at indices 0, 5, 10, 15... (every 5th position) are consistently higher than their neighbors, this indicates 5-second interval bot activity.
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
-Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
-Place the article into the <article> </article> tags.
+- **Buy/Sell Ratio**
+    Description: The proportion of buy to sell market orders in a given time period.
+    Metric keys: `buysellratio` (normalized) and `buysellratioabs` (absolute).
+    Anomalous patterns — two distinct types:
+    1. **Directional anomaly**: Ratio significantly outside the 0.4–0.6 range indicates one-sided pressure, potentially from coordinated buying or selling.
+    2. **Stability anomaly**: Ratio that remains unnaturally steady (fluctuating within a narrow band, e.g., 0.48–0.52) during periods of high market volatility. This is particularly suspicious for exchange-native tokens, where the exchange has an incentive to stabilize the token price. In the Huobi reference case, HT's buy/sell ratio showed "abnormal stability that fluctuates within a narrow range" as a key finding.
+    Benchmark: A balanced market has a buy/sell ratio around 0.4–0.6 with natural volatility. Sustained deviation or unnatural steadiness both warrant investigation.
+
+- **Volume Weighted Average Price (VWAP)**
+    Description: The average price weighted by volume traded over a specific time period — more weight is given to price levels where substantial trading occurred.
+    Metric key: `vwap`.
+    Anomalous pattern: A significant and consistent difference between VWAP and the actual trading price, particularly if the trading price is persistently above or below the VWAP.
+    Benchmark: While no specific numerical threshold exists, deviation that persists beyond normal intraday fluctuations (more than 2-3 standard deviations from the rolling mean difference) is a red flag.
+
+- **Average Transaction Size**
+    Description: Computed from `volume` / `tradecount` for each time window. This is one of the most revealing metrics for detecting algorithmic wash trading.
+    Metric key: `avgtransactionsize`. Also examine `volume` and `tradecount` individually.
+    Anomalous patterns:
+    1. Sudden large spikes in average transaction size while `tradecount` remains stable or decreases — indicates fewer but larger trades, consistent with volume-generating algorithms inflating reported volume.
+    2. Low standard deviation of average transaction size across consecutive time windows — organic trading produces inherently variable transaction sizes; uniformity suggests bot activity.
+    Benchmark: Cross-exchange comparison is the strongest benchmark. Significant divergence in average transaction size for the same trading pair on the analyzed exchange versus established exchanges (Binance, Coinbase, OKX) during the same period constitutes evidence of artificial volume.
+
+## Cross-Metric Correlation Patterns
+
+When multiple metrics deviate simultaneously, the evidence for manipulation is substantially stronger. Document these patterns when observed:
+
+1. **Volume Distribution + Volume-Volatility Correlation**: A volume distribution that deviates from the power law (especially with unusually many large trades), combined with low volume-volatility correlation, suggests market manipulation. Large trades should introduce volatility; their failure to do so indicates they are not genuine market-moving orders.
+
+2. **First-Digit Distribution + K-S Test (Benford's Law)**: Significant deviations from Benford's Law in First-Digit Distribution, combined with K-S test values persistently exceeding the critical value, strongly indicate data fabrication — potentially wash trading where artificial trade volumes create non-natural digit distributions.
+
+3. **VWAP + Buy/Sell Ratio**: A substantial gap between VWAP and market prices, coupled with abnormal buy/sell ratios, could signify price manipulation through strategic buying or selling to influence the perceived average price.
+
+4. **Time-of-Trade + Buy/Sell Ratio**: High-frequency or evenly distributed trades (from Time-of-Trade) plus a buy/sell ratio significantly outside the 0.4–0.6 range suggest automated trading systems attempting to influence market prices or create false market sentiment.
+
+5. **Average Transaction Size + Volume Distribution**: Spikes in average transaction size coinciding with volume distribution losing its power-law shape (skewness dropping toward zero) point to order-printing bots generating high-volume trades of uniform size. This pattern was observed across multiple Huobi spot markets in mid-2023.
+
+6. **Average Transaction Size + Buy/Sell Ratio Stability**: Elevated and steady average transaction sizes combined with an unnaturally stable buy/sell ratio indicate a coordinated algorithmic operation controlling both order flow direction and trade sizing.
+
+## Output Format
+
+Create an article with the results of your analysis. The article must follow this exact structure:
+
+### YAML Front Matter (between `---` and `---`):
+
+```yaml
+---
+title: "<Descriptive title highlighting the key finding>"
+date: "<YYYY-MM-DD>"
+entities:
+  - <Exchange name>
+  - <Token symbol 1>
+  - <Token symbol 2>
+---
+```
+
+Field requirements:
+- `title`: A specific, descriptive title that names the exchange and type of manipulation found. Example: `"Uncovering Wash Trading and Market Manipulation on Huobi"`
+- `date`: A single date in YYYY-MM-DD format. Use the end date of the analysis period.
+- `entities`: A YAML list (one item per line, each prefixed with `- `). Include the exchange name and all token symbols where anomalies were found.
+
+### Article Body:
+
+**`## Summary`** — A numbered list of 4–6 key findings. Each finding should be:
+- One sentence with a specific, data-backed claim.
+- Bold the most important phrase in each finding (e.g., "**surge in manipulative practices**").
+- Only include findings directly supported by the data. Do not speculate.
+
+**`## Metrics used`** — Contains `###` subsections organized by analytical finding (not by raw metric name). Use descriptive headings that communicate the insight, for example:
+- "### Abnormal activity indicator - Average transaction size" (not "### avgtransactionsize")
+- "### Order printing bots - Volume distribution tail and skewness" (not "### Volume distribution")
+- "### Real users presence - Trade clustering analysis" (not "### Time-of-trade")
+
+Each subsection should:
+1. Explain the metric and its relevance in 1–2 sentences.
+2. Present specific data observations with timestamps and quantitative values.
+3. Include the relevant illustration placeholder at the point where it supports the narrative.
+4. State the conclusion drawn from this specific analysis.
+
+### Illustrations
+
+You can create placeholders for illustrations. Each corresponds to a specific chart generated by the visualization tool:
+- `volume_hist.png`: Histogram of transaction volume distribution — use when discussing volume distribution and power-law conformity.
+- `crypto_metrics.png`: Time-series chart of volume, trade count, average transaction size, and buy/sell ratio — use when discussing temporal trends, average transaction size spikes, or buy/sell ratio stability.
+- `benford_law.png`: Benford's Law K-S test score and critical value threshold over time — use when discussing first-digit distribution conformity.
+- `vv_correlation.png`: Volume-volatility correlation over time — use when discussing the relationship between volume and price volatility.
+
+Illustration syntax: `{{< figure src="<filename>" alt="<descriptive alt text>" caption="<caption describing what the chart shows and the time period>" loading="lazy" >}}`
+
+### Writing Style
+
+Follow the example in the <example> </example> tags. Key style guidelines from the example article:
+- Use a narrative analytical flow — each subsection tells a story about what the data reveals, not just metric descriptions.
+- Connect findings across subsections to build a coherent case.
+- Include cross-exchange comparisons when the data supports them.
+- Reference specific time windows when anomalies cluster.
+- Avoid generic language like "further investigation needed" — either the evidence supports a conclusion or it does not.
+
+Put into the article only the information from the data provided. Place the complete article inside <article> </article> tags.

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,1 +1,8 @@
-You are a cryptocurrency market analyst with a focus on the market manipulations and anomalous trade activity detection. Conduct a thorough analysis of the data, using the instructions provided to you.
+You are a cryptocurrency market surveillance analyst specializing in wash trading detection and anomalous trade activity identification. Your role is to produce publication-ready investigative articles for the DN Institute Market Health wiki.
+
+Core principles:
+- Ground every claim in quantitative evidence from the provided data. Cite specific metric values, timestamps, and thresholds.
+- Distinguish between confirmed manipulation patterns (multiple corroborating metrics) and isolated statistical anomalies (single-metric deviations that may be noise).
+- When the data is inconclusive or shows no significant anomalies, state this clearly rather than speculating. A report finding no manipulation is still a valid and useful report.
+- Write in a professional, concise analytical tone. Avoid hedging language when evidence is strong; avoid definitive claims when evidence is weak.
+- Structure your output as a Hugo-compatible markdown article wrapped in <article> </article> tags.


### PR DESCRIPTION
## Problem

Fixes #427

After a systematic comparison of the [current prompts](https://github.com/1712n/dn-institute/tree/main/tools/market_health_reporter/doc/prompts) against the [Huobi reference article](https://github.com/1712n/dn-institute/blob/main/content/research/market-health/posts/2023-08-14-huobi/index.md), the [contribution guidelines](https://github.com/1712n/dn-institute/issues/277), the [project metric documentation](https://github.com/1712n/dn-institute/tree/main/content/research/market-health/docs), and the [visualization tool code](https://github.com/1712n/dn-institute/blob/main/tools/python_modules/report_graphics_tool.py), I identified several structural and analytical gaps between what the prompts instruct and what the published standards require.

## Key Gaps Identified

1. **No severity framework** — The original prompt treats all anomalies equally. A single metric deviation (potentially noise) gets the same weight as three metrics deviating simultaneously (strong evidence). This leads to reports that either cry wolf on minor fluctuations or understate genuine manipulation.

2. **Missing metric: Average Transaction Size** — The `avgtransactionsize` field is plotted by the visualization tool in `crypto_metrics.png` and is the *primary finding* in the Huobi reference article ("Abnormal activity indicator - Average transaction size"), yet the prompt never instructs the model to analyze it.

3. **No quantitative thresholds for key metrics** — The prompt mentions Benford's Law but doesn't provide the expected digit frequencies (30.1%, 17.6%, 12.5%...). It mentions the K-S test but doesn't include the p-value interpretation tiers from the project's [own documentation](https://github.com/1712n/dn-institute/blob/main/content/research/market-health/docs/benford/index.md). Without concrete numbers, the model has no reference for quantifying deviations.

4. **Broken output format** — The original prompt specifies `date: 'YYYY-MM-DD — YYYY-MM-DD'` (range format) and `entities: 'Huobi, HT, TRX, DOGE'` (comma-separated string). Every published article uses a single `date: YYYY-MM-DD` and a YAML list for entities. This produces Hugo front matter that doesn't match the site's schema.

5. **No article structure guidance** — The prompt says "create an article" but doesn't specify the `## Summary` + `## Metrics used` structure or the descriptive subsection headings that the Huobi article uses (e.g., "Order printing bots - Volume distribution tail and skewness").

6. **Missing analytical patterns from the reference article** — Buy/sell ratio *stability* anomaly (HT's abnormally narrow fluctuation range), volume distribution *skewness* analysis (below-zero skewness indicating order-printing bots), and time-of-trade *periodicity* detection (5-second interval bot patterns from the OKEx article) are all absent.

7. **Illustration files undocumented** — The prompt lists four allowed illustration filenames but doesn't describe what each chart contains, making it impossible for the model to place them at the correct point in the narrative.

## Changes Made

### `system_prompt.txt`
- Expanded from a single generic sentence to a focused role definition with five core analytical principles
- Added explicit instructions to distinguish confirmed patterns (multi-metric) from isolated anomalies (single-metric)
- Added constraint to report clearly when data is inconclusive rather than speculating
- Specified the output format requirement (Hugo markdown in `<article>` tags)

### `prompt1.txt`

**Analytical Methodology:**
- Restructured the 4-step procedure into a severity-based framework with explicit evidence thresholds:
  - **Strong evidence**: 3+ metrics deviating simultaneously, or 2 metrics matching a documented cross-metric pattern
  - **Moderate evidence**: 2 metrics deviating in overlapping windows without a documented correlation
  - **Weak evidence**: Single-metric deviations (report as observation, not conclusion)
- Added guidance to prioritize sustained multi-window deviations over isolated single-point spikes

**Metric Definitions:**
- **Added Average Transaction Size** as an explicit metric with anomaly patterns (spikes with low variance, declining trade count) and cross-exchange comparison benchmark
- **Added Benford's Law expected digit frequencies** (30.1%, 17.6%, 12.5%, 9.7%, 7.9%, 6.7%, 5.8%, 5.1%, 4.6%) with a 5-percentage-point deviation threshold
- **Added K-S test p-value interpretation tiers** from the project's own Benford documentation (p > 0.01 good fit; 0.005 < p ≤ 0.01 moderate; p ≤ 0.005 high concern)
- **Added K-S test persistence requirement** — flag violations only when the K-S test exceeds the critical value across multiple consecutive windows
- **Added volume distribution skewness analysis** with thresholds (>1 healthy, near-zero suspicious, below-zero wash trading indicator)
- **Added time-of-trade coefficient of variation** (CV < 0.3 suspicious uniformity, 0.3–1.0 normal, >1.0 organic burstiness) and periodic pattern detection (every-5th-position spikes)
- **Added buy/sell ratio stability anomaly type** — unnatural steadiness (0.48–0.52 band) during volatile periods, especially on exchange-native tokens, per the Huobi reference article's key finding
- Fixed typo: "benchmarkes" → "benchmarks"

**Cross-Metric Correlations:**
- Expanded from 4 to 6 documented cross-metric patterns, adding:
  - Average Transaction Size + Volume Distribution (order-printing bot detection)
  - Average Transaction Size + Buy/Sell Ratio Stability (coordinated algorithmic operation)
- Numbered all patterns for clear reference

**Output Format:**
- Fixed YAML front matter to match published articles: single `date: YYYY-MM-DD`, YAML list for `entities`
- Added explicit `## Summary` and `## Metrics used` section structure
- Specified descriptive `###` subsection headings matching the reference article style (e.g., "Abnormal activity indicator - Average transaction size", not "avgtransactionsize")
- Added per-subsection requirements: explain metric, present data with timestamps/values, place illustration, state conclusion

**Illustration Documentation:**
- Mapped each filename to its visualization tool output:
  - `volume_hist.png` → transaction volume histogram (volume distribution analysis)
  - `crypto_metrics.png` → 4-panel time series of volume, trade count, avg tx size, buy/sell ratio
  - `benford_law.png` → K-S test score vs critical value over time
  - `vv_correlation.png` → volume-volatility correlation over time
- Provided illustration syntax template with alt text and caption guidance

**Writing Style:**
- Added guidelines matching the Huobi reference article's narrative analytical flow
- Specified to connect findings across subsections to build a coherent investigative case
- Instructed to avoid generic hedging language in favor of evidence-based conclusions

## What This PR Does NOT Do

- Does not modify the Python code, visualization tool, or any non-prompt files
- Does not change the fundamental metric definitions or their anomaly patterns
- Does not add speculative or ungrounded analytical criteria
- Preserves the original prompt's logical structure while extending it

## Methodology

Each change maps directly to a specific gap between the current prompt output and the published article standards:

| Gap | Source of Ground Truth | Change |
|-----|----------------------|--------|
| No severity framework | Reference article leads with multi-metric findings | Added 3-tier evidence assessment |
| Missing avg tx size | Visualization tool plots it; reference article's primary finding | Added as explicit metric |
| No digit frequencies | Project's Benford docs list exact percentages | Added frequency table |
| No p-value tiers | Project's Benford docs define 3 tiers | Added p-value interpretation |
| Wrong date format | All published articles use single YYYY-MM-DD | Fixed format specification |
| Wrong entities format | All published articles use YAML list | Fixed to YAML list |
| No article structure | Reference article uses Summary + Metrics used | Added section requirements |
| Generic headings | Reference article uses descriptive insight headings | Added heading style guidance |
| Undocumented illustrations | Visualization tool source code | Added filename-to-chart mapping |

## AI Disclosure

AI (Claude) was used as a coding assistant. All analytical decisions — the severity framework design, threshold selections, cross-metric patterns, and gap analysis — are based on systematic comparison of the existing codebase, published articles, and project documentation.