### PR TITLE
feat: add batch message processing to Similarity Search API

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,9 @@ type TextEntry = {
   namespace: string
 }
 
+const AI_MODEL = "@cf/baai/bge-base-en-v1.5"
+const MAX_BATCH_SIZE = 100
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -27,6 +30,20 @@ app.use("*", async (c, next) => {
   return next()
 })
 
+async function embedTexts(ai: Ai, texts: string[]): Promise<number[][]> {
+  const response = await ai.run(AI_MODEL, { text: texts })
+  return response.data
+}
+
+async function querySimilarity(
+  index: VectorizeIndex,
+  vector: number[],
+  namespace: string
+): Promise<number> {
+  const response = await index.query(vector, { namespace, topK: 1 })
+  return response.matches[0]?.score || 0
+}
+
 app.post("/", async (c) => {
   const data = await c.req.json<TextEntry>()
   const { text, namespace } = data
@@ -35,17 +52,63 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: [text]
-  })
-  const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
-    namespace,
-    topK: 1
-  })
-  const similarityScore = searchResponse.matches[0]?.score || 0
+  const [vector] = await embedTexts(c.env.AI, [text])
+  const similarityScore = await querySimilarity(c.env.VECTORIZE_INDEX, vector, namespace)
 
   return c.json({ similarity_score: similarityScore })
+})
+
+app.post("/batch", async (c) => {
+  const data = await c.req.json<{ messages: TextEntry[] }>()
+
+  if (!Array.isArray(data.messages)) {
+    return c.json({ error: "messages must be an array" }, 400)
+  }
+  if (data.messages.length === 0) {
+    return c.json({ error: "messages array must not be empty" }, 400)
+  }
+  if (data.messages.length > MAX_BATCH_SIZE) {
+    return c.json({ error: `batch size exceeds maximum of ${MAX_BATCH_SIZE}` }, 400)
+  }
+
+  for (const [i, entry] of data.messages.entries()) {
+    if (typeof entry.text !== "string" || typeof entry.namespace !== "string") {
+      return c.json({ error: `invalid format at index ${i}: text and namespace must be strings` }, 400)
+    }
+  }
+
+  // Deduplicate texts for embedding — each unique text is embedded only once
+  const uniqueTexts = [...new Set(data.messages.map((m) => m.text))]
+  const embeddings = await embedTexts(c.env.AI, uniqueTexts)
+  const embeddingMap = new Map<string, number[]>()
+  uniqueTexts.forEach((text, i) => embeddingMap.set(text, embeddings[i]))
+
+  // Deduplicate (text, namespace) pairs for Vectorize queries
+  const queryKey = (text: string, namespace: string) => `${text}\0${namespace}`
+  const uniqueQueries = new Map<string, TextEntry>()
+  for (const msg of data.messages) {
+    const key = queryKey(msg.text, msg.namespace)
+    if (!uniqueQueries.has(key)) {
+      uniqueQueries.set(key, msg)
+    }
+  }
+
+  // Run all unique Vectorize queries in parallel
+  const scoreMap = new Map<string, number>()
+  await Promise.all(
+    [...uniqueQueries.entries()].map(async ([key, { text, namespace }]) => {
+      const vector = embeddingMap.get(text)!
+      const score = await querySimilarity(c.env.VECTORIZE_INDEX, vector, namespace)
+      scoreMap.set(key, score)
+    })
+  )
+
+  // Map results back to the original request order
+  const results = data.messages.map((msg) => ({
+    similarity_score: scoreMap.get(queryKey(msg.text, msg.namespace)) || 0,
+  }))
+
+  return c.json({ results })
 })
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,6 +3,11 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const VALID_HEADERS = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key",
+}
+
 describe("Authentication", () => {
   it("returns 401 Unauthorized when API key is missing or invalid", async () => {
     const response = await SELF.fetch("https://example.com/", {
@@ -18,5 +23,165 @@ describe("Authentication", () => {
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 when API key header has wrong value", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "wrong-key",
+      },
+      body: JSON.stringify({
+        text: "Sample text",
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("POST / (single message)", () => {
+  it("returns similarity score for a valid request", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        text: "Sample text",
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json() as { similarity_score: number }
+    expect(body).toHaveProperty("similarity_score")
+    expect(typeof body.similarity_score).toBe("number")
+  })
+
+  it("returns 400 for invalid JSON format", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        text: 123,
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+})
+
+describe("POST /batch", () => {
+  it("returns similarity scores for a valid batch request", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        messages: [
+          { text: "First text", namespace: "ns1" },
+          { text: "Second text", namespace: "ns2" },
+        ]
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json() as { results: { similarity_score: number }[] }
+    expect(body.results).toHaveLength(2)
+    expect(body.results[0]).toHaveProperty("similarity_score")
+    expect(body.results[1]).toHaveProperty("similarity_score")
+  })
+
+  it("handles duplicate texts efficiently and returns correct order", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        messages: [
+          { text: "Same text", namespace: "ns1" },
+          { text: "Different text", namespace: "ns1" },
+          { text: "Same text", namespace: "ns1" },
+        ]
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json() as { results: { similarity_score: number }[] }
+    expect(body.results).toHaveLength(3)
+    // Duplicate entries should have the same score
+    expect(body.results[0].similarity_score).toBe(body.results[2].similarity_score)
+  })
+
+  it("returns 400 when messages is not an array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ messages: "not an array" })
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json() as { error: string }
+    expect(body.error).toBe("messages must be an array")
+  })
+
+  it("returns 400 when messages array is empty", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ messages: [] })
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json() as { error: string }
+    expect(body.error).toBe("messages array must not be empty")
+  })
+
+  it("returns 400 when batch size exceeds maximum", async () => {
+    const messages = Array.from({ length: 101 }, (_, i) => ({
+      text: `Text ${i}`,
+      namespace: "ns"
+    }))
+
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ messages })
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json() as { error: string }
+    expect(body.error).toContain("batch size exceeds maximum")
+  })
+
+  it("returns 400 when a message has invalid format", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        messages: [
+          { text: "Valid", namespace: "ns" },
+          { text: 123, namespace: "ns" },
+        ]
+      })
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json() as { error: string }
+    expect(body.error).toContain("invalid format at index 1")
+  })
+
+  it("requires authentication", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ text: "Test", namespace: "ns" }]
+      })
+    })
+
+    expect(response.status).toBe(401)
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,9 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    const texts = data.text || [];
+                    const embeddings = texts.map(() => new Array(768).fill(0.1));
+                    return Promise.resolve({ data: embeddings });
                   }
                 };
               };`


### PR DESCRIPTION
## Summary

Adds a `POST /batch` endpoint to the Similarity Search API worker for processing multiple messages in a single request.

## Methodology

### Architecture: Separate Batch Endpoint

A dedicated `POST /batch` endpoint is introduced rather than modifying the existing `POST /` endpoint. This preserves backward compatibility and any caching mechanisms configured on the single-message endpoint.

### Two-Level Deduplication for Cost Efficiency

The batch implementation reduces both AI and Vectorize costs through deduplication:

1. **Text-level deduplication**: Before calling Workers AI, duplicate texts are removed so each unique text is embedded only once. In workloads with repeated messages (e.g., near-duplicate detection against a reference set), this can significantly reduce embedding costs.

2. **Query-level deduplication**: Identical `(text, namespace)` pairs are queried against Vectorize only once. Results are mapped back to all matching entries in the original request, preserving response order.

### Resource Efficiency

| Operation | Single endpoint (N requests) | Batch endpoint (1 request, N messages) |
|-----------|------------------------------|---------------------------------------|
| AI calls | N | 1 |
| Vectorize queries | N | ≤ N (reduced by deduplication) |
| HTTP round-trips | N | 1 |

### Cloudflare Workers Constraints

- **Batch size limit**: 100 messages per request, matching the `@cf/baai/bge-base-en-v1.5` model's `maxItems` constraint
- **Parallel execution**: Vectorize queries run concurrently via `Promise.all`
- **No new bindings**: Uses only existing AI and Vectorize bindings

### Code Organization

Shared helper functions (`embedTexts`, `querySimilarity`) are extracted so both endpoints use the same embedding and query logic, reducing duplication and maintenance burden.

## API

### Request
```
POST /batch
X-API-Key: <key>
Content-Type: application/json

{
  "messages": [
    { "text": "first message", "namespace": "ns1" },
    { "text": "second message", "namespace": "ns2" }
  ]
}
```

### Response
```json
{
  "results": [
    { "similarity_score": 0.85 },
    { "similarity_score": 0.42 }
  ]
}
```

### Error Responses
- `400` — invalid input (not an array, empty, exceeds limit, bad format)
- `401` — missing or invalid API key

## Tests

Added comprehensive test coverage:
- Valid batch request with multiple messages
- Deduplication behavior (duplicate entries return identical scores)
- Validation: non-array input, empty array, oversized batch, invalid entry format
- Authentication on the batch endpoint
- Updated AI mock to return proper embedding arrays

Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)