### PR TITLE
Improve Market Health Reporter Prompts

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -1,82 +1,128 @@
-There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny. 
-Here is some basic procedure of the market surveillance analysis:
+## Task
 
-1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio and time-of-trade. It is crucial to observe these metrics over time. 
-2. Identify anomalies using specific criteria, such as sudden spikes or significantly unusual trading volumes. The anomalous patterns and benchmarkes are provided below. Analyze metrics over time to identify trends and patterns. 
-3. Construct a coherent and convincing report, beginning with the metric that shows significant deviation and has a noticeable impact on other metrics. Ensure the report accurately captures market abnormalities that occurred concurrently. Include specific timestamps and quantitative values as evidence.
-4. If the data does not indicate any significant and clear anomalous patterns, avoid over-interpreting the datasets. If no signs of fraud or manipulation are evident, concisely report this absence and attach supporting evidence.
+Analyze the provided market surveillance data and produce a structured article documenting your findings. Follow the analysis procedure and output format below exactly.
 
-- Volume-Volatility Correlation.
-    Description: It is a statistical measure that identifies the relationship between trading volume and market volatility in cryptocurrency exchanges. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `vvcorrelation`.
-    Anomalous Pattern: A consistently low correlation (significantly below 0.4) between volume and volatility over extended periods. This might suggest artificial trading volume, as real market trades typically correlate with price volatility.
-    Benchmark: A normal range might vary, but a correlation coefficient consistently below 0.4 can be considered suspicious.
+---
 
-- First-Digit Distribution. 
-    Description: In the context of cryptocurrency trading, adherence of the first-digit distribution to Benford’s Law can be used to scrutinize trading data for inconsistencies or abnormalities. Non-conformity to the expected digit distribution could suggest manipulation, such as wash trading or massive sell-offs, warranting further investigation. 
-    Name of the metric: This value is stored in the key `firstdigitdist`.
-    Anomalous Pattern: Significant deviation from Benford's expected distribution in leading digits of trading data. For instance, if numbers begin disproportionately with higher digits (like 8 or 9) instead of lower digits (like 1, 2, or 3).
-    Benchmark: Normally, the empirical first-digit distribution converges with the Benford's Law.      
+## Analysis Procedure
 
-- Kolmogorov-Smirnov (K-S) Test for the First-Digit Distribution.
-    Description: The Kolmogorov-Smirnov test is used to compare a sample with Benford's law. 
-    Name of the metrics: This value is stored in the key `benfordlawtest`.
-    Anomalous Pattern: A larger test value suggests a greater discrepancy between your dataset's distribution and Benford's Law.
-    Benchmark: The K-S test is sensitive to sample size. Sample size is stored in the key `tradecount`. It's necessary for the critical and the test values comparison.   
-    If test value > critical value, then you reject the null hypothesis. This suggests that your data does not conform to Benford's Law at the chosen significance level.
-    If test value ≤ critical value, then you do not reject the null hypothesis. This suggests that there is not enough evidence to conclude that your data deviates from Benford's Law at the chosen significance level.
-    The critical value is a ratio of 1.36 and a square root of `tradecount`. 
-    
-- Volume distribution. 
-    Description: Volume distribution is a graphical representation that shows how frequently different sizes of transactions occur within a time range. 
-    Name of the metric: This value is stored in the key `volumedist`.
-    Anomalous Pattern: A distribution that significantly deviates from the power law, such as an unusually high number of large (whale) trades or a lack of small/medium trades requires closer inspection.
-    Benchmark: The volume distribution is expected to follow the power law. The power law describes a phenomenon where a small number of items are concentrated at the top of a distribution. In simpler terms, this suggests that medium to small retail transactions are frequent, while large “whale” orders are rare.
-    The histogram of a power law distribution is not symmetric. It typically shows a steep drop-off at the beginning (for smaller values) and then a long tail that gradually descends but never really touches the x-axis.
+### Step 1: Evaluate Each Metric
 
-- Time-of-trade.
-    Description: This metric is designed to analyze trading activity distribution within each minute of an hour/each second of a minute, irrespective of the day/hour/minute in which the trades occur. By focusing solely on the minute/second of trade execution (ranging from 0 to 59), it provides a unique perspective on trading patterns and frequencies that occur at specific minute/second intervals. This approach aggregates transaction data from various time periods into a consolidated array of 60 items, each representing a distinct minute/second within an hour.
-    Name of the metrics: This value is stored in the key `timeoftrade`.
-    Anomalous Pattern: The Time-of-Trade metric detects a two-sided pattern. This means it flags both a high frequency of trades executed at the same time (second or minute) and an almost even distribution of trade counts across seconds or minutes. Such patterns suggest the presence of bot activity or automated trading systems.
-    Benchmark: No specific benchmark exists for this metric. However, trading patterns that significantly deviate from typical human trading behaviors, such as consistent trade spikes every minute or second, or evenly distributed trading activity across seconds or minutes, are considered suspect.
-    
-- Buy/sell ratio.
-    Description: The proportion of buy to sell market orders in a given time period. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `buysellratio` and `buysellratioabs`. 
-    Anomalous Pattern: Ratios that significantly deviate from the norm (0.4-0.6 range) or display unnatural steadiness during the periods of high volatility.
-    Benchmark: A balanced market should have a buy/sell ratio around 0.4-0.6. A buy/sell ratio significantly higher than 0.5 suggests a market bias towards buying. Such a scenario could lead to a price increase. A buy/sell ratio significantly lower than 0.5 indicates a market bias towards selling, possibly leading to a price decrease. 
-    
- 
-    Depending on the market context, both irregular and steady fluctuations in this ratio can be indicative of automated trading systems operating to influence the market. 
+For each metric below, extract the relevant values from the data, assess whether they fall within normal benchmarks, and note any anomalies with specific timestamps and values.
 
-- Volume Weighted Average Price (VWAP).
-    Description: A trading benchmark that calculates the average price of a cryptocurrency, weighted by its volume traded over a specific time period - more weight is given to the price levels where a lot of trading activity has occurred.
-    Name of the metric: This value is stored in the key `vwap`.
-    Anomalous Pattern: A significant and consistent difference between the VWAP and the actual trading price, particularly if the trading price is much higher or lower than the VWAP.
-    Benchmark: While there's no specific numerical benchmark, a deviation that's outside normal trading fluctuations could be a red flag.
+#### 1. Volume-Volatility Correlation (`vvcorrelation`)
+- **What it measures:** Statistical relationship between trading volume and price volatility.
+- **Normal benchmark:** Correlation coefficient ≥ 0.4.
+- **Anomaly signal:** Correlation consistently below 0.4 over extended periods suggests artificial volume (real trades typically move prices).
 
-To enhance the analysis, here are some tips regarding simultaneous anomalous deviations of these metrics which can be indicative of market anomalies:
+#### 2. First-Digit Distribution (`firstdigitdist`)
+- **What it measures:** Whether leading digits of trading data conform to Benford's Law.
+- **Normal benchmark:** Empirical distribution converges with Benford's Law (digit 1 appears ~30.1%, digit 2 ~17.6%, etc.).
+- **Anomaly signal:** Disproportionately high frequency of leading digits 8 or 9, or suppressed frequency of digits 1–3.
 
-Volume Distribution and Volume-Volatility Correlation: A volume distribution that deviates from the power law, especially with an unusual number of large trades, coupled with a low volume-volatility correlation, can suggest market manipulation. Large trades should typically introduce volatility, and a lack of this correlation might indicate that these large trades are not impacting the market as expected.
-Concurrent Irregularities in First-Digit Distribution and K-S Test: Significant deviations from Benford's Law in First-Digit Distribution, coupled with a K-S Test value greater than the critical value, strongly indicate data manipulation. This could be a sign of practices like wash trading, where large volumes of trades are artificially created to mislead the market.
-Inconsistencies in VWAP and Buy/Sell Ratio: A substantial difference between VWAP and market prices, along with abnormal Buy/Sell Ratios, could signify price manipulation. Traders might be attempting to influence the perceived average price through strategic buying or selling.
-Correlation between Time-of-Trade and Buy/Sell Ratio Anomalies: If the Time-of-Trade metric shows high frequency or evenly distributed trades, and the Buy/Sell Ratio deviates significantly from the 0.4-0.6 range, this might suggest automated trading systems are in play. This could be an attempt to influence market prices or create false market sentiment.
+#### 3. Kolmogorov-Smirnov Test (`benfordlawtest`)
+- **What it measures:** Statistical test comparing the sample distribution against Benford's Law.
+- **How to interpret:**
+  - Compute critical value = 1.36 / √(`tradecount`)
+  - If test value > critical value → reject null hypothesis → data does NOT conform to Benford's Law (anomalous).
+  - If test value ≤ critical value → insufficient evidence of deviation (normal).
+- **Important:** This test is sensitive to sample size. Always report the `tradecount` alongside the test result.
 
-Create an article with the results of your analysis. The article should include:
-- Fields between --- and ---:
-    - 'date'
-        The content of this field must match the format YYYY-MM-DD — YYYY-MM-DD, where the first date is the start of the analysis period, and the second date is the end of the analysis period.
-        Example: '2023-10-02 — 2023-10-08'
-    - 'entities'
-        The content of this field should include entities implicated in wash trading. Example: 'Huobi, HT, TRX, DOGE'
-    - 'title'
-        The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
+#### 4. Volume Distribution (`volumedist`)
+- **What it measures:** Frequency distribution of transaction sizes.
+- **Normal benchmark:** Follows a power law — many small trades, few large trades. The histogram shows a steep initial drop-off with a long right tail.
+- **Anomaly signal:** Unusually high count of large (whale) trades, absence of small/medium trades, or symmetric distribution.
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
-Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
-Place the article into the <article> </article> tags.
+#### 5. Time-of-Trade (`timeoftrade`)
+- **What it measures:** Distribution of trades across seconds (0–59) within each minute, aggregated across all time periods.
+- **Anomaly signal (two-sided):**
+  - Spikes: High concentration of trades at specific seconds → bot activity.
+  - Flatness: Nearly uniform distribution across all seconds → automated system.
+- **Normal benchmark:** No fixed benchmark, but natural human trading shows irregular clustering patterns, not uniform or spike-heavy.
+
+#### 6. Buy/Sell Ratio (`buysellratio`, `buysellratioabs`)
+- **What it measures:** Proportion of buy vs. sell market orders over time.
+- **Normal benchmark:** 0.4–0.6 range with natural volatility.
+- **Anomaly signals:**
+  - Ratio consistently outside 0.4–0.6 → directional bias.
+  - Unnaturally stable ratio during high volatility → automated market-making or manipulation.
+
+#### 7. Volume Weighted Average Price (`vwap`)
+- **What it measures:** Average price weighted by volume — highlights price levels with concentrated trading.
+- **Anomaly signal:** Persistent, significant divergence between VWAP and actual trading price.
+
+### Step 2: Cross-Reference Anomalies
+
+After evaluating individual metrics, check for these high-confidence manipulation patterns:
+
+| Combined Signals | Interpretation |
+|---|---|
+| Non-power-law volume distribution + low volume-volatility correlation | Large trades not impacting price → likely artificial volume |
+| Benford's Law deviation (first-digit + K-S test) | Data fabrication, possible wash trading |
+| VWAP divergence + abnormal buy/sell ratio | Strategic price manipulation through coordinated buying/selling |
+| Uniform/spiked time-of-trade + abnormal buy/sell ratio | Automated trading systems influencing market sentiment |
+
+### Step 3: Construct the Report
+
+- **Lead with the strongest anomaly** — the metric showing the most significant deviation.
+- **Group concurrent anomalies** that share overlapping timestamps.
+- **Cite specific values:** Include exact metric values, timestamps, and computed thresholds.
+- **If no clear anomalies exist:** State this directly with supporting evidence. Do not force a manipulation narrative.
+
+---
+
+## Output Format
+
+Produce a markdown article wrapped in `<article>` tags with the following structure:
+
+```
+<article>
+---
+title: "[Descriptive title about findings]"
+date: 'YYYY-MM-DD — YYYY-MM-DD'
+entities:
+  - [Exchange name]
+  - [Token symbols implicated, if any]
+---
+
+## Summary
+
+[Numbered list of 3–6 key findings. Each finding should be one sentence with bold emphasis on the critical insight. Be specific — include metric names and values.]
+
+## [Metric Section Title]
+
+[Analysis of the most significant anomaly. Include:]
+- What the metric measures (one sentence)
+- What the data shows (with specific values and timestamps)
+- Why this is anomalous (comparison to benchmark)
+- What it implies about market health
+
+{{< figure src="[filename].png" alt="[descriptive alt text]" caption="[Caption describing the visualization]" loading="lazy" >}}
+
+## [Additional Metric Sections as needed]
+
+[Continue with other anomalous metrics, ordered by significance.]
+
+## [Cross-Metric Analysis Section, if applicable]
+
+[Describe how multiple anomalies corroborate each other.]
+
+</article>
+```
+
+### Formatting Rules
+
+- **Frontmatter fields:**
+  - `date`: Must be `'YYYY-MM-DD — YYYY-MM-DD'` format (analysis period start — end).
+  - `entities`: List the exchange and any specific tokens implicated.
+  - `title`: Descriptive, specific to the findings.
+- **Allowed illustration filenames:** `volume_hist.png`, `crypto_metrics.png`, `benford_law.png`, `vv_correlation.png`
+- **Style:** Professional, data-driven. Minimize speculation. Every claim must reference specific data points from the provided dataset.
+- **Length:** Proportional to findings. Short if data is clean; detailed if anomalies are present.
+
+---
+
+## Reference Example
+
+Study the article in the `<example>` tags below for tone, structure, and depth. Match its professional quality and data-driven approach.
+

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,1 +1,9 @@
-You are a cryptocurrency market analyst with a focus on the market manipulations and anomalous trade activity detection. Conduct a thorough analysis of the data, using the instructions provided to you.
+You are a senior cryptocurrency market surveillance analyst specializing in detecting wash trading, spoofing, and other forms of market manipulation on digital asset exchanges.
+
+Your role:
+- Analyze quantitative trading metrics to identify anomalous patterns indicative of market manipulation.
+- Produce professional, data-driven reports suitable for publication on a market health research platform.
+- Base all conclusions strictly on the provided data. Do not speculate or fabricate findings.
+- When the data does not support manipulation claims, clearly state the absence of anomalies.
+
+Your tone is authoritative, precise, and objective — similar to a financial compliance report. Avoid hedging language unless genuinely uncertain. Use specific numbers, timestamps, and metric values as evidence.


### PR DESCRIPTION
## Summary

Refactors the LLM prompts used by the Market Health Reporter tool to produce higher-quality, more structured analysis articles that better match the [contribution guidelines](https://github.com/1712n/dn-institute/issues/277) and the [example article](https://github.com/1712n/dn-institute/tree/main/content/research/market-health/posts/2023-08-14-huobi).

Closes #427

## Changes

### System Prompt (`system_prompt.txt`)
**Before:** A single vague sentence ("You are a cryptocurrency market analyst...").
**After:** Detailed role definition with:
- Specific expertise areas (wash trading, spoofing, market manipulation)
- Tone guidance (authoritative, precise, objective)
- Anti-speculation guardrails (base conclusions strictly on data)
- Instruction to clearly state absence of anomalies when data is clean

**Why:** The original system prompt gave the model almost no constraints on tone, depth, or approach. This led to inconsistent output quality. The improved version anchors the model in a specific professional persona.

### Main Prompt (`prompt1.txt`)
**Before:** A wall of text mixing metric definitions, analysis instructions, and output format with no clear structure.
**After:** Three clearly separated sections:

1. **Analysis Procedure** — Each metric gets a structured block with:
   - What it measures (one line)
   - Normal benchmark (specific threshold)
   - Anomaly signal (what deviation looks like)
   
2. **Cross-Reference Table** — A markdown table mapping combined metric anomalies to manipulation interpretations (e.g., "non-power-law volume + low VV correlation → artificial volume")

3. **Output Format** — Explicit article template with:
   - Frontmatter field specifications
   - Section structure matching the example article (Summary with numbered findings, metric sections, cross-metric analysis)
   - Formatting rules (allowed image filenames, style guidance)

**Why each change matters:**
- **Structured metric blocks** → Model can systematically evaluate each metric instead of parsing a paragraph. Reduces missed metrics.
- **Explicit benchmarks** → Less hallucinated thresholds. Original had benchmarks buried in prose; now each is a clear bullet point.
- **Cross-reference table** → The original listed correlations in paragraph form. A table is faster for the model to reference and produces more consistent cross-metric analysis.
- **Output template** → The original only specified frontmatter fields but not article body structure. The example article uses Summary + Metric Sections + Cross-Analysis, but the prompt never told the model to follow that structure. Now it does.
- **"Lead with strongest anomaly"** instruction → Produces more impactful reports instead of mechanical metric-by-metric dumps.
- **"If no anomalies, say so"** reinforcement → Reduces false positive manipulation claims.
- **Fixed typo** (`benchmarkes` → `benchmarks`)

## Methodology

1. Compared the example Huobi article structure against what the original prompt requested — found the prompt under-specified the article body format
2. Identified that metric definitions were correct but poorly organized for LLM consumption
3. Restructured without changing any metric logic, thresholds, or interpretation guidelines
4. Preserved all original metric names, key names, and benchmark values