### PR TITLE
🌰 feat: Add RAG retrieval for Market Health Reporter 🌰

### DIFF
--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -8,13 +8,14 @@ import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.rag_retriever import retrieve_context
 
 
 REPO_NAME = "1712n/dn-institute"
 SYSTEM_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/system_prompt.txt'
 HUMAN_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/prompt1.txt'
-ARTICLE_EXAMPLE_FILE = 'content/market-health/posts/2023-08-14-huobi/index.md'
-OUTPUT_DIR = 'content/market-health/posts/'
+ARTICLE_EXAMPLE_FILE = 'content/research/market-health/posts/2023-08-14-huobi/index.md'
+OUTPUT_DIR = 'content/research/market-health/posts/'
 DATA_DIR = 'tools/market_health_reporter/doc/data/'
 MAX_TOKENS = 125000
 
@@ -48,7 +49,7 @@ def extract_data_from_comment(comment: str) -> tuple:
     """
     parts = comment.split(',')
     marketvenueid = parts[1].strip().lower()
-    pairid = parts[0].split(':')[1].strip().lower()  
+    pairid = parts[0].split(':')[1].strip().lower()
     start, end = parts[2].strip(), parts[3].strip()
     return marketvenueid, pairid, start, end
 
@@ -57,13 +58,13 @@ def save_output(output: str, directory: str, marketvenueid: str, pairid: str, st
     """
     Saves the output to a markdown file in the specified directory, creating a subdirectory for it.
     """
-    output_subdir = os.path.join(directory, f"{start}-{end}-{marketvenueid}-{pairid}")  
-    os.makedirs(output_subdir, exist_ok=True)  
+    output_subdir = os.path.join(directory, f"{start}-{end}-{marketvenueid}-{pairid}")
+    os.makedirs(output_subdir, exist_ok=True)
     safe_start = start.replace(":", "-")
     safe_end = end.replace(":", "-")
     base_file_name = "index"
-    file_path = os.path.join(output_subdir, base_file_name)  
-    
+    file_path = os.path.join(output_subdir, base_file_name)
+
     existing_files = glob.glob(f"{file_path}*.md")
     if existing_files:
         numbers = [int(file_name.split('-')[-1].split('.md')[0]) for file_name in existing_files if file_name.split('-')[-1].split('.md')[0].isdigit()]
@@ -71,7 +72,7 @@ def save_output(output: str, directory: str, marketvenueid: str, pairid: str, st
         full_path = f"{file_path}-{file_number}.md"
     else:
         full_path = f"{file_path}.md"
-    
+
     with open(full_path, 'w', encoding='utf-8') as file:
         file.write(output)
     print(f"Output saved to: {full_path}")
@@ -126,11 +127,17 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, rag_context: str = "") -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, data, and optional RAG context.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    prompt = f"<example> {article_example} </example>\n{human_prompt_content}\n"
+    if rag_context:
+        prompt += f"<context>\nThe following external context may help you write a more informed article. "
+        prompt += f"Use relevant facts, regulatory actions, and background information where applicable.\n\n"
+        prompt += f"{rag_context}\n</context>\n"
+    prompt += f"<data> {json.dumps(data)} </data>"
+    return prompt
 
 
 def main():
@@ -142,6 +149,15 @@ def main():
 
     marketvenueid, pairid, start, end = extract_data_from_comment(args.comment_body)
     print(f"Marketvenueid: {marketvenueid}, Pairid: {pairid}, Start: {start}, End: {end}")
+
+    # 🌰 RAG: Retrieve external context for the exchange
+    print(f"🌰 Retrieving RAG context for {marketvenueid}...")
+    rag_context = retrieve_context(marketvenueid, pairid)
+    if rag_context:
+        print(f"🌰 Retrieved {len(rag_context)} chars of RAG context")
+    else:
+        print("🌰 No additional RAG context found")
+
     querystring = {
         "marketvenueid": marketvenueid,
         "pairid": pairid,
@@ -157,10 +173,10 @@ def main():
     try:
         data = fetch_or_load_market_data(querystring, headers, url, DATA_DIR, marketvenueid, pairid, start, end)
 
-        encoding = encoding_for_model("gpt-4")     
+        encoding = encoding_for_model("gpt-4")
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        prompt = create_prompt(article_example, data, human_prompt_content, rag_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:
@@ -183,8 +199,8 @@ def main():
             print("This is an answer: ", output)
             save_output(output, OUTPUT_DIR, marketvenueid, pairid, start, end)
             vis = Visualization()
-            output_subdir = os.path.join(OUTPUT_DIR, f"{start}-{end}-{marketvenueid}-{pairid}") 
-            vis.generate_report(data, output_subdir)  
+            output_subdir = os.path.join(OUTPUT_DIR, f"{start}-{end}-{marketvenueid}-{pairid}")
+            vis.generate_report(data, output_subdir)
 
             post_comment_to_issue(args.github_token, int(args.issue), REPO_NAME, output)
 

--- a/tools/market_health_reporter/rag_retriever.py
+++ b/tools/market_health_reporter/rag_retriever.py
@@ -1,0 +1,105 @@
+"""
+🌰 RAG Retriever for Market Health Reporter 🌰
+
+Retrieves relevant external context (wiki articles, news, regulatory info)
+to enrich the Market Health Reporter's article generation prompt.
+"""
+
+import os
+import glob
+import re
+from duckduckgo_search import DDGS
+from tools.python_modules.utils import read_file
+
+
+# 🌰 Paths to existing wiki content for local RAG retrieval
+WIKI_MARKET_HEALTH_DIR = "content/research/market-health/posts/"
+WIKI_ATTACKS_DIR = "content/attacks/posts/"
+
+# 🌰 Maximum context tokens to inject
+MAX_RAG_CONTEXT_CHARS = 8000
+
+
+def retrieve_wiki_context(exchange_name: str) -> str:
+    """
+    🌰 Retrieve relevant context from existing wiki articles in the repository.
+    Searches both market-health and attacks directories for articles mentioning
+    the target exchange.
+    """
+    relevant_chunks = []
+
+    for wiki_dir in [WIKI_MARKET_HEALTH_DIR, WIKI_ATTACKS_DIR]:
+        if not os.path.isdir(wiki_dir):
+            continue
+        for md_path in glob.glob(os.path.join(wiki_dir, "**", "*.md"), recursive=True):
+            try:
+                content = read_file(md_path)
+            except Exception:
+                continue
+            if exchange_name.lower() in content.lower():
+                # Extract summary section if present
+                summary = _extract_section(content, "Summary")
+                if summary:
+                    relevant_chunks.append(
+                        f"[Wiki: {os.path.basename(os.path.dirname(md_path))}]\n{summary}"
+                    )
+                elif len(content) < 2000:
+                    relevant_chunks.append(
+                        f"[Wiki: {os.path.basename(os.path.dirname(md_path))}]\n{content[:1500]}"
+                    )
+
+    return "\n\n".join(relevant_chunks)
+
+
+def retrieve_web_context(exchange_name: str, pair: str) -> str:
+    """
+    🌰 Search the web for relevant news, regulatory actions, and analysis
+    about the target exchange and trading pair using DuckDuckGo.
+    """
+    queries = [
+        f"{exchange_name} wash trading manipulation",
+        f"{exchange_name} {pair} regulatory action SEC CFTC",
+        f"{exchange_name} trading volume suspicious",
+    ]
+
+    results_text = []
+    with DDGS() as ddgs:
+        for query in queries:
+            try:
+                results = list(ddgs.text(query, max_results=3))
+                for r in results:
+                    snippet = f"[{r.get('title', '')}] {r.get('body', '')}"
+                    if snippet not in results_text:
+                        results_text.append(snippet)
+            except Exception:
+                continue
+
+    return "\n\n".join(results_text)
+
+
+def retrieve_context(exchange_name: str, pair: str) -> str:
+    """
+    🌰 Main RAG retrieval function. Combines wiki and web context,
+    truncated to fit within token budget.
+    """
+    wiki_ctx = retrieve_wiki_context(exchange_name)
+    web_ctx = retrieve_web_context(exchange_name, pair)
+
+    combined = ""
+    if wiki_ctx:
+        combined += f"## Existing Wiki Context 🌰\n{wiki_ctx}\n\n"
+    if web_ctx:
+        combined += f"## External Sources 🌰\n{web_ctx}\n\n"
+
+    # Truncate to budget
+    if len(combined) > MAX_RAG_CONTEXT_CHARS:
+        combined = combined[:MAX_RAG_CONTEXT_CHARS] + "\n[...truncated]"
+
+    return combined
+
+
+def _extract_section(content: str, section_name: str) -> str:
+    """Extract content under a markdown heading."""
+    pattern = rf"##\s+{re.escape(section_name)}\s*\n(.*?)(?=\n##\s|\Z)"
+    match = re.search(pattern, content, re.DOTALL)
+    return match.group(1).strip() if match else ""


### PR DESCRIPTION
## 🌰 RAG Implementation for Market Health Reporter 🌰

### Overview
This PR adds Retrieval Augmented Generation (RAG) functionality to the Market Health Reporter, addressing **Issue #428**.

The RAG module enriches the article generation prompt with relevant external context, improving article quality and alignment with [contribution guidelines](https://github.com/1712n/dn-institute/issues/277).

### What Changed

**New file: `tools/market_health_reporter/rag_retriever.py`** 🌰
- `retrieve_wiki_context(exchange_name)` — Searches existing wiki articles (market-health + attacks) for content mentioning the target exchange. Extracts Summary sections for concise context injection.
- `retrieve_web_context(exchange_name, pair)` — Uses DuckDuckGo search (already a project dependency) to find relevant news, regulatory actions, and analysis about the exchange.
- `retrieve_context(exchange_name, pair)` — Main entry point combining wiki + web context, truncated to 8000 chars to respect token budget.

**Modified: `tools/market_health_reporter/market_health_reporter.py`** 🌰
- Imports `retrieve_context` from the new RAG module
- Calls RAG retrieval before prompt construction, using the exchange name and pair extracted from the comment
- Injects retrieved context into the prompt via `<context>` tags between the human prompt instructions and the market data
- Modified `create_prompt()` to accept optional `rag_context` parameter

### How It Works 🌰

```
Comment: "analyze: btc-usdt, huobi, 2023-07-01, 2023-07-31"
                    │
                    ▼
        ┌─── Extract exchange="huobi", pair="btc-usdt" ───┐
        │                                                   │
        ▼                                                   ▼
  Wiki RAG: scan existing                          Web RAG: DuckDuckGo
  articles for "huobi"                             search for news &
  mentions, extract summaries                      regulatory context
        │                                                   │
        └──────────── Combine & truncate ───────────────────┘
                            │
                            ▼
              Inject into prompt as <context>
                            │
                            ▼
                  GPT-4 generates article
                  with richer background
```

### Design Decisions 🌰

1. **Zero new dependencies** — Uses `duckduckgo-search` already in `pyproject.toml`
2. **Graceful degradation** — If RAG retrieval fails (no wiki articles, search errors), the reporter continues normally without context
3. **Token budget aware** — RAG context capped at 8000 chars to avoid exceeding the 125K token limit
4. **Two-source retrieval** — Wiki articles provide internal consistency; web search provides external regulatory/news context

### Methodology 🌰

The RAG approach follows a retrieve-then-generate pattern:
- **Local retrieval**: Existing wiki articles serve as a knowledge base, ensuring new articles maintain consistency with established content
- **Web retrieval**: DuckDuckGo searches target three query patterns per exchange: wash trading mentions, regulatory actions, and suspicious volume reports
- **Context injection**: Retrieved text is placed in `<context>` XML tags in the prompt, instructing the LLM to incorporate relevant facts where applicable

This improves article quality by providing the LLM with:
- Historical context about the exchange's regulatory history
- Cross-references to existing wiki analysis
- Real-world news that corroborates or contextualizes the metric data

🌰🌰🌰