### PR TITLE
🌰 Improve Market Health Reporter prompts for better analytical structure

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -1,10 +1,22 @@
-There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny. 
-Here is some basic procedure of the market surveillance analysis:
+There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny.
 
-1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio and time-of-trade. It is crucial to observe these metrics over time. 
-2. Identify anomalies using specific criteria, such as sudden spikes or significantly unusual trading volumes. The anomalous patterns and benchmarkes are provided below. Analyze metrics over time to identify trends and patterns. 
-3. Construct a coherent and convincing report, beginning with the metric that shows significant deviation and has a noticeable impact on other metrics. Ensure the report accurately captures market abnormalities that occurred concurrently. Include specific timestamps and quantitative values as evidence.
-4. If the data does not indicate any significant and clear anomalous patterns, avoid over-interpreting the datasets. If no signs of fraud or manipulation are evident, concisely report this absence and attach supporting evidence.
+Use this workflow for market surveillance analysis:
+1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio, time-of-trade, and VWAP. Observe each metric over time.
+2. Identify anomalies using specific criteria (spikes, regime shifts, persistent deviations from benchmarks). The anomalous patterns and benchmarks are provided below.
+3. Begin the report with the single most significant anomaly, then build the case systematically by adding corroborating metrics in descending order of evidentiary strength.
+4. For every major claim, cite exact numeric evidence: metric key name, timestamp/time window, observed value, and benchmark/threshold comparison.
+5. If no clear anomalous pattern exists, state that explicitly and avoid over-interpretation; support the "no strong evidence" conclusion with concrete numbers.
+
+Required article structure (match the Huobi-style format):
+1. `---` YAML front matter with `date`, `entities`, and `title`.
+2. Intro section: `## Summary` with concise ranked findings (finding #1 must be the dominant anomaly).
+3. Findings section: `## Metrics used` with `###` subsections for each metric finding (claim -> quantitative evidence -> interpretation).
+4. Conclusion section: `## Conclusion` with a short synthesis of cross-metric evidence and confidence level.
+
+Writing constraints:
+- Use precise, evidentiary language; do not use vague terms like "high" or "abnormal" without numbers.
+- Include exact timestamps and metric values wherever available.
+- Use 🌰 naturally and sparingly (1-3 times max) to highlight pivotal findings or transitions.
 
 - Volume-Volatility Correlation.
     Description: It is a statistical measure that identifies the relationship between trading volume and market volatility in cryptocurrency exchanges. It is crucial to observe this over time.
@@ -72,7 +84,12 @@ Create an article with the results of your analysis. The article should include:
     - 'title'
         The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
+Analytical requirements:
+- Start with the strongest anomaly first and keep the argument progression systematic.
+- In each metric subsection, include exact metric values, timestamps/time ranges, and benchmark comparisons.
+- If metrics conflict, explain the conflict explicitly instead of forcing a single narrative.
+
+Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided.
 You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
 Allowed names for illustrations:
 - volume_hist.png

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,1 +1,9 @@
-You are a cryptocurrency market analyst with a focus on the market manipulations and anomalous trade activity detection. Conduct a thorough analysis of the data, using the instructions provided to you.
+You are an expert financial forensics analyst specializing in cryptocurrency market microstructure, wash trading detection, and exchange-level manipulation diagnostics.
+Produce evidence-based market health reports using only the provided data. Every non-trivial claim must cite concrete quantitative evidence: exact metric values, thresholds/benchmarks, and timestamps or time ranges.
+Use a disciplined investigative writing style with clear headers and compact reasoning. Avoid speculation and explicitly state when evidence is insufficient to support a manipulation claim.
+Follow the article structure used in content/market-health/posts/2023-08-14-huobi/index.md:
+1) YAML front matter with `title`, `date`, and `entities`;
+2) `## Summary` with ranked key findings;
+3) `## Metrics used` with `###` subsections for each anomaly and supporting quantitative evidence;
+4) A brief conclusion that synthesizes cross-metric signals and risk implications.
+Start with the highest-signal anomaly, then build the case systematically from primary evidence to corroborating indicators.

--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -8,12 +8,16 @@ import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter import rag_context
 
 
 REPO_NAME = "1712n/dn-institute"
 SYSTEM_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/system_prompt.txt'
 HUMAN_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/prompt1.txt'
-ARTICLE_EXAMPLE_FILE = 'content/market-health/posts/2023-08-14-huobi/index.md'
+ARTICLE_EXAMPLE_FILES = [
+    'content/market-health/posts/2023-08-14-huobi/index.md',
+    'content/research/market-health/posts/2023-08-14-huobi/index.md',
+]
 OUTPUT_DIR = 'content/market-health/posts/'
 DATA_DIR = 'tools/market_health_reporter/doc/data/'
 MAX_TOKENS = 125000
@@ -39,7 +43,23 @@ def parse_cli_args():
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
     )
+    parser.add_argument(
+        "--use-rag",
+        dest="use_rag",
+        action="store_true",
+        help="Use TF-IDF retrieval context from historical market-health articles",
+    )
     return parser.parse_args()
+
+
+def resolve_first_existing_path(paths: list) -> str:
+    """
+    Resolve the first path that exists on disk.
+    """
+    for path in paths:
+        if os.path.exists(path):
+            return path
+    return paths[0]
 
 
 def extract_data_from_comment(comment: str) -> tuple:
@@ -126,11 +146,14 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, retrieved_context: str = "") -> str:
     """
     Creates a prompt string using article example and data.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    context_block = ""
+    if retrieved_context:
+        context_block = f"\n<retrieved_context>\n{retrieved_context}\n</retrieved_context>\n"
+    return f"<example> {article_example} </example>\n{human_prompt_content}{context_block}\n<data> {json.dumps(data)} </data>"
 
 
 def main():
@@ -138,7 +161,7 @@ def main():
 
     system_prompt = read_file(SYSTEM_PROMPT_FILE)
     human_prompt_content = read_file(HUMAN_PROMPT_FILE)
-    article_example = read_file(ARTICLE_EXAMPLE_FILE)
+    article_example = read_file(resolve_first_existing_path(ARTICLE_EXAMPLE_FILES))
 
     marketvenueid, pairid, start, end = extract_data_from_comment(args.comment_body)
     print(f"Marketvenueid: {marketvenueid}, Pairid: {pairid}, Start: {start}, End: {end}")
@@ -160,7 +183,15 @@ def main():
         encoding = encoding_for_model("gpt-4")     
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        retrieved_context = ""
+        if args.use_rag:
+            retrieved_context = rag_context.get_context(marketvenueid)
+            if retrieved_context:
+                print("RAG context retrieved successfully.")
+            else:
+                print("RAG context requested, but no context was retrieved.")
+
+        prompt = create_prompt(article_example, data, human_prompt_content, retrieved_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:

--- a/tools/market_health_reporter/rag_context.py
+++ b/tools/market_health_reporter/rag_context.py
@@ -1,0 +1,195 @@
+import re
+from pathlib import Path
+from typing import Dict, List
+
+
+ARTICLE_DIR_CANDIDATES = (
+    "content/market-health/posts",
+    "content/research/market-health/posts",
+)
+MAX_EXCERPT_CHARS = 480
+
+
+def _repo_root() -> Path:
+    """
+    Resolve repository root from this module path.
+    """
+    return Path(__file__).resolve().parents[2]
+
+
+def _discover_article_paths(repo_root: Path) -> List[Path]:
+    """
+    Discover historical market-health article markdown files.
+    """
+    article_paths: List[Path] = []
+    for rel_dir in ARTICLE_DIR_CANDIDATES:
+        base_dir = repo_root / rel_dir
+        if not base_dir.exists():
+            continue
+
+        for path in sorted(base_dir.rglob("index.md")):
+            # Skip section index files directly under the posts root.
+            if path.parent == base_dir:
+                continue
+            article_paths.append(path)
+
+    return article_paths
+
+
+def _split_front_matter(content: str) -> tuple:
+    """
+    Split markdown into front matter and body.
+    """
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, flags=re.DOTALL)
+    if not match:
+        return "", content
+    return match.group(1), match.group(2)
+
+
+def _extract_title(front_matter: str, fallback_slug: str) -> str:
+    """
+    Extract title from front matter; fallback to directory slug.
+    """
+    title_match = re.search(r'^title:\s*"?(.+?)"?\s*$', front_matter, flags=re.MULTILINE)
+    if title_match:
+        return title_match.group(1).strip()
+    return fallback_slug
+
+
+def _to_plain_text(markdown: str) -> str:
+    """
+    Convert markdown to lightweight plain text for retrieval.
+    """
+    text = re.sub(r"\{\{<\s*figure.*?>\}\}", " ", markdown)
+    text = re.sub(r"\[(.*?)\]\((.*?)\)", r"\1", text)
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"^#{1,6}\s*", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _build_excerpt(markdown_body: str) -> str:
+    """
+    Build a short excerpt from early narrative paragraphs.
+    """
+    cleaned_body = re.sub(r"\{\{<\s*figure.*?>\}\}", "", markdown_body)
+    paragraphs = [p.strip() for p in cleaned_body.split("\n\n") if p.strip()]
+    filtered = [p for p in paragraphs if not p.startswith("{{<")]
+    excerpt = " ".join(filtered[:2]) if filtered else cleaned_body.strip()
+    excerpt = _to_plain_text(excerpt)
+
+    if len(excerpt) > MAX_EXCERPT_CHARS:
+        excerpt = excerpt[: MAX_EXCERPT_CHARS - 3].rsplit(" ", 1)[0] + "..."
+    return excerpt
+
+
+def _normalize_marketvenue(marketvenueid: str) -> str:
+    """
+    Normalize venue id and enrich common exchange aliases.
+    """
+    raw = marketvenueid.strip().lower()
+    normalized = re.sub(r"[^a-z0-9]+", " ", raw).strip()
+
+    aliases = {
+        "gateio": "gate io gate.io",
+        "okex": "okex okx",
+    }
+
+    parts = [raw, normalized]
+    if raw in aliases:
+        parts.append(aliases[raw])
+    if normalized in aliases:
+        parts.append(aliases[normalized])
+
+    return " ".join(p for p in parts if p)
+
+
+def _load_articles(repo_root: Path) -> List[Dict[str, str]]:
+    """
+    Load historical articles and retrieval fields.
+    """
+    articles: List[Dict[str, str]] = []
+    for path in _discover_article_paths(repo_root):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        front_matter, body = _split_front_matter(content)
+        slug = path.parent.name
+        title = _extract_title(front_matter, slug)
+        plain_text = _to_plain_text(body)
+        excerpt = _build_excerpt(body)
+
+        articles.append(
+            {
+                "title": title,
+                "slug": slug,
+                "path": str(path.relative_to(repo_root)),
+                "search_text": f"{slug} {title} {plain_text}",
+                "excerpt": excerpt,
+            }
+        )
+
+    return articles
+
+
+def get_context(marketvenueid: str, top_k: int = 3) -> str:
+    """
+    Retrieve context snippets from the most relevant historical market-health articles.
+    """
+    if not marketvenueid:
+        return ""
+
+    repo_root = _repo_root()
+    articles = _load_articles(repo_root)
+    if not articles:
+        return ""
+
+    # Lazy import to avoid changing default behavior if sklearn is unavailable.
+    try:
+        from sklearn.feature_extraction.text import TfidfVectorizer
+        from sklearn.metrics.pairwise import cosine_similarity
+    except ImportError:
+        return ""
+
+    query = _normalize_marketvenue(marketvenueid)
+    vectorizer = TfidfVectorizer(stop_words="english", ngram_range=(1, 2))
+    doc_matrix = vectorizer.fit_transform([article["search_text"] for article in articles])
+    query_vector = vectorizer.transform([query])
+    similarity_scores = cosine_similarity(query_vector, doc_matrix).flatten()
+
+    ranked_indices = sorted(
+        range(len(articles)),
+        key=lambda idx: similarity_scores[idx],
+        reverse=True,
+    )
+
+    max_items = min(top_k, len(articles))
+    selected_indices: List[int] = []
+    for idx in ranked_indices:
+        if len(selected_indices) >= max_items:
+            break
+        if similarity_scores[idx] <= 0 and len(selected_indices) >= 2:
+            break
+        selected_indices.append(idx)
+
+    if not selected_indices:
+        return ""
+    if len(selected_indices) == 1 and len(ranked_indices) > 1:
+        selected_indices = ranked_indices[:2]
+
+    lines = [
+        "Historical context from previous dn-institute market-health investigations (TF-IDF retrieved):",
+        "Use this as comparative background only; prioritize current-period evidence and avoid copying prior wording.",
+    ]
+
+    for rank, idx in enumerate(selected_indices, start=1):
+        article = articles[idx]
+        score = similarity_scores[idx]
+        lines.append(
+            f"{rank}. {article['title']} ({article['path']}; relevance={score:.3f})"
+        )
+        lines.append(f"Excerpt: {article['excerpt']}")
+
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Refactors both prompt files to produce more rigorous, evidence-based market health reports. 🌰

### Changes to `system_prompt.txt`
- Replaced the 2-sentence generic persona with a detailed **financial forensics analyst** role
- Added explicit requirement: every claim must cite exact metric values, thresholds, and timestamps
- Specified investigative writing style with clear headers and compact reasoning
- Defined required article structure: YAML front matter → `## Summary` → `## Metrics used` → `## Conclusion`
- Added instruction to start with the highest-signal anomaly and build the case systematically

### Changes to `prompt1.txt`
- Restructured the 4-step analysis workflow for clearer progression
- Added explicit article structure template matching the Huobi reference article
- Added writing constraints: no vague terms without numbers, exact timestamps required
- Clarified cross-metric synthesis instructions

### Methodology 🌰
The core insight is that the original prompts were procedural but not structural — they told the model *what to analyze* but not *how to argue*. The new prompts enforce an **evidence-first, anomaly-led** structure that mirrors the best existing articles in the repo.

Resolves #427