### PR TITLE
🌰 test: add comprehensive integration tests for Similarity Search API (#430)

### DIFF
--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,298 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
-describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
-    const response = await SELF.fetch("https://example.com/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
-    })
+// 🌰 Shared helpers
+const VALID_HEADERS = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key"
+}
 
-    expect(response.status).toBe(401)
-    expect(await response.text()).toBe("Unauthorized")
+const NO_AUTH_HEADERS = {
+  "Content-Type": "application/json"
+}
+
+function postRequest(
+  body: unknown,
+  headers: Record<string, string> = VALID_HEADERS,
+  path = "/"
+) {
+  return SELF.fetch(`https://example.com${path}`, {
+    method: "POST",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body)
+  })
+}
+
+// 🌰 Authentication middleware tests
+describe("🌰 Authentication", () => {
+  it("returns 401 when X-API-Key header is missing", async () => {
+    const res = await postRequest(
+      { text: "hello", namespace: "test" },
+      NO_AUTH_HEADERS
+    )
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 when X-API-Key is incorrect", async () => {
+    const res = await postRequest(
+      { text: "hello", namespace: "test" },
+      { "Content-Type": "application/json", "X-API-Key": "wrong-key" }
+    )
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 when X-API-Key is empty string", async () => {
+    const res = await postRequest(
+      { text: "hello", namespace: "test" },
+      { "Content-Type": "application/json", "X-API-Key": "" }
+    )
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+  })
+
+  it("blocks unauthenticated requests regardless of path", async () => {
+    const res = await SELF.fetch("https://example.com/nonexistent", {
+      method: "POST",
+      headers: NO_AUTH_HEADERS,
+      body: JSON.stringify({ text: "hello", namespace: "test" })
+    })
+    expect(res.status).toBe(401)
+  })
+})
+
+// 🌰 POST / — happy path
+describe("🌰 POST / — happy path", () => {
+  it("returns similarity score for valid input", async () => {
+    const res = await postRequest({ text: "sample text", namespace: "test-ns" })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(json).toHaveProperty("similarity_score")
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("returns the mocked similarity score (0.5678)", async () => {
+    const res = await postRequest({ text: "test", namespace: "ns" })
+    const json = (await res.json()) as { similarity_score: number }
+    expect(json.similarity_score).toBeCloseTo(0.5678, 4)
+  })
+
+  it("responds with application/json content type", async () => {
+    const res = await postRequest({ text: "test", namespace: "ns" })
+    expect(res.headers.get("content-type")).toContain("application/json")
+  })
+
+  it("returns only similarity_score in response body", async () => {
+    const res = await postRequest({ text: "test", namespace: "ns" })
+    const json = (await res.json()) as Record<string, unknown>
+    expect(Object.keys(json)).toEqual(["similarity_score"])
+  })
+})
+
+// 🌰 POST / — input validation
+describe("🌰 POST / — input validation", () => {
+  it("returns 400 when text is a number", async () => {
+    const res = await postRequest({ text: 123, namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is a number", async () => {
+    const res = await postRequest({ text: "hello", namespace: 456 })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when text is null", async () => {
+    const res = await postRequest({ text: null, namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is null", async () => {
+    const res = await postRequest({ text: "hello", namespace: null })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when text field is missing", async () => {
+    const res = await postRequest({ namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace field is missing", async () => {
+    const res = await postRequest({ text: "hello" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when text is boolean", async () => {
+    const res = await postRequest({ text: true, namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when text is an array", async () => {
+    const res = await postRequest({ text: ["a", "b"], namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 500 when body is malformed JSON (unhandled parse error)", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: "not-json{{"
+    })
+    expect(res.status).toBe(500)
+  })
+
+  it("returns 500 when body is empty (unhandled parse error)", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: ""
+    })
+    expect(res.status).toBe(500)
+  })
+})
+
+// 🌰 POST / — edge cases
+describe("🌰 POST / — edge cases", () => {
+  it("handles empty string text and namespace", async () => {
+    const res = await postRequest({ text: "", namespace: "" })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("handles very long text input (10k characters)", async () => {
+    const longText = "a".repeat(10_000)
+    const res = await postRequest({ text: longText, namespace: "ns" })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("handles unicode text", async () => {
+    const res = await postRequest({
+      text: "你好世界 🌰 مرحبا العالم こんにちは",
+      namespace: "unicode-ns"
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("handles special characters and XSS payloads safely", async () => {
+    const res = await postRequest({
+      text: '<script>alert("xss")</script>',
+      namespace: "security"
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("handles unicode namespace", async () => {
+    const res = await postRequest({
+      text: "test",
+      namespace: "名前空間-🌰"
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("ignores extra fields in request body", async () => {
+    const res = await postRequest({
+      text: "test",
+      namespace: "ns",
+      extra: "should-be-ignored",
+      another: 42
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(json).toHaveProperty("similarity_score")
+  })
+
+  it("returns score 0 when no vectorize matches found", async () => {
+    const res = await postRequest({ text: "no match", namespace: "empty-ns" })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { similarity_score: number }
+    expect(json.similarity_score).toBe(0)
+  })
+
+  it("similarity score is within valid range [0, 1]", async () => {
+    const res = await postRequest({ text: "test", namespace: "ns" })
+    const json = (await res.json()) as { similarity_score: number }
+    expect(json.similarity_score).toBeGreaterThanOrEqual(0)
+    expect(json.similarity_score).toBeLessThanOrEqual(1)
+  })
+})
+
+// 🌰 HTTP method handling
+describe("🌰 HTTP method handling", () => {
+  it("returns 404 for GET request", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "GET",
+      headers: VALID_HEADERS
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 404 for PUT request", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "PUT",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "test", namespace: "ns" })
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 404 for DELETE request", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "DELETE",
+      headers: VALID_HEADERS
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 404 for undefined routes", async () => {
+    const res = await postRequest(
+      { text: "test", namespace: "ns" },
+      VALID_HEADERS,
+      "/nonexistent"
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+// 🌰 Response structure validation
+describe("🌰 Response structure", () => {
+  it("successful response is valid JSON", async () => {
+    const res = await postRequest({ text: "test", namespace: "ns" })
+    const text = await res.text()
+    expect(() => JSON.parse(text)).not.toThrow()
+  })
+
+  it("error responses are plain text, not JSON", async () => {
+    const res = await postRequest({ text: 123, namespace: "ns" })
+    expect(res.status).toBe(400)
+    const text = await res.text()
+    expect(text).toBe("Invalid JSON format")
+    expect(res.headers.get("content-type")).toContain("text/plain")
+  })
+
+  it("401 response body is plain text", async () => {
+    const res = await postRequest(
+      { text: "test", namespace: "ns" },
+      NO_AUTH_HEADERS
+    )
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+    expect(res.headers.get("content-type")).toContain("text/plain")
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,10 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    const vectors = data.text.map(() =>
+                      Array.from({ length: 768 }, (_, j) => j * 0.001)
+                    );
+                    return Promise.resolve({ data: vectors });
                   }
                 };
               };`
@@ -36,7 +39,10 @@ export default defineWorkersConfig({
               modules: true,
               script: `export default function() {
                 return {
-                  query: async (vectorData, options) => {
+                  query: async (vector, options) => {
+                    if (options && options.namespace === "empty-ns") {
+                      return Promise.resolve({ matches: [] });
+                    }
                     const score = 0.5678;
                     return Promise.resolve({ matches: [{ score }] });
                   }


### PR DESCRIPTION
## Summary

Resolves #430

Adds **33 integration tests** for the [Similarity Search worker](https://github.com/1712n/dn-institute/tree/main/tools/similarity_search) using `@cloudflare/vitest-pool-workers` and Vitest. 🌰

## 🌰 Test Coverage (33 cases)

### Authentication (4 tests)
- Missing `X-API-Key` header → 401
- Incorrect API key → 401
- Empty API key → 401
- Unauthenticated request on arbitrary path → 401

### POST `/` — Happy Path (4 tests)
- Valid input returns `similarity_score` as number
- Returns expected mocked score (0.5678)
- Response Content-Type is `application/json`
- Response body contains only `similarity_score` field

### POST `/` — Input Validation (10 tests)
- `text` as number / null / boolean / array → 400
- `namespace` as number / null → 400
- Missing `text` / missing `namespace` → 400
- Malformed JSON body → 500 (unhandled parse error)
- Empty body → 500 (unhandled parse error)

### POST `/` — Edge Cases (8 tests)
- Empty string text and namespace
- Very long text input (10k characters)
- Unicode text (CJK, Arabic, emoji 🌰)
- Special characters & XSS payloads
- Unicode namespace
- Extra fields in request body (ignored gracefully)
- No Vectorize matches → score 0
- Similarity score within valid range [0, 1]

### HTTP Method Handling (4 tests)
- GET / PUT / DELETE → 404
- Undefined route → 404

### Response Structure (3 tests)
- Successful response is valid parseable JSON
- Error responses (400) are plain text
- Unauthorized responses (401) are plain text

## 🌰 Methodology

Tests target **higher-level integration behavior** (full request → response cycle) rather than individual function internals, following Cloudflare's [Vitest integration best practices](https://developers.cloudflare.com/workers/testing/vitest-integration/).

Key design decisions:
- Uses `SELF.fetch()` to exercise the complete worker stack including middleware
- **Fixed AI mock** to return proper 768-dimensional vector arrays (original mock returned `{}`)
- **Namespace-aware Vectorize mock** that returns empty matches for `"empty-ns"` to test the no-match code path (`score || 0`)
- Helper function `postRequest()` reduces test boilerplate
- All tests are deterministic and fully offline — no external dependencies

## 🌰 Changes

| File | Change |
|------|--------|
| `tools/similarity_search/test/index.spec.ts` | Expanded from 1 → 33 test cases |
| `tools/similarity_search/vitest.config.ts` | Fixed AI mock (proper vector arrays) + namespace-aware Vectorize mock |

No source code changes. No new dependencies.

@Lavriz requesting review 🌰