### PR TITLE
feat: Replace static PNG charts with dynamic Chart.js shortcodes (#415)

### DIFF
--- a/layouts/shortcodes/metric_chart.html
+++ b/layouts/shortcodes/metric_chart.html
@@ -1,0 +1,61 @@
+{{/*
+  metric_chart shortcode — renders an interactive Chart.js chart from inline JSON data.
+
+  Usage:
+    {{< metric_chart id="unique-id" type="line" title="Chart Title" >}}
+    { "labels": [...], "datasets": [...] }
+    {{< /metric_chart >}}
+
+  Parameters:
+    id       — unique DOM id for the canvas (required)
+    type     — Chart.js chart type: line, bar, scatter (default: "line")
+    title    — chart title (optional)
+    height   — canvas height in px (default: 400)
+    caption  — caption text below chart (optional)
+*/}}
+
+{{ $id := .Get "id" }}
+{{ $chartType := .Get "type" | default "line" }}
+{{ $title := .Get "title" | default "" }}
+{{ $height := .Get "height" | default "400" }}
+{{ $caption := .Get "caption" | default "" }}
+
+<figure class="metric-chart-figure">
+  <div style="position:relative; width:100%; height:{{ $height }}px;">
+    <canvas id="{{ $id }}"></canvas>
+  </div>
+  {{ with $caption }}<figcaption>{{ . }}</figcaption>{{ end }}
+</figure>
+
+{{ $chart := resources.Get "/js/chart.js" }}
+<script src="{{ $chart.Permalink }}"></script>
+<script>
+(function() {
+  var ctx = document.getElementById('{{ $id }}').getContext('2d');
+  var chartData = {{ .Inner }};
+  new Chart(ctx, {
+    type: '{{ $chartType }}',
+    data: chartData,
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        title: {
+          display: {{ if $title }}true{{ else }}false{{ end }},
+          text: '{{ $title }}'
+        },
+        legend: { position: 'bottom' }
+      },
+      elements: {
+        point: { radius: 0 },
+        line: { tension: 0.1, borderWidth: 2 }
+      },
+      scales: {
+        x: {
+          ticks: { maxRotation: 45, autoSkip: true, maxTicksLimit: 20 }
+        }
+      }
+    }
+  });
+})();
+</script>

--- a/tools/python_modules/report_graphics_tool.py
+++ b/tools/python_modules/report_graphics_tool.py
@@ -1,92 +1,202 @@
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-import matplotlib.dates as mdates
+"""
+report_graphics_tool.py — Generates interactive Chart.js charts via Hugo shortcodes.
+
+Replaces the previous matplotlib-based static PNG generation with dynamic,
+browser-rendered charts using the {{< metric_chart >}} Hugo shortcode.
+Each method returns a shortcode markdown string that can be embedded directly
+in the generated article.
+
+The generate_report() method returns the full set of chart shortcodes as a
+string, and also injects them into the article markdown file if it exists.
+"""
+
+import json
 import os
+import re
+import math
+import pandas as pd
 
 
 class Visualization:
+    """Generate interactive Chart.js chart shortcodes for market health reports."""
+
     def __init__(self):
         pass
 
+    @staticmethod
+    def _format_timestamps(timestamps):
+        """Format pandas timestamps to short readable strings."""
+        return [t.strftime("%b %d %H:%M") for t in timestamps]
 
-    def _make_volume_hist(self, data, directory):
-        plt.figure(figsize=(10, 6))
-        plt.hist(data['volume'], bins=30, color='skyblue', edgecolor='black')
-        plt.xlabel('Transaction Volume')
-        plt.ylabel('Frequency')
-        plt.title('Transaction Volume Distribution')
-        plt.grid(True, which='both', linestyle='--', linewidth=0.5)
-        plt.savefig(os.path.join(directory, 'volume_hist.png'))
-        plt.close()
+    def _make_volume_hist(self, data):
+        """Generate a volume distribution histogram shortcode."""
+        volumes = data["volume"].dropna().tolist()
+        # Create histogram bins
+        num_bins = 30
+        min_v, max_v = min(volumes), max(volumes)
+        bin_width = (max_v - min_v) / num_bins if max_v != min_v else 1
+        bins = [0] * num_bins
+        for v in volumes:
+            idx = min(int((v - min_v) / bin_width), num_bins - 1)
+            bins[idx] += 1
+        labels = [f"{min_v + i * bin_width:.1f}" for i in range(num_bins)]
 
+        chart_data = {
+            "labels": labels,
+            "datasets": [{
+                "label": "Transaction Volume Frequency",
+                "data": bins,
+                "backgroundColor": "rgba(135, 206, 235, 0.7)",
+                "borderColor": "rgba(0, 0, 0, 0.8)",
+                "borderWidth": 1,
+            }],
+        }
+        return (
+            '{{< metric_chart id="volume-hist" type="bar" '
+            'title="Transaction Volume Distribution" '
+            'caption="Distribution of transaction volumes over the analysis period" >}}\n'
+            f"{json.dumps(chart_data)}\n"
+            "{{< /metric_chart >}}"
+        )
 
-    def _make_crypto_metrics(self, data, directory):
-        fig, axs = plt.subplots(4, 1, figsize=(15, 10), sharex=True)
+    def _make_crypto_metrics(self, data):
+        """Generate a multi-metric time series chart shortcode."""
+        timestamps = self._format_timestamps(data.index)
+        chart_data = {
+            "labels": timestamps,
+            "datasets": [
+                {
+                    "label": "Volume",
+                    "data": data["volume"].tolist(),
+                    "borderColor": "rgb(54, 162, 235)",
+                    "yAxisID": "y",
+                },
+                {
+                    "label": "Trade Count",
+                    "data": data["tradecount"].tolist(),
+                    "borderColor": "rgb(75, 192, 192)",
+                    "yAxisID": "y1",
+                },
+                {
+                    "label": "Avg Transaction Size",
+                    "data": data["avgtransactionsize"].tolist(),
+                    "borderColor": "rgb(255, 159, 64)",
+                    "yAxisID": "y2",
+                },
+                {
+                    "label": "Buy/Sell Ratio",
+                    "data": data["buysellratio"].tolist(),
+                    "borderColor": "rgb(255, 99, 132)",
+                    "yAxisID": "y3",
+                },
+            ],
+        }
+        return (
+            '{{< metric_chart id="crypto-metrics" type="line" '
+            'title="Cryptocurrency Metrics Over Time" '
+            'caption="Volume, trade count, average transaction size, and buy/sell ratio" >}}\n'
+            f"{json.dumps(chart_data)}\n"
+            "{{< /metric_chart >}}"
+        )
 
-        axs[0].plot(data.index, data['volume'], label='Volume', color='blue')
-        axs[0].set_ylabel('Volume')
+    def _make_benfordlaw(self, data):
+        """Generate a Benford's Law test chart shortcode."""
+        timestamps = self._format_timestamps(data.index)
+        # Calculate critical values: 1.36 / sqrt(tradecount)
+        critical_values = [
+            1.36 / math.sqrt(tc) if tc > 0 else 0
+            for tc in data["tradecount"].tolist()
+        ]
+        chart_data = {
+            "labels": timestamps,
+            "datasets": [
+                {
+                    "label": "Benford Law Test Score",
+                    "data": data["benfordlawtest"].tolist(),
+                    "borderColor": "rgb(54, 162, 235)",
+                    "yAxisID": "y",
+                },
+                {
+                    "label": "Critical Value (1.36/sqrt(n))",
+                    "data": critical_values,
+                    "borderColor": "rgb(75, 192, 192)",
+                    "borderDash": [5, 5],
+                    "yAxisID": "y",
+                },
+            ],
+        }
+        return (
+            '{{< metric_chart id="benford-law" type="line" '
+            'title="Benford Law Test Score Over Time" '
+            'caption="Benford Law test statistic vs. critical value threshold" >}}\n'
+            f"{json.dumps(chart_data)}\n"
+            "{{< /metric_chart >}}"
+        )
 
-        axs[1].plot(data.index, data['tradecount'], label='Trade Count', color='green')
-        axs[1].set_ylabel('Trade Count')
-
-        axs[2].plot(data.index, data['avgtransactionsize'], label='Avg Transaction Size', color='orange')
-        axs[2].set_ylabel('Avg Transaction Size')
-
-        axs[3].plot(data.index, data['buysellratio'], label='Buy/Sell Ratio', color='red')
-        axs[3].set_ylabel('Buy/Sell Ratio')
-
-        axs[3].set_xlabel('Timestamp')
-
-        fig.suptitle('Cryptocurrency Metrics Over Time')
-
-        for ax in axs:
-            plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
-
-        plt.tight_layout()
-        plt.savefig(os.path.join(directory, 'crypto_metrics.png'))
-        plt.close()
-        
-
-    def _make_benfordlaw(self, data, directory):
-        fig, ax1 = plt.subplots(figsize=(15, 10), layout='constrained')
-        ax1.plot(data.index, data['benfordlawtest'], color='blue', linestyle='-', label='Benford Law Test Score')
-        ax1.set_xlabel('Timestamp')
-        ax1.set_ylabel('Benford Law Test Score', color='blue')
-        ax1.xaxis.set_major_locator(mdates.HourLocator(interval=24))
-        ax1.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-        ax2 = ax1.twinx()
-        ax2.plot(data.index, 1.36 / np.sqrt(data['tradecount']), color='green', linestyle='-', label='Trade Count')
-        ax2.set_ylabel('Trade Count', color='green')
-        ax1.set_title('Benford Law Test Score and Trade Count Over Time')
-        lines = ax1.get_lines() + ax2.get_lines()
-        labels = [line.get_label() for line in lines]
-        ax1.legend(lines, labels, loc='upper left')
-        plt.savefig(os.path.join(directory, 'benford_law.png'))
-        plt.close()
-
-
-    def _make_vvcorrelation(self, data, directory):
-        fig, ax = plt.subplots(figsize=(15, 10), layout='constrained')
-        ax.plot(data.index, data['vvcorrelation'], color='purple', linestyle='-', marker='o', label='VV Correlation')
-        ax.xaxis.set_major_locator(mdates.HourLocator(interval=24))
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-        ax.set_xlabel('Timestamp')
-        ax.set_ylabel('VV Correlation')
-        ax.set_title('VV Correlation Over Time')
-        ax.legend()
-        plt.xticks(rotation=45)
-        plt.savefig(os.path.join(directory, 'vv_correlation.png'))
-        plt.close()
+    def _make_vvcorrelation(self, data):
+        """Generate a volume-volatility correlation chart shortcode."""
+        timestamps = self._format_timestamps(data.index)
+        chart_data = {
+            "labels": timestamps,
+            "datasets": [{
+                "label": "Volume-Volatility Correlation",
+                "data": data["vvcorrelation"].tolist(),
+                "borderColor": "rgb(153, 102, 255)",
+                "backgroundColor": "rgba(153, 102, 255, 0.1)",
+                "fill": True,
+            }],
+        }
+        return (
+            '{{< metric_chart id="vv-correlation" type="line" '
+            'title="Volume-Volatility Correlation Over Time" '
+            'caption="Correlation between trading volume and price volatility" >}}\n'
+            f"{json.dumps(chart_data)}\n"
+            "{{< /metric_chart >}}"
+        )
 
     def generate_report(self, data, directory):
+        """
+        Generate interactive chart shortcodes and inject them into the article.
+
+        Args:
+            data: Raw API response data (list of dicts or dict with lists).
+            directory: Path to the article output directory.
+
+        Returns:
+            str: Combined shortcode markdown for all charts.
+        """
         if not os.path.exists(directory):
             os.makedirs(directory)
-        data = pd.DataFrame(data)
-        data['timestamp'] = pd.to_datetime(data['timestamp'])
-        data.set_index('timestamp', inplace=True)
 
-        self._make_volume_hist(data, directory)
-        self._make_crypto_metrics(data, directory)
-        self._make_benfordlaw(data, directory)
-        self._make_vvcorrelation(data, directory)
+        df = pd.DataFrame(data)
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df.set_index("timestamp", inplace=True)
+
+        charts = []
+        charts.append(self._make_volume_hist(df))
+        charts.append(self._make_crypto_metrics(df))
+        if "benfordlawtest" in df.columns:
+            charts.append(self._make_benfordlaw(df))
+        if "vvcorrelation" in df.columns:
+            charts.append(self._make_vvcorrelation(df))
+
+        chart_block = "\n\n".join(charts)
+
+        # Inject charts into the article markdown if it exists
+        # Append charts section before the end of the article
+        index_files = [
+            f for f in os.listdir(directory)
+            if f.startswith("index") and f.endswith(".md")
+        ]
+        if index_files:
+            article_path = os.path.join(directory, index_files[-1])
+            with open(article_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Append interactive charts section if not already present
+            if "metric_chart" not in content:
+                content += f"\n\n## Interactive Charts\n\n{chart_block}\n"
+                with open(article_path, "w", encoding="utf-8") as f:
+                    f.write(content)
+
+        return chart_block


### PR DESCRIPTION
## Summary

Replaces static matplotlib PNG image generation in the Market Health Reporter with interactive, browser-rendered Chart.js charts using a new Hugo shortcode.

Closes #415

## Changes

### 1. New Hugo shortcode: `metric_chart`
- `layouts/shortcodes/metric_chart.html` — a reusable shortcode that renders Chart.js charts from inline JSON data
- Supports all Chart.js chart types (line, bar, scatter)
- Configurable via parameters: `id`, `type`, `title`, `height`, `caption`
- Uses the existing `assets/js/chart.js` already in the repo (no new dependencies)
- Responsive and mobile-friendly with auto-scaling

### 2. Rewritten `report_graphics_tool.py`
- Removed matplotlib/numpy dependency entirely
- `Visualization` class now generates Hugo shortcode markdown strings instead of PNG files
- Each chart method returns a shortcode block with embedded JSON data
- `generate_report()` returns combined shortcode markdown and auto-injects charts into the article `.md` file
- Covers all 4 original chart types:
  - **Volume histogram** — transaction volume distribution
  - **Crypto metrics** — multi-series time series (volume, trade count, avg tx size, buy/sell ratio)  
  - **Benford Law** — test score vs. critical value threshold
  - **VV Correlation** — volume-volatility correlation over time

## Methodology

The existing pipeline generates reports via:
1. Fetch market data from API → 2. LLM generates article markdown → 3. `Visualization.generate_report()` creates charts

Previously step 3 saved static PNGs via matplotlib. Now it produces `{{< metric_chart >}}` shortcode blocks with the chart data serialized as inline JSON. When Hugo renders the site, each shortcode creates a `<canvas>` element and initializes a Chart.js instance with the embedded data.

**Why inline JSON instead of API calls at render time?**
- Reports are point-in-time analysis — the data should be frozen at generation time
- No dependency on API availability when viewing historical reports
- Consistent with how the existing `market_widget` shortcode works, but self-contained

**Why Chart.js?**
- Already used in the repo (`assets/js/chart.js` and `assets/js/widget.js`)
- No additional dependencies to add
- Interactive (hover tooltips, zoom potential) vs static PNGs

## Testing

The shortcode can be tested with any Hugo build. The Python module maintains the same `Visualization` class interface so the existing `market_health_reporter.py` workflow is unchanged — it just produces interactive charts instead of PNGs.

cc @Kseymur @evgenydmitriev for review