### PR TITLE
feat: add RAG context to Market Health Reporter (issue #428)

### DIFF
--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -8,6 +8,7 @@ import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.rag import build_rag_context
 
 
 REPO_NAME = "1712n/dn-institute"
@@ -17,6 +18,8 @@ ARTICLE_EXAMPLE_FILE = 'content/market-health/posts/2023-08-14-huobi/index.md'
 OUTPUT_DIR = 'content/market-health/posts/'
 DATA_DIR = 'tools/market_health_reporter/doc/data/'
 MAX_TOKENS = 125000
+# Token budget reserved for RAG news context (out of MAX_TOKENS)
+RAG_MAX_TOKENS = 2000
 
 
 def parse_cli_args():
@@ -38,6 +41,13 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
+    )
+    parser.add_argument(
+        "--cryptopanic-token",
+        dest="cryptopanic_token",
+        help="CryptoPanic API auth token (optional, enables RAG news context)",
+        default="",
+        required=False,
     )
     return parser.parse_args()
 
@@ -126,11 +136,30 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(
+    article_example: str,
+    data: dict,
+    human_prompt_content: str,
+    rag_context: str = None,
+) -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, market data, and optional RAG context.
+
+    When *rag_context* is provided (non-empty string), it is appended after the
+    human prompt instructions and before the market data so the model can use
+    recent news to enrich its analysis.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    rag_section = (
+        f"\n<news_context>\n{rag_context}\n</news_context>\n"
+        if rag_context
+        else ""
+    )
+    return (
+        f"<example> {article_example} </example>\n"
+        f"{human_prompt_content}"
+        f"{rag_section}"
+        f"\n<data> {json.dumps(data)} </data>"
+    )
 
 
 def main():
@@ -160,7 +189,26 @@ def main():
         encoding = encoding_for_model("gpt-4")     
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        # --- RAG: fetch recent news context (optional, graceful fallback) ---
+        rag_context = None
+        cryptopanic_token = getattr(args, "cryptopanic_token", "")
+        try:
+            rag_context = build_rag_context(
+                marketvenueid=marketvenueid,
+                pairid=pairid,
+                cryptopanic_token=cryptopanic_token,
+                max_tokens=RAG_MAX_TOKENS,
+            )
+            if rag_context:
+                print(f"RAG context fetched: ~{len(encoding.encode(rag_context))} tokens")
+            else:
+                print("RAG: no relevant news context found, proceeding without it.")
+        except Exception as rag_exc:
+            print(f"RAG fetch failed (non-fatal): {rag_exc}")
+            rag_context = None
+        # ---------------------------------------------------------------------
+
+        prompt = create_prompt(article_example, data, human_prompt_content, rag_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:

--- a/tools/market_health_reporter/rag.py
+++ b/tools/market_health_reporter/rag.py
@@ -1,0 +1,316 @@
+"""
+RAG (Retrieval-Augmented Generation) module for Market Health Reporter.
+
+Fetches recent news articles related to a market venue and trading pair from
+CryptoPanic, extracts clean article text, and returns a token-budget-capped
+context string that can be injected into the LLM prompt.
+
+Usage::
+
+    from tools.market_health_reporter.rag import build_rag_context
+
+    context = build_rag_context(
+        marketvenueid="binance",
+        pairid="btc-usdt",
+        cryptopanic_token="<your_token>",   # optional – pass "" for public feed
+        max_tokens=2000,
+    )
+    # context is either a non-empty string or None (graceful fallback)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CRYPTOPANIC_API_URL = "https://cryptopanic.com/api/v1/posts/"
+
+# Approximate average token length in characters (conservative estimate)
+_CHARS_PER_TOKEN = 4
+
+# Hard cap on characters fetched per article body
+_MAX_ARTICLE_CHARS = 8_000
+
+# Request timeout for external HTTP calls (seconds)
+_HTTP_TIMEOUT = 10
+
+# Maximum number of articles to fetch from CryptoPanic
+_MAX_ARTICLES = 10
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_currencies(pairid: str) -> list[str]:
+    """
+    Derive currency symbols from a pairid like 'btc-usdt' → ['BTC', 'USDT'].
+    Falls back to the whole pairid as a single symbol if no separator is found.
+    """
+    for sep in ("-", "/", "_"):
+        if sep in pairid:
+            return [p.upper() for p in pairid.split(sep) if p]
+    return [pairid.upper()]
+
+
+def _fetch_cryptopanic_posts(
+    currencies: list[str],
+    auth_token: str,
+    kind: str = "news",
+    filter_: str = "hot",
+) -> list[dict]:
+    """
+    Fetch posts from CryptoPanic API for the given currency symbols.
+
+    Returns a list of post dicts (may be empty on error).
+    """
+    params: dict = {
+        "currencies": ",".join(currencies),
+        "kind": kind,
+        "filter": filter_,
+        "public": "true",
+    }
+    if auth_token:
+        params["auth_token"] = auth_token
+
+    try:
+        resp = requests.get(
+            CRYPTOPANIC_API_URL, params=params, timeout=_HTTP_TIMEOUT
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("results", [])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("CryptoPanic fetch failed: %s", exc)
+        return []
+
+
+def _fetch_article_text(url: str) -> Optional[str]:
+    """
+    Fetch a URL and return clean plain-text content (HTML stripped).
+
+    Returns None if the fetch or extraction fails.
+    """
+    try:
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (compatible; MarketHealthReporter/1.0; "
+                "+https://github.com/1712n/dn-institute)"
+            )
+        }
+        resp = requests.get(url, headers=headers, timeout=_HTTP_TIMEOUT)
+        resp.raise_for_status()
+
+        content_type = resp.headers.get("Content-Type", "")
+        if "html" not in content_type.lower():
+            # Not HTML – skip
+            return None
+
+        soup = BeautifulSoup(resp.text, "lxml")
+
+        # Remove non-content elements
+        for tag in soup(["script", "style", "nav", "header", "footer",
+                         "aside", "form", "noscript", "iframe", "meta",
+                         "link", "figure"]):
+            tag.decompose()
+
+        # Prefer <article> or <main> if available
+        body_node = soup.find("article") or soup.find("main") or soup.body
+        if body_node is None:
+            return None
+
+        raw_text = body_node.get_text(separator="\n")
+
+        # Collapse excessive whitespace
+        cleaned = re.sub(r"\n{3,}", "\n\n", raw_text)
+        cleaned = re.sub(r"[ \t]+", " ", cleaned)
+        cleaned = cleaned.strip()
+
+        if len(cleaned) < 100:
+            return None
+
+        return cleaned[:_MAX_ARTICLE_CHARS]
+
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Article fetch failed for %s: %s", url, exc)
+        return None
+
+
+def _is_relevant(text: str, keywords: list[str]) -> bool:
+    """
+    Return True if the text mentions at least one of the keywords
+    (case-insensitive).
+    """
+    lowered = text.lower()
+    return any(kw.lower() in lowered for kw in keywords)
+
+
+def _token_count(text: str) -> int:
+    """Rough token count estimate (characters / 4)."""
+    return len(text) // _CHARS_PER_TOKEN
+
+
+def _truncate_to_token_budget(text: str, budget: int) -> str:
+    """Truncate *text* so that its estimated token count ≤ *budget*."""
+    max_chars = budget * _CHARS_PER_TOKEN
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rsplit(" ", 1)[0] + " [...]"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def fetch_news_posts(
+    marketvenueid: str,
+    pairid: str,
+    cryptopanic_token: str = "",
+    max_articles: int = _MAX_ARTICLES,
+) -> list[dict]:
+    """
+    Retrieve CryptoPanic news posts relevant to *marketvenueid* / *pairid*.
+
+    Parameters
+    ----------
+    marketvenueid:
+        Exchange identifier (e.g. ``"binance"``).
+    pairid:
+        Trading pair string (e.g. ``"btc-usdt"``).
+    cryptopanic_token:
+        CryptoPanic API auth token. Pass empty string to use public endpoint
+        (rate-limited, but functional).
+    max_articles:
+        Maximum number of posts to return.
+
+    Returns
+    -------
+    list[dict]
+        List of post dicts from the CryptoPanic API (may be empty).
+    """
+    currencies = _extract_currencies(pairid)
+    posts = _fetch_cryptopanic_posts(currencies, cryptopanic_token)
+
+    # Also try fetching for the venue name if it looks like a known coin ticker
+    if marketvenueid.upper() not in currencies:
+        venue_posts = _fetch_cryptopanic_posts(
+            [marketvenueid.upper()], cryptopanic_token
+        )
+        # Deduplicate by URL
+        seen_urls = {p.get("url") for p in posts}
+        for p in venue_posts:
+            if p.get("url") not in seen_urls:
+                posts.append(p)
+                seen_urls.add(p.get("url"))
+
+    return posts[:max_articles]
+
+
+def build_rag_context(
+    marketvenueid: str,
+    pairid: str,
+    cryptopanic_token: str = "",
+    max_tokens: int = 2000,
+) -> Optional[str]:
+    """
+    Build a RAG context string for the given market venue and pair.
+
+    Fetches recent news, scrapes article full text, filters for relevance,
+    and returns a clean context block within *max_tokens*.
+
+    Parameters
+    ----------
+    marketvenueid:
+        Exchange identifier (e.g. ``"binance"``).
+    pairid:
+        Trading pair identifier (e.g. ``"btc-usdt"``).
+    cryptopanic_token:
+        CryptoPanic API auth token (empty string uses public endpoint).
+    max_tokens:
+        Approximate maximum token budget for the returned context string.
+
+    Returns
+    -------
+    str or None
+        A formatted context string ready to inject into the LLM prompt, or
+        ``None`` if no relevant content could be retrieved (graceful fallback).
+    """
+    currencies = _extract_currencies(pairid)
+    # Build keyword list for relevance filtering
+    keywords = currencies + [marketvenueid]
+
+    posts = fetch_news_posts(marketvenueid, pairid, cryptopanic_token)
+    if not posts:
+        logger.info("No CryptoPanic posts found for %s/%s", marketvenueid, pairid)
+        return None
+
+    snippets: list[str] = []
+    token_budget = max_tokens
+
+    for post in posts:
+        if token_budget <= 0:
+            break
+
+        title = post.get("title", "")
+        url = post.get("url") or post.get("source", {}).get("url", "")
+        published = post.get("published_at", "")
+
+        if not url:
+            continue
+
+        # Try to fetch full article text; fall back to title-only snippet
+        body = _fetch_article_text(url)
+
+        if body:
+            # Filter: article must mention at least one relevant keyword
+            combined = f"{title} {body}"
+            if not _is_relevant(combined, keywords):
+                logger.debug("Skipping unrelated article: %s", title)
+                continue
+            content = body
+        else:
+            # Use title only if we couldn't retrieve the body
+            if not _is_relevant(title, keywords):
+                continue
+            content = "(Full text unavailable)"
+
+        # Compose per-article snippet
+        snippet = f"### {title}\n_Source: {url}_\n_Published: {published}_\n\n{content}"
+        snippet_tokens = _token_count(snippet)
+
+        if snippet_tokens > token_budget:
+            # Try to fit a truncated version
+            snippet = _truncate_to_token_budget(snippet, token_budget)
+
+        snippets.append(snippet)
+        token_budget -= _token_count(snippet)
+
+        # Small delay to be polite to external servers
+        time.sleep(0.3)
+
+    if not snippets:
+        logger.info(
+            "No relevant articles found after filtering for %s/%s",
+            marketvenueid,
+            pairid,
+        )
+        return None
+
+    header = (
+        f"## Recent News Context for {marketvenueid.upper()} / {pairid.upper()}\n\n"
+        "The following articles were retrieved automatically to provide additional "
+        "context. Use them to enrich your market analysis where relevant.\n\n"
+    )
+    return header + "\n\n---\n\n".join(snippets)

--- a/tools/market_health_reporter/tests/test_rag.py
+++ b/tools/market_health_reporter/tests/test_rag.py
@@ -1,0 +1,265 @@
+"""
+Unit tests for the RAG module (tools/market_health_reporter/rag.py).
+
+All external network calls are mocked so tests run offline.
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure the repo root is on the path so we can import the module directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from tools.market_health_reporter.rag import (
+    _extract_currencies,
+    _is_relevant,
+    _token_count,
+    _truncate_to_token_budget,
+    build_rag_context,
+    fetch_news_posts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests (no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCurrencies(unittest.TestCase):
+    def test_dash_separator(self):
+        self.assertEqual(_extract_currencies("btc-usdt"), ["BTC", "USDT"])
+
+    def test_slash_separator(self):
+        self.assertEqual(_extract_currencies("eth/usdc"), ["ETH", "USDC"])
+
+    def test_underscore_separator(self):
+        self.assertEqual(_extract_currencies("sol_bnb"), ["SOL", "BNB"])
+
+    def test_no_separator(self):
+        self.assertEqual(_extract_currencies("btc"), ["BTC"])
+
+    def test_already_upper(self):
+        self.assertEqual(_extract_currencies("BTC-USDT"), ["BTC", "USDT"])
+
+
+class TestIsRelevant(unittest.TestCase):
+    def test_match_found(self):
+        self.assertTrue(_is_relevant("Bitcoin hits new high", ["bitcoin"]))
+
+    def test_match_case_insensitive(self):
+        self.assertTrue(_is_relevant("BINANCE exchange news", ["binance"]))
+
+    def test_no_match(self):
+        self.assertFalse(_is_relevant("Stock market rally", ["bitcoin", "binance"]))
+
+    def test_empty_keywords(self):
+        self.assertFalse(_is_relevant("Some text", []))
+
+
+class TestTokenCount(unittest.TestCase):
+    def test_empty_string(self):
+        self.assertEqual(_token_count(""), 0)
+
+    def test_known_length(self):
+        # 8 chars → 2 tokens with floor division by 4
+        self.assertEqual(_token_count("abcdefgh"), 2)
+
+
+class TestTruncateToTokenBudget(unittest.TestCase):
+    def test_no_truncation_needed(self):
+        text = "Hello world"
+        self.assertEqual(_truncate_to_token_budget(text, 1000), text)
+
+    def test_truncation_applied(self):
+        # budget = 2 tokens ≈ 8 chars; text is much longer
+        text = "The quick brown fox jumps over the lazy dog and then some more words"
+        result = _truncate_to_token_budget(text, 2)
+        self.assertIn("[...]", result)
+        self.assertLessEqual(len(result), 8 + len(" [...]") + 5)
+
+    def test_truncation_ends_on_word_boundary(self):
+        text = "alpha beta gamma delta epsilon"
+        result = _truncate_to_token_budget(text, 5)
+        # Should not cut in the middle of a word
+        self.assertFalse(result.startswith(" "))
+
+
+# ---------------------------------------------------------------------------
+# Network-dependent tests (mocked)
+# ---------------------------------------------------------------------------
+
+_SAMPLE_POSTS = [
+    {
+        "title": "Binance BTC-USDT trading volume surges",
+        "url": "https://example.com/article1",
+        "published_at": "2024-01-15T10:00:00Z",
+        "source": {"url": "https://example.com"},
+    },
+    {
+        "title": "Unrelated sports news article",
+        "url": "https://example.com/article2",
+        "published_at": "2024-01-15T09:00:00Z",
+        "source": {"url": "https://example.com"},
+    },
+]
+
+_SAMPLE_ARTICLE_HTML = """
+<html>
+<head><title>Binance BTC-USDT trading volume surges</title></head>
+<body>
+<nav>Navigation</nav>
+<article>
+<h1>Binance BTC-USDT trading volume surges</h1>
+<p>Binance reported a significant increase in BTC-USDT trading volume today,
+with analysts pointing to institutional demand as the main driver.</p>
+<p>The exchange saw a 40% uptick in spot trading activity over the past 24 hours.</p>
+</article>
+<footer>Footer content</footer>
+</body>
+</html>
+"""
+
+
+class TestFetchNewsPosts(unittest.TestCase):
+    @patch("tools.market_health_reporter.rag.requests.get")
+    def test_returns_posts_on_success(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"results": _SAMPLE_POSTS}
+        mock_get.return_value = mock_resp
+
+        posts = fetch_news_posts("binance", "btc-usdt", cryptopanic_token="test")
+        self.assertEqual(len(posts), 2)
+
+    @patch("tools.market_health_reporter.rag.requests.get")
+    def test_returns_empty_on_api_error(self, mock_get):
+        mock_get.side_effect = Exception("Network error")
+        posts = fetch_news_posts("binance", "btc-usdt")
+        self.assertEqual(posts, [])
+
+    @patch("tools.market_health_reporter.rag.requests.get")
+    def test_deduplicates_venue_posts(self, mock_get):
+        """Posts fetched for venue ticker should be deduplicated."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"results": _SAMPLE_POSTS[:1]}
+        mock_get.return_value = mock_resp
+
+        posts = fetch_news_posts("btc", "btc-usdt")
+        # Even though both calls return the same URL, result should not duplicate
+        urls = [p.get("url") for p in posts]
+        self.assertEqual(len(urls), len(set(urls)))
+
+
+class TestBuildRagContext(unittest.TestCase):
+    @patch("tools.market_health_reporter.rag._fetch_article_text")
+    @patch("tools.market_health_reporter.rag.fetch_news_posts")
+    def test_returns_context_when_articles_found(self, mock_posts, mock_text):
+        mock_posts.return_value = [_SAMPLE_POSTS[0]]
+        mock_text.return_value = (
+            "Binance BTC-USDT trading volume surges. Institutional demand drives "
+            "a 40 percent uptick in spot trading activity on the exchange."
+        )
+
+        context = build_rag_context("binance", "btc-usdt", max_tokens=500)
+        self.assertIsNotNone(context)
+        self.assertIn("binance", context.lower())
+        self.assertIn("btc", context.lower())
+
+    @patch("tools.market_health_reporter.rag.fetch_news_posts")
+    def test_returns_none_when_no_posts(self, mock_posts):
+        mock_posts.return_value = []
+        context = build_rag_context("binance", "btc-usdt")
+        self.assertIsNone(context)
+
+    @patch("tools.market_health_reporter.rag._fetch_article_text")
+    @patch("tools.market_health_reporter.rag.fetch_news_posts")
+    def test_returns_none_when_no_relevant_articles(self, mock_posts, mock_text):
+        # Post exists but text is not relevant to our pair
+        mock_posts.return_value = [_SAMPLE_POSTS[1]]  # "Unrelated sports news"
+        mock_text.return_value = "A football team won the championship last night."
+
+        context = build_rag_context("binance", "btc-usdt")
+        self.assertIsNone(context)
+
+    @patch("tools.market_health_reporter.rag._fetch_article_text")
+    @patch("tools.market_health_reporter.rag.fetch_news_posts")
+    def test_respects_token_budget(self, mock_posts, mock_text):
+        mock_posts.return_value = [_SAMPLE_POSTS[0]]
+        # Provide a very long text
+        long_text = "Binance BTC-USDT market update. " * 500
+        mock_text.return_value = long_text
+
+        context = build_rag_context("binance", "btc-usdt", max_tokens=100)
+        self.assertIsNotNone(context)
+        # Rough check: context should be well within token budget chars
+        self.assertLessEqual(len(context), 100 * 4 + 500)  # budget chars + header
+
+    @patch("tools.market_health_reporter.rag._fetch_article_text")
+    @patch("tools.market_health_reporter.rag.fetch_news_posts")
+    def test_falls_back_to_title_when_no_body(self, mock_posts, mock_text):
+        """When article body fetch fails, use title-based snippet if relevant."""
+        mock_posts.return_value = [_SAMPLE_POSTS[0]]  # title mentions binance btc
+        mock_text.return_value = None  # simulate fetch failure
+
+        context = build_rag_context("binance", "btc-usdt", max_tokens=500)
+        self.assertIsNotNone(context)
+        self.assertIn("Binance BTC-USDT", context)
+
+    @patch("tools.market_health_reporter.rag.fetch_news_posts")
+    def test_graceful_fallback_on_exception(self, mock_posts):
+        """build_rag_context should not raise even if internals throw."""
+        mock_posts.side_effect = RuntimeError("unexpected crash")
+        # Should propagate (caller wraps in try/except), but let's ensure
+        # the function itself doesn't silently swallow exceptions from fetch_news_posts.
+        with self.assertRaises(RuntimeError):
+            build_rag_context("binance", "btc-usdt")
+
+
+class TestCreatePromptIntegration(unittest.TestCase):
+    """Test that market_health_reporter.create_prompt correctly embeds RAG context.
+
+    We mock out heavy optional dependencies (openai, tiktoken, github) so this
+    test suite can run without a full poetry environment.
+    """
+
+    def _import_create_prompt(self):
+        """Import create_prompt, mocking unavailable deps as needed."""
+        # Stub out modules that may not be installed in the test environment
+        for mod in ("openai", "tiktoken", "github", "tools.python_modules.utils",
+                    "tools.python_modules.report_graphics_tool"):
+            if mod not in sys.modules:
+                sys.modules[mod] = MagicMock()
+
+        # Force re-evaluation if already partially imported
+        import importlib
+        import tools.market_health_reporter.market_health_reporter as mhr_mod
+        importlib.reload(mhr_mod)
+        return mhr_mod.create_prompt
+
+    def test_prompt_without_rag(self):
+        create_prompt = self._import_create_prompt()
+        prompt = create_prompt("example", {"key": "val"}, "instructions")
+        self.assertNotIn("news_context", prompt)
+        self.assertIn("<data>", prompt)
+        self.assertIn("<example>", prompt)
+
+    def test_prompt_with_rag(self):
+        create_prompt = self._import_create_prompt()
+        rag = "## Recent News\n\nSome article content here."
+        prompt = create_prompt("example", {"key": "val"}, "instructions", rag_context=rag)
+        self.assertIn("<news_context>", prompt)
+        self.assertIn("Recent News", prompt)
+        # RAG section should appear before the data section
+        self.assertLess(prompt.index("<news_context>"), prompt.index("<data>"))
+
+    def test_prompt_with_none_rag(self):
+        create_prompt = self._import_create_prompt()
+        prompt = create_prompt("example", {"key": "val"}, "instructions", rag_context=None)
+        self.assertNotIn("news_context", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds **RAG (Retrieval-Augmented Generation)** functionality to the Market Health Reporter, addressing [issue #428](https://github.com/1712n/dn-institute/issues/428).

## What Changed

### New file: `tools/market_health_reporter/rag.py`

A self-contained module that:

1. **Fetches live news from CryptoPanic API** – uses the free public endpoint (or optionally an auth token). Queries by currency symbols derived from the `pairid` (e.g. `btc-usdt` → `BTC,USDT`) and the `marketvenueid`.
2. **Scrapes article full text** – uses `BeautifulSoup` + `lxml` to parse HTML. Strips all scripts, styles, nav, headers, footers, and other non-content elements before extracting text. **No raw HTML is ever passed to the prompt.**
3. **Relevance filtering** – each article is checked for keyword matches (currencies + venue name) and skipped if unrelated.
4. **Token budget enforcement** – text is truncated to a configurable token cap (default `2000` tokens) using a conservative char-based estimate, keeping the total prompt well within `MAX_TOKENS`.
5. **Graceful fallback** – returns `None` (not an error) when no relevant content is found, so the reporter continues to work identically without news context.

### Updated: `tools/market_health_reporter/market_health_reporter.py`

- Added optional `--cryptopanic-token` CLI argument (fully backward-compatible; works without it via CryptoPanic public endpoint).
- `create_prompt()` accepts an optional `rag_context` keyword argument; when provided, it is injected as `<news_context>…</news_context>` between the instructions and `<data>` blocks.
- RAG fetch is wrapped in `try/except` so any failure is logged and skipped non-fatally.

### New: `tools/market_health_reporter/tests/test_rag.py`

26 unit tests covering:
- Currency extraction from pair strings
- Relevance keyword filtering
- Token counting and budget truncation
- Mocked CryptoPanic API calls (success / error / deduplication)
- Mocked article text scraping (full text / unavailable / irrelevant)
- Token budget enforcement
- Graceful fallback when no posts or no relevant content
- Prompt injection with and without RAG context

All 26 tests pass offline (zero live network calls).

## Methodology

The previous PR (#480) was rejected for using a static knowledge base and passing raw HTML into the prompt. This implementation fixes both issues:

| Previous approach | This approach |
|---|---|
| Static knowledge base (pre-baked text) | Live CryptoPanic API → always fresh |
| Raw HTML in prompt | BeautifulSoup extracts plain text only |
| Not optional | Fully optional; `--cryptopanic-token` not required |
| No tests | 26 unit tests, all offline |

The news context gives the LLM real-world background on recent exchange events, regulatory news, and market sentiment—enabling better interpretation of metric anomalies in the generated report.

## Testing

```bash
python3 -m pytest tools/market_health_reporter/tests/test_rag.py -v
# 26 passed in 1.37s
```