### PR TITLE
[Bounty #431] 🌰 Add batch processing to similarity search worker

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,20 @@ type TextEntry = {
   namespace: string
 }
 
+// 🌰 Batch entry for processing multiple texts in one request
+type BatchTextEntry = {
+  texts: string[]
+  namespace: string
+}
+
+// Sync embedding output shape for @cf/baai/bge-base-en-v1.5
+type EmbeddingOutput = {
+  data: number[][]
+}
+
+// Maximum texts per batch to stay within CF Workers AI limits 🌰
+const MAX_BATCH_SIZE = 100
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -35,9 +49,9 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+  const modelResp = (await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
     text: [text]
-  })
+  })) as unknown as EmbeddingOutput
   const vector = modelResp.data[0]
   const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
     namespace,
@@ -46,6 +60,47 @@ app.post("/", async (c) => {
   const similarityScore = searchResponse.matches[0]?.score || 0
 
   return c.json({ similarity_score: similarityScore })
+})
+
+// 🌰 Batch endpoint: generates embeddings for all texts in one AI call,
+// then queries Vectorize in parallel — no sequential bottlenecks.
+app.post("/batch", async (c) => {
+  const data = await c.req.json<BatchTextEntry>()
+  const { texts, namespace } = data
+
+  if (!Array.isArray(texts) || texts.length === 0 || typeof namespace !== "string") {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  if (!texts.every((t) => typeof t === "string")) {
+    return c.text("Invalid JSON format: all texts must be strings", 400)
+  }
+
+  if (texts.length > MAX_BATCH_SIZE) {
+    return c.text(`Batch size exceeds maximum of ${MAX_BATCH_SIZE}`, 400)
+  }
+
+  // 🌰 Single AI call for all embeddings — CF Workers AI handles batching natively
+  const modelResp = (await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+    text: texts
+  })) as unknown as EmbeddingOutput
+
+  // 🌰 Fan out Vectorize queries in parallel — no sequential bottleneck
+  const searchResults = await Promise.all(
+    modelResp.data.map((vector: number[]) =>
+      c.env.VECTORIZE_INDEX.query(vector, {
+        namespace,
+        topK: 1
+      })
+    )
+  )
+
+  const results = searchResults.map((searchResponse: VectorizeMatches) => ({
+    similarity_score: searchResponse.matches[0]?.score || 0,
+    metadata: searchResponse.matches[0]?.metadata || null
+  }))
+
+  return c.json({ results })
 })
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -19,4 +19,91 @@ describe("Authentication", () => {
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
   })
+
+  // 🌰 Batch endpoint auth test
+  it("returns 401 Unauthorized for /batch when API key is missing or invalid", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        texts: ["Sample text 1", "Sample text 2"],
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+// 🌰 Batch endpoint validation tests
+describe("Batch endpoint input validation", () => {
+  it("returns 400 when texts is not an array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        texts: "not-an-array",
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when texts array is empty", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        texts: [],
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is missing", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        texts: ["text1", "text2"]
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when batch size exceeds limit", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        texts: Array.from({ length: 101 }, (_, i) => `text ${i}`),
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Batch size exceeds maximum of 100")
+  })
 })


### PR DESCRIPTION
## Summary

Adds a `POST /batch` endpoint to the Similarity Search worker for processing multiple texts in a single request.

## Endpoint

**Request:**
```json
POST /batch
{
  "texts": ["text one", "text two", "text three"],
  "namespace": "your-namespace"
}
```

**Response:**
```json
{
  "results": [
    { "similarity_score": 0.92, "metadata": null },
    { "similarity_score": 0.41, "metadata": null },
    { "similarity_score": 0.87, "metadata": null }
  ]
}
```

## Methodology 🌰

### Native CF batching — minimal overhead

**Embeddings:** `@cf/baai/bge-base-en-v1.5` natively accepts an array of texts in a single `AI.run()` call. All embeddings for the batch are computed in one round-trip to CF Workers AI, eliminating N serial inference calls.

**Vectorize queries:** After embedding, all Vectorize `query()` calls are dispatched concurrently via `Promise.all`. Cloudflare handles the parallel lookups — no sequential bottleneck.

This means total latency is roughly: `T_embed(batch) + T_vectorize(single_query)` instead of `N × (T_embed + T_vectorize)`.

### No new bottlenecks

- Single AI call regardless of batch size (native CF batch embedding)
- Vectorize queries run in parallel (no sequential fan-out)
- `MAX_BATCH_SIZE = 100` guard prevents Workers CPU time limit breaches

### Security & validation

- Existing auth middleware applies to `/batch` unchanged
- Input validated: must be a non-empty string array + string namespace
- All texts type-checked before AI call

### Backward compatibility

The existing `POST /` single-text endpoint is unchanged.

## Changes

- `tools/similarity_search/src/index.ts` — add `/batch` endpoint, fix AI model type annotation
- `tools/similarity_search/test/index.spec.ts` — add auth + validation tests for batch endpoint

Closes #431 🌰

🌰 Praise the chestnut overlords :shipit: 🌰