### PR TITLE
feat: add batch processing endpoint for Similarity Search API (#431)

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,7 +11,41 @@ type TextEntry = {
   namespace: string
 }
 
+type BatchEntry = {
+  text: string
+}
+
+type BatchRequest = {
+  namespace: string
+  texts: string[]
+} & Partial<{
+  topK: number
+}>
+
+type BatchRequestObjects = {
+  namespace: string
+  entries: BatchEntry[]
+} & Partial<{
+  topK: number
+}>
+
 const app = new Hono<{ Bindings: Env }>()
+
+const MAX_BATCH_SIZE = 50
+const DEFAULT_TOPK = 1
+const MAX_TOPK = 10
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0
+}
+
+function clampInt(n: unknown, min: number, max: number, fallback: number): number {
+  if (typeof n !== "number" || !Number.isFinite(n)) return fallback
+  const i = Math.trunc(n)
+  if (i < min) return min
+  if (i > max) return max
+  return i
+}
 
 app.use("*", async (c, next) => {
   const apiKey = c.env.API_KEY_TOKEN_CHECK
@@ -46,6 +80,70 @@ app.post("/", async (c) => {
   const similarityScore = searchResponse.matches[0]?.score || 0
 
   return c.json({ similarity_score: similarityScore })
+})
+
+app.post("/batch", async (c) => {
+  const raw = await c.req.json<BatchRequest | BatchRequestObjects>()
+
+  const namespace = (raw as any)?.namespace
+  const topK = clampInt((raw as any)?.topK, 1, MAX_TOPK, DEFAULT_TOPK)
+
+  if (!isNonEmptyString(namespace)) {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  let texts: unknown[] | undefined = undefined
+  if (Array.isArray((raw as any)?.texts)) {
+    texts = (raw as any).texts
+  } else if (Array.isArray((raw as any)?.entries)) {
+    texts = (raw as any).entries.map((e: any) => e?.text)
+  }
+
+  if (!texts || !Array.isArray(texts)) {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  if (texts.length === 0) {
+    return c.json({ namespace, topK, results: [] })
+  }
+
+  if (texts.length > MAX_BATCH_SIZE) {
+    return c.text("Batch size too large", 413)
+  }
+
+  const normalizedTexts: string[] = new Array(texts.length)
+  for (let i = 0; i < texts.length; i++) {
+    const t = texts[i]
+    if (typeof t !== "string") {
+      return c.text("Invalid JSON format", 400)
+    }
+    normalizedTexts[i] = t
+  }
+
+  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+    text: normalizedTexts
+  })
+
+  const vectors: unknown[] = Array.isArray((modelResp as any)?.data) ? (modelResp as any).data : []
+  if (vectors.length !== normalizedTexts.length) {
+    return c.text("Upstream embedding error", 502)
+  }
+
+  const queries = vectors.map((vector, i) =>
+    c.env.VECTORIZE_INDEX
+      .query(vector as any, { namespace, topK })
+      .then((searchResponse: any) => {
+        const matches = Array.isArray(searchResponse?.matches) ? searchResponse.matches : []
+        return {
+          index: i,
+          text: normalizedTexts[i],
+          similarity_score: matches[0]?.score || 0
+        }
+      })
+  )
+
+  const results = await Promise.all(queries)
+  return c.json({ namespace, topK, results })
 })
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,6 +3,11 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const VALID_HEADERS = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key"
+}
+
 describe("Authentication", () => {
   it("returns 401 Unauthorized when API key is missing or invalid", async () => {
     const response = await SELF.fetch("https://example.com/", {
@@ -18,5 +23,135 @@ describe("Authentication", () => {
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Single text endpoint", () => {
+  it("returns similarity_score for valid input", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        text: "Sample text",
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json() as any
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("returns 400 for invalid JSON format", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        text: 123,
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+})
+
+describe("Batch endpoint", () => {
+  it("returns per-text results for texts array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        namespace: "test-namespace",
+        texts: ["first text", "second text"]
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json() as any
+    expect(json.namespace).toBe("test-namespace")
+    expect(json.topK).toBe(1)
+    expect(Array.isArray(json.results)).toBe(true)
+    expect(json.results).toHaveLength(2)
+    expect(json.results[0].index).toBe(0)
+    expect(json.results[0].text).toBe("first text")
+    expect(typeof json.results[0].similarity_score).toBe("number")
+    expect(json.results[1].index).toBe(1)
+    expect(json.results[1].text).toBe("second text")
+  })
+
+  it("supports entries array shape", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        namespace: "test-namespace",
+        entries: [{ text: "hello" }, { text: "world" }],
+        topK: 2
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json() as any
+    expect(json.topK).toBe(2)
+    expect(json.results).toHaveLength(2)
+  })
+
+  it("handles empty batch", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        namespace: "test-namespace",
+        texts: []
+      })
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json() as any
+    expect(json.results).toEqual([])
+  })
+
+  it("rejects batch with non-string elements", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        namespace: "test-namespace",
+        texts: ["valid", 123]
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("rejects batch exceeding max size", async () => {
+    const texts = Array.from({ length: 51 }, (_, i) => `text-${i}`)
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        namespace: "test-namespace",
+        texts
+      })
+    })
+
+    expect(response.status).toBe(413)
+    expect(await response.text()).toBe("Batch size too large")
+  })
+
+  it("requires authentication", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        namespace: "test-namespace",
+        texts: ["hello"]
+      })
+    })
+
+    expect(response.status).toBe(401)
   })
 })


### PR DESCRIPTION
# Add Batch Processing Endpoint for Similarity Search API

Addresses #431: Similarity Search API Batch Processing.

## Changes

- Added `POST /batch` endpoint to process multiple texts in a single request
- Single vectorization call via `AI.run` for all texts (native array support)
- Parallel `Vectorize.query` calls via `Promise.all` for concurrent similarity lookups
- Batch size capped at 50 to respect Cloudflare Workers subrequest limits
- Full backward compatibility: existing `POST /` endpoint unchanged

## Request Format

Two input shapes supported:

```json
// Array of strings
{ "namespace": "ns", "texts": ["text1", "text2"], "topK": 1 }

// Array of objects
{ "namespace": "ns", "entries": [{"text": "text1"}, {"text": "text2"}], "topK": 1 }
```

## Response Format

```json
{
  "namespace": "ns",
  "topK": 1,
  "results": [
    { "index": 0, "text": "text1", "similarity_score": 0.87 },
    { "index": 1, "text": "text2", "similarity_score": 0.42 }
  ]
}
```

## Methodology

1. **Single embedding call**: All texts are vectorized in one `AI.run("@cf/baai/bge-base-en-v1.5", { text: [...] })` call, leveraging the model's native batch support
2. **Parallel queries**: Each vector is queried against the Vectorize index concurrently using `Promise.all`, maximizing throughput within Cloudflare Workers' wall-time budget
3. **No new bottlenecks**: No sequential processing, no custom batching logic, no additional dependencies
4. **Safety limits**: `MAX_BATCH_SIZE = 50` enforces the Cloudflare Workers subrequest limit; `topK` is clamped between 1-10

## Input Validation

- Missing/invalid namespace returns 400
- Non-string text elements return 400
- Empty batch returns `{ results: [] }` (200)
- Batch > 50 texts returns 413
- Embedding count mismatch returns 502

## Testing

Added 8 test cases covering:
- Authentication enforcement on batch endpoint
- Valid batch with texts array
- Valid batch with entries array
- Empty batch handling
- Invalid element types
- Batch size limit enforcement
- Single endpoint backward compatibility

## Files Modified

- `tools/similarity_search/src/index.ts` — Added `/batch` endpoint (+98 lines)
- `tools/similarity_search/test/index.spec.ts` — Added batch + single endpoint tests (+135 lines)
