### PR TITLE
feat: add RAG retrieval for Market Health Reporter (#428)

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -79,4 +79,11 @@ Allowed names for illustrations:
 - crypto_metrics.png
 - benford_law.png
 - vv_correlation.png
+
+If additional background context is provided within <context></context> tags, use it to enrich your analysis with relevant historical precedents, token background information, and recent news. This context should help you:
+- Reference prior incidents involving the same exchange or tokens
+- Provide market context (token market cap, trading volume) for more informed analysis
+- Connect findings to broader industry trends or known manipulation patterns
+Do NOT fabricate information — only use context that is explicitly provided.
+
 Place the article into the <article> </article> tags.

--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -5,15 +5,19 @@ import json
 import os
 import requests
 import glob
+import logging
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.rag_retriever import RAGRetriever
 
+logger = logging.getLogger(__name__)
 
 REPO_NAME = "1712n/dn-institute"
 SYSTEM_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/system_prompt.txt'
 HUMAN_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/prompt1.txt'
 ARTICLE_EXAMPLE_FILE = 'content/market-health/posts/2023-08-14-huobi/index.md'
+ARTICLES_DIR = 'content/research/market-health/posts'
 OUTPUT_DIR = 'content/market-health/posts/'
 DATA_DIR = 'tools/market_health_reporter/doc/data/'
 MAX_TOKENS = 125000
@@ -38,6 +42,14 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
+    )
+    parser.add_argument(
+        "--disable-rag", dest="disable_rag", action="store_true",
+        default=False, help="Disable RAG context retrieval"
+    )
+    parser.add_argument(
+        "--disable-web-search", dest="disable_web_search", action="store_true",
+        default=False, help="Disable web search in RAG (use local articles + CoinGecko only)"
     )
     return parser.parse_args()
 
@@ -126,11 +138,19 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, rag_context: str = "") -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, data, and optional RAG context.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    context_block = ""
+    if rag_context:
+        context_block = f"\n<context>\n{rag_context}\n</context>\n"
+    return (
+        f"<example> {article_example} </example>\n"
+        f"{human_prompt_content}\n"
+        f"{context_block}"
+        f"<data> {json.dumps(data)} </data>"
+    )
 
 
 def main():
@@ -142,6 +162,34 @@ def main():
 
     marketvenueid, pairid, start, end = extract_data_from_comment(args.comment_body)
     print(f"Marketvenueid: {marketvenueid}, Pairid: {pairid}, Start: {start}, End: {end}")
+
+    # --- RAG context retrieval ---
+    rag_context = ""
+    if not args.disable_rag:
+        try:
+            # Extract the base token and quote token from the pair id
+            # pairid format is typically "btc-usdt" or "ht-usdt"
+            tokens = [t.upper() for t in pairid.split("-") if t.upper() != "USDT"]
+
+            retriever = RAGRetriever(
+                articles_dir=ARTICLES_DIR,
+                enable_web_search=not args.disable_web_search,
+                enable_coingecko=True,
+            )
+            rag_context = retriever.get_context(
+                exchange=marketvenueid,
+                tokens=tokens,
+                start_date=start,
+                end_date=end,
+            )
+            if rag_context:
+                print(f"RAG context retrieved: {len(rag_context)} characters")
+            else:
+                print("RAG: no additional context found")
+        except Exception as e:
+            logger.warning("RAG retrieval failed (non-fatal): %s", e)
+            print(f"RAG retrieval failed (continuing without context): {e}")
+
     querystring = {
         "marketvenueid": marketvenueid,
         "pairid": pairid,
@@ -160,33 +208,41 @@ def main():
         encoding = encoding_for_model("gpt-4")     
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        prompt = create_prompt(article_example, data, human_prompt_content, rag_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:
-            error_message = "Your request is too long. It's possible that the period for the data is too broad. Please narrow it down."
-            print(error_message)
-            post_comment_to_issue(args.github_token, int(args.issue), REPO_NAME, error_message)
-        else:
-            openai.api_key = args.API_key
-            completion = openai.ChatCompletion.create(
-                model="gpt-4-0125-preview",
-                temperature=0.0,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt}
-                ]
-            )
-            output = completion.choices[0].message.content
-            output = extract_between_tags("article", output)
+            # If prompt is too long due to RAG context, retry without it
+            if rag_context:
+                print("Prompt too long with RAG context — retrying without context")
+                prompt = create_prompt(article_example, data, human_prompt_content)
+                prompt_token_count = len(encoding.encode(prompt))
 
-            print("This is an answer: ", output)
-            save_output(output, OUTPUT_DIR, marketvenueid, pairid, start, end)
-            vis = Visualization()
-            output_subdir = os.path.join(OUTPUT_DIR, f"{start}-{end}-{marketvenueid}-{pairid}") 
-            vis.generate_report(data, output_subdir)  
+            if prompt_token_count > MAX_TOKENS:
+                error_message = "Your request is too long. It's possible that the period for the data is too broad. Please narrow it down."
+                print(error_message)
+                post_comment_to_issue(args.github_token, int(args.issue), REPO_NAME, error_message)
+                return
 
-            post_comment_to_issue(args.github_token, int(args.issue), REPO_NAME, output)
+        openai.api_key = args.API_key
+        completion = openai.ChatCompletion.create(
+            model="gpt-4-0125-preview",
+            temperature=0.0,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt}
+            ]
+        )
+        output = completion.choices[0].message.content
+        output = extract_between_tags("article", output)
+
+        print("This is an answer: ", output)
+        save_output(output, OUTPUT_DIR, marketvenueid, pairid, start, end)
+        vis = Visualization()
+        output_subdir = os.path.join(OUTPUT_DIR, f"{start}-{end}-{marketvenueid}-{pairid}") 
+        vis.generate_report(data, output_subdir)  
+
+        post_comment_to_issue(args.github_token, int(args.issue), REPO_NAME, output)
 
     except Exception as e:
         print(f"Error occurred: {e}")

--- a/tools/market_health_reporter/rag_retriever.py
+++ b/tools/market_health_reporter/rag_retriever.py
@@ -1,0 +1,404 @@
+"""
+RAG (Retrieval Augmented Generation) module for the Market Health Reporter.
+
+Retrieves relevant context from multiple sources to enrich report generation:
+1. Local articles from dn.institute market health posts
+2. CoinGecko public API for token/exchange metadata
+3. DuckDuckGo web search for recent news and context
+"""
+
+import os
+import re
+import json
+import glob
+import logging
+import requests
+from typing import Optional
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+# Default path to existing market health articles (relative to repo root)
+DEFAULT_ARTICLES_DIR = "content/research/market-health/posts"
+
+# CoinGecko free API base URL (no API key required)
+COINGECKO_API_BASE = "https://api.coingecko.com/api/v3"
+
+# Maximum snippet length for local article excerpts
+MAX_SNIPPET_LENGTH = 800
+
+# Maximum number of web search results to include
+MAX_WEB_RESULTS = 5
+
+
+class RAGRetriever:
+    """
+    Retrieval-Augmented Generation context builder for market health reports.
+
+    Searches local articles, public crypto APIs, and the web to gather
+    background context that is injected into the LLM prompt before
+    report generation.
+    """
+
+    def __init__(
+        self,
+        articles_dir: str = DEFAULT_ARTICLES_DIR,
+        enable_web_search: bool = True,
+        enable_coingecko: bool = True,
+    ):
+        self.articles_dir = articles_dir
+        self.enable_web_search = enable_web_search
+        self.enable_coingecko = enable_coingecko
+
+    # ------------------------------------------------------------------
+    # 1. Local article search
+    # ------------------------------------------------------------------
+
+    def search_local_articles(self, entity: str, limit: int = 3) -> list[dict]:
+        """
+        Search existing dn.institute market-health articles that mention
+        the given entity (exchange name, token symbol, etc.).
+
+        Returns a list of dicts with keys: source, title, date, snippet.
+        """
+        results = []
+        pattern = os.path.join(self.articles_dir, "*/index.md")
+        for path in sorted(glob.glob(pattern)):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    content = f.read()
+            except OSError as exc:
+                logger.warning("Could not read %s: %s", path, exc)
+                continue
+
+            if entity.lower() not in content.lower():
+                continue
+
+            # Extract front-matter metadata
+            title = self._extract_front_matter_field(content, "title") or os.path.basename(os.path.dirname(path))
+            date = self._extract_front_matter_field(content, "date") or ""
+
+            # Build a contextual snippet: grab paragraphs mentioning the entity
+            snippet = self._extract_relevant_snippet(content, entity)
+
+            results.append(
+                {
+                    "source": path,
+                    "title": title,
+                    "date": date,
+                    "snippet": snippet,
+                }
+            )
+
+            if len(results) >= limit:
+                break
+
+        logger.info("Local article search for '%s': %d result(s)", entity, len(results))
+        return results
+
+    # ------------------------------------------------------------------
+    # 2. CoinGecko public API
+    # ------------------------------------------------------------------
+
+    def fetch_coingecko_info(self, token_symbol: str) -> Optional[dict]:
+        """
+        Fetch basic information about a token from the CoinGecko free API.
+        Returns a dict with name, symbol, description snippet, market_cap_rank,
+        and current price — or None on failure.
+        """
+        if not self.enable_coingecko:
+            return None
+
+        try:
+            # Step 1: search for the coin id by symbol
+            search_url = f"{COINGECKO_API_BASE}/search"
+            resp = requests.get(
+                search_url,
+                params={"query": token_symbol},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            coins = resp.json().get("coins", [])
+
+            if not coins:
+                logger.info("CoinGecko: no results for symbol '%s'", token_symbol)
+                return None
+
+            # Pick the best match (prefer exact symbol match)
+            coin = next(
+                (c for c in coins if c.get("symbol", "").lower() == token_symbol.lower()),
+                coins[0],
+            )
+            coin_id = coin.get("id")
+            if not coin_id:
+                return None
+
+            # Step 2: get coin details
+            detail_url = f"{COINGECKO_API_BASE}/coins/{coin_id}"
+            resp = requests.get(
+                detail_url,
+                params={
+                    "localization": "false",
+                    "tickers": "false",
+                    "market_data": "true",
+                    "community_data": "false",
+                    "developer_data": "false",
+                },
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            description_en = (data.get("description", {}).get("en") or "")[:600]
+            # Strip HTML tags from CoinGecko descriptions
+            description_en = re.sub(r"<[^>]+>", "", description_en)
+
+            market_data = data.get("market_data", {})
+            return {
+                "name": data.get("name", ""),
+                "symbol": data.get("symbol", ""),
+                "description": description_en,
+                "market_cap_rank": data.get("market_cap_rank"),
+                "current_price_usd": (
+                    market_data.get("current_price", {}).get("usd")
+                ),
+                "total_volume_usd": (
+                    market_data.get("total_volume", {}).get("usd")
+                ),
+            }
+
+        except requests.RequestException as exc:
+            logger.warning("CoinGecko API error for '%s': %s", token_symbol, exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # 3. Web search via DuckDuckGo
+    # ------------------------------------------------------------------
+
+    def search_web(self, query: str, limit: int = MAX_WEB_RESULTS) -> list[dict]:
+        """
+        Run a web search using the duckduckgo-search library
+        (already a project dependency).
+
+        Returns a list of dicts with keys: title, url, snippet.
+        """
+        if not self.enable_web_search:
+            return []
+
+        try:
+            from duckduckgo_search import ddg  # type: ignore
+        except ImportError:
+            # duckduckgo-search >= 4.0 changed the API
+            try:
+                from duckduckgo_search import DDGS  # type: ignore
+
+                return self._search_with_ddgs(query, limit)
+            except ImportError:
+                logger.warning("duckduckgo-search library not available — skipping web search")
+                return []
+
+        try:
+            raw_results = ddg(query, max_results=limit) or []
+            return [
+                {
+                    "title": r.get("title", ""),
+                    "url": r.get("href", r.get("link", "")),
+                    "snippet": r.get("body", r.get("snippet", "")),
+                }
+                for r in raw_results[:limit]
+            ]
+        except Exception as exc:
+            logger.warning("DuckDuckGo search failed: %s", exc)
+            return []
+
+    def _search_with_ddgs(self, query: str, limit: int) -> list[dict]:
+        """Fallback for duckduckgo-search >= 4.x which uses the DDGS class."""
+        try:
+            from duckduckgo_search import DDGS  # type: ignore
+
+            with DDGS() as ddgs:
+                raw_results = list(ddgs.text(query, max_results=limit))
+            return [
+                {
+                    "title": r.get("title", ""),
+                    "url": r.get("href", r.get("link", "")),
+                    "snippet": r.get("body", r.get("snippet", "")),
+                }
+                for r in raw_results[:limit]
+            ]
+        except Exception as exc:
+            logger.warning("DDGS search failed: %s", exc)
+            return []
+
+    # ------------------------------------------------------------------
+    # 4. Context builder  — main entry point
+    # ------------------------------------------------------------------
+
+    def get_context(
+        self,
+        exchange: str,
+        tokens: list[str],
+        start_date: str = "",
+        end_date: str = "",
+    ) -> str:
+        """
+        Build a combined context string for the LLM prompt.
+
+        Parameters
+        ----------
+        exchange : str
+            Name of the exchange being analysed (e.g. "huobi").
+        tokens : list[str]
+            Token symbols involved in the analysis (e.g. ["HT", "TRX"]).
+        start_date / end_date : str
+            Analysis period (used to refine web searches).
+
+        Returns
+        -------
+        str
+            Formatted context block ready to be injected into the prompt.
+            Returns an empty string if no context was found.
+        """
+        sections: list[str] = []
+
+        # --- Local articles ---
+        local_results = self.search_local_articles(exchange)
+        for token in tokens:
+            local_results.extend(self.search_local_articles(token))
+
+        # Deduplicate by source path
+        seen_sources: set[str] = set()
+        unique_local: list[dict] = []
+        for item in local_results:
+            if item["source"] not in seen_sources:
+                seen_sources.add(item["source"])
+                unique_local.append(item)
+
+        if unique_local:
+            parts = []
+            for item in unique_local[:5]:
+                parts.append(
+                    f"### {item['title']} ({item['date']})\n"
+                    f"Source: {item['source']}\n"
+                    f"{item['snippet']}"
+                )
+            sections.append(
+                "## Existing dn.institute Articles\n" + "\n\n".join(parts)
+            )
+
+        # --- CoinGecko token info ---
+        cg_parts = []
+        for token in tokens:
+            info = self.fetch_coingecko_info(token)
+            if info:
+                cg_parts.append(
+                    f"### {info['name']} ({info['symbol'].upper()})\n"
+                    f"Market Cap Rank: {info.get('market_cap_rank', 'N/A')}\n"
+                    f"Current Price (USD): {info.get('current_price_usd', 'N/A')}\n"
+                    f"24h Volume (USD): {info.get('total_volume_usd', 'N/A')}\n"
+                    f"Description: {info.get('description', 'N/A')}"
+                )
+        if cg_parts:
+            sections.append(
+                "## Token Information (CoinGecko)\n" + "\n\n".join(cg_parts)
+            )
+
+        # --- Web search ---
+        date_range = ""
+        if start_date and end_date:
+            date_range = f" {start_date} to {end_date}"
+
+        web_query = f"{exchange} cryptocurrency wash trading market manipulation{date_range}"
+        web_results = self.search_web(web_query, limit=MAX_WEB_RESULTS)
+
+        # Also search for each token
+        for token in tokens[:3]:  # limit to avoid too many searches
+            token_results = self.search_web(
+                f"{token} {exchange} trading anomaly", limit=2
+            )
+            web_results.extend(token_results)
+
+        if web_results:
+            parts = []
+            seen_urls: set[str] = set()
+            for item in web_results:
+                url = item.get("url", "")
+                if url in seen_urls:
+                    continue
+                seen_urls.add(url)
+                parts.append(
+                    f"- **{item['title']}**\n"
+                    f"  URL: {url}\n"
+                    f"  {item['snippet']}"
+                )
+            sections.append(
+                "## Recent Web Results\n" + "\n".join(parts[:MAX_WEB_RESULTS])
+            )
+
+        if not sections:
+            logger.info("RAG retriever: no context found for %s / %s", exchange, tokens)
+            return ""
+
+        context = (
+            f"# Background Context (auto-retrieved on {datetime.utcnow().strftime('%Y-%m-%d')})\n\n"
+            + "\n\n".join(sections)
+        )
+        logger.info(
+            "RAG context built: %d section(s), %d chars",
+            len(sections),
+            len(context),
+        )
+        return context
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_front_matter_field(content: str, field: str) -> Optional[str]:
+        """Extract a field value from YAML front matter."""
+        match = re.search(
+            r"^---\s*\n(.*?)\n---", content, re.DOTALL
+        )
+        if not match:
+            return None
+        front_matter = match.group(1)
+        # Simple single-line field extraction
+        field_match = re.search(
+            rf'^{field}:\s*["\']?(.+?)["\']?\s*$',
+            front_matter,
+            re.MULTILINE,
+        )
+        return field_match.group(1) if field_match else None
+
+    @staticmethod
+    def _extract_relevant_snippet(content: str, entity: str, max_length: int = MAX_SNIPPET_LENGTH) -> str:
+        """
+        Extract the most relevant paragraphs from an article that mention
+        the entity, up to max_length characters.
+        """
+        # Remove front matter
+        content = re.sub(r"^---\s*\n.*?\n---\s*\n", "", content, flags=re.DOTALL)
+
+        paragraphs = re.split(r"\n\s*\n", content)
+        relevant: list[str] = []
+        total = 0
+
+        for para in paragraphs:
+            if entity.lower() in para.lower():
+                # Skip Hugo shortcodes that are just image references
+                if para.strip().startswith("{{<"):
+                    continue
+                relevant.append(para.strip())
+                total += len(para)
+                if total >= max_length:
+                    break
+
+        if not relevant:
+            # Fallback: return the summary section or first paragraphs
+            for para in paragraphs[:3]:
+                if para.strip() and not para.strip().startswith("{{<"):
+                    relevant.append(para.strip())
+
+        snippet = "\n\n".join(relevant)
+        return snippet[:max_length]

--- a/tools/market_health_reporter/tests/__init__.py
+++ b/tools/market_health_reporter/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tools/market_health_reporter/tests/test_rag_retriever.py
+++ b/tools/market_health_reporter/tests/test_rag_retriever.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for the RAG retriever module.
+"""
+
+import os
+import tempfile
+import shutil
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.market_health_reporter.rag_retriever import RAGRetriever
+
+
+@pytest.fixture
+def sample_articles_dir():
+    """Create a temporary directory with sample article files."""
+    tmpdir = tempfile.mkdtemp()
+
+    # Create sample article 1
+    article1_dir = os.path.join(tmpdir, "2023-08-14-huobi")
+    os.makedirs(article1_dir)
+    with open(os.path.join(article1_dir, "index.md"), "w") as f:
+        f.write(
+            '---\n'
+            'title: "Uncovering Wash Trading on Huobi"\n'
+            'date: 2023-08-14\n'
+            '---\n\n'
+            '## Summary\n\n'
+            'Recent data reveals a surge in manipulative practices on Huobi.\n\n'
+            'HT and TRX tokens were subject to manipulation.\n'
+        )
+
+    # Create sample article 2
+    article2_dir = os.path.join(tmpdir, "2021-01-19-Gate-io")
+    os.makedirs(article2_dir)
+    with open(os.path.join(article2_dir, "index.md"), "w") as f:
+        f.write(
+            '---\n'
+            'title: "Gate.io Market Analysis"\n'
+            'date: 2021-01-19\n'
+            '---\n\n'
+            '## Summary\n\n'
+            'Analysis of Gate.io trading patterns.\n'
+        )
+
+    yield tmpdir
+    shutil.rmtree(tmpdir)
+
+
+class TestSearchLocalArticles:
+    """Tests for local article search functionality."""
+
+    def test_finds_matching_articles(self, sample_articles_dir):
+        retriever = RAGRetriever(articles_dir=sample_articles_dir)
+        results = retriever.search_local_articles("huobi")
+        assert len(results) == 1
+        assert "Huobi" in results[0]["title"]
+        assert "2023-08-14" in results[0]["date"]
+
+    def test_case_insensitive_search(self, sample_articles_dir):
+        retriever = RAGRetriever(articles_dir=sample_articles_dir)
+        results = retriever.search_local_articles("HUOBI")
+        assert len(results) == 1
+
+    def test_no_results_for_unknown_entity(self, sample_articles_dir):
+        retriever = RAGRetriever(articles_dir=sample_articles_dir)
+        results = retriever.search_local_articles("binance")
+        assert len(results) == 0
+
+    def test_limit_results(self, sample_articles_dir):
+        retriever = RAGRetriever(articles_dir=sample_articles_dir)
+        results = retriever.search_local_articles("trading", limit=1)
+        assert len(results) <= 1
+
+    def test_finds_token_mention(self, sample_articles_dir):
+        retriever = RAGRetriever(articles_dir=sample_articles_dir)
+        results = retriever.search_local_articles("HT")
+        assert len(results) == 1
+
+
+class TestExtractFrontMatter:
+    """Tests for YAML front matter extraction."""
+
+    def test_extracts_title(self):
+        content = '---\ntitle: "Test Title"\ndate: 2023-01-01\n---\nBody'
+        result = RAGRetriever._extract_front_matter_field(content, "title")
+        assert result == "Test Title"
+
+    def test_extracts_date(self):
+        content = '---\ntitle: "Test"\ndate: 2023-08-14\n---\nBody'
+        result = RAGRetriever._extract_front_matter_field(content, "date")
+        assert result == "2023-08-14"
+
+    def test_returns_none_for_missing_field(self):
+        content = '---\ntitle: "Test"\n---\nBody'
+        result = RAGRetriever._extract_front_matter_field(content, "author")
+        assert result is None
+
+    def test_returns_none_without_front_matter(self):
+        content = "No front matter here"
+        result = RAGRetriever._extract_front_matter_field(content, "title")
+        assert result is None
+
+
+class TestExtractRelevantSnippet:
+    """Tests for relevant snippet extraction."""
+
+    def test_extracts_relevant_paragraphs(self):
+        content = (
+            '---\ntitle: "Test"\n---\n\n'
+            'First paragraph about Huobi trading.\n\n'
+            'Second paragraph about something else.\n\n'
+            'Third paragraph mentioning Huobi again.\n'
+        )
+        snippet = RAGRetriever._extract_relevant_snippet(content, "Huobi")
+        assert "Huobi" in snippet
+
+    def test_respects_max_length(self):
+        content = '---\ntitle: "T"\n---\n\n' + "Huobi " * 500
+        snippet = RAGRetriever._extract_relevant_snippet(content, "Huobi", max_length=100)
+        assert len(snippet) <= 100
+
+    def test_skips_hugo_shortcodes(self):
+        content = (
+            '---\ntitle: "T"\n---\n\n'
+            '{{< figure src="test.png" alt="Huobi chart" >}}\n\n'
+            'Real paragraph about Huobi.\n'
+        )
+        snippet = RAGRetriever._extract_relevant_snippet(content, "Huobi")
+        assert "figure" not in snippet
+
+
+class TestFetchCoinGeckoInfo:
+    """Tests for CoinGecko API integration."""
+
+    @patch("tools.market_health_reporter.rag_retriever.requests.get")
+    def test_successful_fetch(self, mock_get):
+        # Mock search response
+        search_response = MagicMock()
+        search_response.status_code = 200
+        search_response.raise_for_status = MagicMock()
+        search_response.json.return_value = {
+            "coins": [{"id": "bitcoin", "symbol": "btc", "name": "Bitcoin"}]
+        }
+
+        # Mock detail response
+        detail_response = MagicMock()
+        detail_response.status_code = 200
+        detail_response.raise_for_status = MagicMock()
+        detail_response.json.return_value = {
+            "name": "Bitcoin",
+            "symbol": "btc",
+            "description": {"en": "Bitcoin is a cryptocurrency."},
+            "market_cap_rank": 1,
+            "market_data": {
+                "current_price": {"usd": 50000},
+                "total_volume": {"usd": 30000000000},
+            },
+        }
+
+        mock_get.side_effect = [search_response, detail_response]
+
+        retriever = RAGRetriever(enable_web_search=False)
+        info = retriever.fetch_coingecko_info("btc")
+
+        assert info is not None
+        assert info["name"] == "Bitcoin"
+        assert info["current_price_usd"] == 50000
+
+    @patch("tools.market_health_reporter.rag_retriever.requests.get")
+    def test_returns_none_on_api_error(self, mock_get):
+        mock_get.side_effect = Exception("API error")
+        retriever = RAGRetriever(enable_web_search=False)
+        info = retriever.fetch_coingecko_info("btc")
+        assert info is None
+
+    def test_disabled_returns_none(self):
+        retriever = RAGRetriever(enable_coingecko=False)
+        info = retriever.fetch_coingecko_info("btc")
+        assert info is None
+
+
+class TestGetContext:
+    """Tests for the main context builder."""
+
+    def test_returns_string(self, sample_articles_dir):
+        retriever = RAGRetriever(
+            articles_dir=sample_articles_dir,
+            enable_web_search=False,
+            enable_coingecko=False,
+        )
+        context = retriever.get_context(exchange="huobi", tokens=["HT"])
+        assert isinstance(context, str)
+        assert "Background Context" in context
+
+    def test_empty_when_no_matches(self, sample_articles_dir):
+        retriever = RAGRetriever(
+            articles_dir=sample_articles_dir,
+            enable_web_search=False,
+            enable_coingecko=False,
+        )
+        context = retriever.get_context(exchange="nonexistent", tokens=["XYZ"])
+        assert context == ""
+
+    def test_includes_local_articles(self, sample_articles_dir):
+        retriever = RAGRetriever(
+            articles_dir=sample_articles_dir,
+            enable_web_search=False,
+            enable_coingecko=False,
+        )
+        context = retriever.get_context(exchange="huobi", tokens=["HT", "TRX"])
+        assert "dn.institute Articles" in context
+        assert "Huobi" in context


### PR DESCRIPTION
## Summary

Addresses #428

This PR adds **Retrieval Augmented Generation (RAG)** functionality to the Market Health Reporter, enriching generated reports with background context from multiple sources.

## What Changed

### New: `rag_retriever.py`
A standalone RAG module with three data sources (ordered by priority):

1. **Local article search** — scans existing `content/research/market-health/posts/` for articles mentioning the exchange or tokens being analyzed. Extracts relevant snippets with front-matter metadata (title, date).

2. **CoinGecko public API** — fetches token metadata (name, market cap rank, current price, 24h volume, description) for each token in the trading pair. No API key required.

3. **DuckDuckGo web search** — searches for recent news about the exchange and tokens to provide current market context. Uses the `duckduckgo-search` library already in the project dependencies.

### Modified: `market_health_reporter.py`
- Integrated RAG retrieval before LLM prompt construction
- Extracts token symbols from the pair ID (e.g., `ht-usdt` → `["HT"]`)
- Passes retrieved context into the prompt via `<context>` XML tags
- **Graceful fallback**: if RAG context makes the prompt exceed the token limit, automatically retries without context
- **Non-fatal errors**: RAG failures are caught and logged; report generation continues normally
- New CLI flags: `--disable-rag` and `--disable-web-search` for fine control

### Modified: `prompt1.txt`
Added instructions for the LLM to use `<context>` tags to:
- Reference prior incidents involving the same exchange or tokens
- Provide market context (market cap, volume) for informed analysis
- Connect findings to broader industry trends
- Explicit instruction to NOT fabricate information

### New: Unit Tests
Comprehensive test suite in `tests/test_rag_retriever.py` covering:
- Local article search (matching, case-insensitivity, limits)
- Front-matter extraction
- Snippet extraction with Hugo shortcode filtering
- CoinGecko API integration (mocked)
- Context builder end-to-end

## Design Decisions

- **No new dependencies**: uses `requests` (already in deps) for CoinGecko and `duckduckgo-search` (already in pyproject.toml)
- **Token-aware**: automatically strips quote currency (USDT) from pair ID to get relevant tokens
- **Deduplication**: both local and web results are deduplicated
- **Defensive**: all external calls are wrapped in try/except; the reporter works exactly as before if RAG fails

## How to Test

```bash
# Run with RAG (default behavior)
python -m tools.market_health_reporter.market_health_reporter --llm-api-key <key> ...

# Run without RAG (original behavior)  
python -m tools.market_health_reporter.market_health_reporter --disable-rag --llm-api-key <key> ...

# Run unit tests
pytest tools/market_health_reporter/tests/test_rag_retriever.py -v
```

**Bounty payout:** challenge.bounties@dn.institute