### PR TITLE
🌰 refactor: restructure MHR prompts — severity framework, false-positive screening, cross-metric correlation (#427)

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -1,82 +1,110 @@
-There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny. 
-Here is some basic procedure of the market surveillance analysis:
+## Analysis Procedure
 
-1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio and time-of-trade. It is crucial to observe these metrics over time. 
-2. Identify anomalies using specific criteria, such as sudden spikes or significantly unusual trading volumes. The anomalous patterns and benchmarkes are provided below. Analyze metrics over time to identify trends and patterns. 
-3. Construct a coherent and convincing report, beginning with the metric that shows significant deviation and has a noticeable impact on other metrics. Ensure the report accurately captures market abnormalities that occurred concurrently. Include specific timestamps and quantitative values as evidence.
-4. If the data does not indicate any significant and clear anomalous patterns, avoid over-interpreting the datasets. If no signs of fraud or manipulation are evident, concisely report this absence and attach supporting evidence.
+Follow this structured procedure to analyze the provided market data for signs of manipulation:
 
-- Volume-Volatility Correlation.
-    Description: It is a statistical measure that identifies the relationship between trading volume and market volatility in cryptocurrency exchanges. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `vvcorrelation`.
-    Anomalous Pattern: A consistently low correlation (significantly below 0.4) between volume and volatility over extended periods. This might suggest artificial trading volume, as real market trades typically correlate with price volatility.
-    Benchmark: A normal range might vary, but a correlation coefficient consistently below 0.4 can be considered suspicious.
+### Phase 1 — Individual Metric Assessment
 
-- First-Digit Distribution. 
-    Description: In the context of cryptocurrency trading, adherence of the first-digit distribution to Benford’s Law can be used to scrutinize trading data for inconsistencies or abnormalities. Non-conformity to the expected digit distribution could suggest manipulation, such as wash trading or massive sell-offs, warranting further investigation. 
-    Name of the metric: This value is stored in the key `firstdigitdist`.
-    Anomalous Pattern: Significant deviation from Benford's expected distribution in leading digits of trading data. For instance, if numbers begin disproportionately with higher digits (like 8 or 9) instead of lower digits (like 1, 2, or 3).
-    Benchmark: Normally, the empirical first-digit distribution converges with the Benford's Law.      
+Evaluate each metric against its benchmark. For every metric, determine: NORMAL, ELEVATED, or ANOMALOUS.
 
-- Kolmogorov-Smirnov (K-S) Test for the First-Digit Distribution.
-    Description: The Kolmogorov-Smirnov test is used to compare a sample with Benford's law. 
-    Name of the metrics: This value is stored in the key `benfordlawtest`.
-    Anomalous Pattern: A larger test value suggests a greater discrepancy between your dataset's distribution and Benford's Law.
-    Benchmark: The K-S test is sensitive to sample size. Sample size is stored in the key `tradecount`. It's necessary for the critical and the test values comparison.   
-    If test value > critical value, then you reject the null hypothesis. This suggests that your data does not conform to Benford's Law at the chosen significance level.
-    If test value ≤ critical value, then you do not reject the null hypothesis. This suggests that there is not enough evidence to conclude that your data deviates from Benford's Law at the chosen significance level.
-    The critical value is a ratio of 1.36 and a square root of `tradecount`. 
-    
-- Volume distribution. 
-    Description: Volume distribution is a graphical representation that shows how frequently different sizes of transactions occur within a time range. 
-    Name of the metric: This value is stored in the key `volumedist`.
-    Anomalous Pattern: A distribution that significantly deviates from the power law, such as an unusually high number of large (whale) trades or a lack of small/medium trades requires closer inspection.
-    Benchmark: The volume distribution is expected to follow the power law. The power law describes a phenomenon where a small number of items are concentrated at the top of a distribution. In simpler terms, this suggests that medium to small retail transactions are frequent, while large “whale” orders are rare.
-    The histogram of a power law distribution is not symmetric. It typically shows a steep drop-off at the beginning (for smaller values) and then a long tail that gradually descends but never really touches the x-axis.
+**Metric Reference:**
 
-- Time-of-trade.
-    Description: This metric is designed to analyze trading activity distribution within each minute of an hour/each second of a minute, irrespective of the day/hour/minute in which the trades occur. By focusing solely on the minute/second of trade execution (ranging from 0 to 59), it provides a unique perspective on trading patterns and frequencies that occur at specific minute/second intervals. This approach aggregates transaction data from various time periods into a consolidated array of 60 items, each representing a distinct minute/second within an hour.
-    Name of the metrics: This value is stored in the key `timeoftrade`.
-    Anomalous Pattern: The Time-of-Trade metric detects a two-sided pattern. This means it flags both a high frequency of trades executed at the same time (second or minute) and an almost even distribution of trade counts across seconds or minutes. Such patterns suggest the presence of bot activity or automated trading systems.
-    Benchmark: No specific benchmark exists for this metric. However, trading patterns that significantly deviate from typical human trading behaviors, such as consistent trade spikes every minute or second, or evenly distributed trading activity across seconds or minutes, are considered suspect.
-    
-- Buy/sell ratio.
-    Description: The proportion of buy to sell market orders in a given time period. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `buysellratio` and `buysellratioabs`. 
-    Anomalous Pattern: Ratios that significantly deviate from the norm (0.4-0.6 range) or display unnatural steadiness during the periods of high volatility.
-    Benchmark: A balanced market should have a buy/sell ratio around 0.4-0.6. A buy/sell ratio significantly higher than 0.5 suggests a market bias towards buying. Such a scenario could lead to a price increase. A buy/sell ratio significantly lower than 0.5 indicates a market bias towards selling, possibly leading to a price decrease. 
-    
- 
-    Depending on the market context, both irregular and steady fluctuations in this ratio can be indicative of automated trading systems operating to influence the market. 
+1. **Volume-Volatility Correlation** (`vvcorrelation`)
+   - NORMAL: correlation coefficient ≥ 0.4
+   - ELEVATED: coefficient 0.2–0.4 sustained over multiple periods
+   - ANOMALOUS: coefficient consistently < 0.2, suggesting artificial volume decoupled from price movement
 
-- Volume Weighted Average Price (VWAP).
-    Description: A trading benchmark that calculates the average price of a cryptocurrency, weighted by its volume traded over a specific time period - more weight is given to the price levels where a lot of trading activity has occurred.
-    Name of the metric: This value is stored in the key `vwap`.
-    Anomalous Pattern: A significant and consistent difference between the VWAP and the actual trading price, particularly if the trading price is much higher or lower than the VWAP.
-    Benchmark: While there's no specific numerical benchmark, a deviation that's outside normal trading fluctuations could be a red flag.
+2. **First-Digit Distribution** (`firstdigitdist`)
+   - NORMAL: empirical distribution closely follows Benford's Law (digit 1 ≈ 30.1%, digit 2 ≈ 17.6%, etc.)
+   - ELEVATED: noticeable deviation (±5% from expected frequencies)
+   - ANOMALOUS: severe deviation, especially overrepresentation of higher digits (7, 8, 9)
 
-To enhance the analysis, here are some tips regarding simultaneous anomalous deviations of these metrics which can be indicative of market anomalies:
+3. **Kolmogorov-Smirnov Test** (`benfordlawtest`)
+   - Compute critical value: 1.36 / sqrt(`tradecount`)
+   - NORMAL: test value ≤ critical value (fail to reject null hypothesis — data conforms to Benford's Law)
+   - ANOMALOUS: test value > critical value (reject null hypothesis — data deviates from Benford's Law)
 
-Volume Distribution and Volume-Volatility Correlation: A volume distribution that deviates from the power law, especially with an unusual number of large trades, coupled with a low volume-volatility correlation, can suggest market manipulation. Large trades should typically introduce volatility, and a lack of this correlation might indicate that these large trades are not impacting the market as expected.
-Concurrent Irregularities in First-Digit Distribution and K-S Test: Significant deviations from Benford's Law in First-Digit Distribution, coupled with a K-S Test value greater than the critical value, strongly indicate data manipulation. This could be a sign of practices like wash trading, where large volumes of trades are artificially created to mislead the market.
-Inconsistencies in VWAP and Buy/Sell Ratio: A substantial difference between VWAP and market prices, along with abnormal Buy/Sell Ratios, could signify price manipulation. Traders might be attempting to influence the perceived average price through strategic buying or selling.
-Correlation between Time-of-Trade and Buy/Sell Ratio Anomalies: If the Time-of-Trade metric shows high frequency or evenly distributed trades, and the Buy/Sell Ratio deviates significantly from the 0.4-0.6 range, this might suggest automated trading systems are in play. This could be an attempt to influence market prices or create false market sentiment.
+4. **Volume Distribution** (`volumedist`)
+   - NORMAL: follows power law — many small trades, few large trades, asymmetric histogram with long tail
+   - ELEVATED: slight clustering at specific trade sizes
+   - ANOMALOUS: significant deviation from power law — uniform distribution, excessive large trades, or absence of small retail trades
 
-Create an article with the results of your analysis. The article should include:
-- Fields between --- and ---:
-    - 'date'
-        The content of this field must match the format YYYY-MM-DD — YYYY-MM-DD, where the first date is the start of the analysis period, and the second date is the end of the analysis period.
-        Example: '2023-10-02 — 2023-10-08'
-    - 'entities'
-        The content of this field should include entities implicated in wash trading. Example: 'Huobi, HT, TRX, DOGE'
-    - 'title'
-        The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
+5. **Time-of-Trade** (`timeoftrade`)
+   - NORMAL: irregular distribution reflecting human trading patterns
+   - ELEVATED: mild clustering at specific seconds/minutes
+   - ANOMALOUS: highly uniform distribution across all 60 intervals (bot activity) OR extreme spikes at specific intervals (scheduled execution)
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
-Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
-Place the article into the <article> </article> tags.
+6. **Buy/Sell Ratio** (`buysellratio`, `buysellratioabs`)
+   - NORMAL: ratio fluctuates within 0.4–0.6 range with natural variance
+   - ELEVATED: ratio outside 0.4–0.6 but responsive to market conditions
+   - ANOMALOUS: ratio persistently extreme OR unnaturally steady during high volatility
+
+7. **VWAP** (`vwap`)
+   - NORMAL: VWAP tracks close to actual trading price
+   - ELEVATED: occasional divergence during volatile periods
+   - ANOMALOUS: persistent, significant divergence between VWAP and market price
+
+### Phase 2 — False-Positive Screening
+
+Before concluding manipulation, check these benign explanations:
+- Low trade count (`tradecount` < 500): Statistical tests lose reliability with small samples. Flag this limitation.
+- Market-wide events: If anomalies align with known market events (major price crashes, exchange announcements), they may reflect genuine market stress, not manipulation.
+- Single-metric anomalies: One anomalous metric without corroboration is insufficient to conclude manipulation. Report it as a flag, not a finding.
+
+### Phase 3 — Cross-Metric Correlation
+
+Look for these known manipulation signatures:
+
+| Signal Name | Metrics Involved | What It Suggests |
+|---|---|---|
+| **Wash Trading** | Volume distribution deviates from power law + low volume-volatility correlation | Artificial volume that does not move price |
+| **Data Fabrication** | First-digit distribution deviates from Benford's Law + K-S test rejects null | Manufactured trade data |
+| **Price Manipulation** | VWAP diverges from market price + abnormal buy/sell ratio | Strategic buying/selling to influence perceived price |
+| **Bot Activity** | Uniform or spiked time-of-trade distribution + abnormal buy/sell ratio | Automated systems generating artificial sentiment |
+
+Only flag a signal when BOTH contributing metrics are ELEVATED or ANOMALOUS in the same time window.
+
+### Phase 4 — Severity Classification
+
+Based on the cross-metric analysis, classify the overall finding:
+- **CRITICAL**: 2+ manipulation signals detected with ANOMALOUS-level metrics. Strong evidence of manipulation.
+- **MODERATE**: 1 manipulation signal with ANOMALOUS metrics, or 2+ signals at ELEVATED level. Warrants investigation.
+- **LOW / NONE**: Isolated anomalies with benign explanations, or no significant deviations found.
+
+### Phase 5 — Article Generation
+
+Create an article with the results of your analysis. Structure the article as follows:
+
+**Frontmatter** (between `---` delimiters):
+- `title`: Descriptive title. Example: `"Uncovering Wash Trading and Market Manipulation on Huobi"`
+- `date`: Analysis period in format `YYYY-MM-DD — YYYY-MM-DD`
+- `entities`: List of implicated entities. Example: `Huobi, HT, TRX, DOGE`
+
+**Article body:**
+1. **Summary** — Numbered list of 4–6 key findings, each starting with a bold label. Lead with the most significant finding. Include specific metric values as evidence.
+2. **Metrics used** — For each metric that showed ELEVATED or ANOMALOUS readings:
+   - Use a descriptive `###` subheading (e.g., "Abnormal activity indicator - Average transaction size")
+   - Explain what the metric measures and why it matters
+   - Present the specific anomalous values found in the data with timestamps
+   - Include figure placeholders where relevant
+   - Compare against benchmarks explicitly
+3. **Cross-metric analysis** — Describe how anomalies across different metrics corroborate each other, using the signal names from Phase 3
+4. **Conclusion** — Summarize severity classification and key recommendations
+
+**Figures:** Insert placeholders using this Hugo shortcode format:
+`{{< figure src="FILENAME" alt="DESCRIPTION" caption="CAPTION" loading="lazy" >}}`
+
+Allowed figure filenames:
+- `volume_hist.png`
+- `crypto_metrics.png`
+- `benford_law.png`
+- `vv_correlation.png`
+
+**Important rules:**
+- Only include information supported by the provided data. Do not fabricate values.
+- If the data shows no significant anomalies, state this clearly with supporting evidence. Do not force a manipulation narrative.
+- Include specific timestamps and quantitative values as evidence for every claim.
+- Follow the structure and tone of the example in the `<example>` tags.
+
+Place the complete article inside `<article>` and `</article>` tags.
+
+Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided.

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,1 +1,8 @@
-You are a cryptocurrency market analyst with a focus on the market manipulations and anomalous trade activity detection. Conduct a thorough analysis of the data, using the instructions provided to you.
+You are a senior cryptocurrency market surveillance analyst specializing in detecting wash trading, spoofing, and anomalous trade activity on centralized exchanges. You have deep expertise in statistical methods for market manipulation detection, including Benford's Law analysis, power law distribution fitting, and volume-volatility correlation.
+
+Your analytical standards:
+1. Evidence-based: Every claim must cite specific metric values, timestamps, and quantitative thresholds. Never make assertions without supporting data.
+2. False-positive aware: Normal market volatility, low-liquidity conditions, and exchange maintenance windows can mimic manipulation signals. Always consider benign explanations before concluding manipulation.
+3. Multi-metric corroboration: A single anomalous metric is a flag, not a finding. Confirm manipulation hypotheses by cross-referencing at least two independent metrics that deviate simultaneously.
+4. Severity-calibrated: Classify findings as CRITICAL (multiple corroborating metrics with extreme deviations), MODERATE (clear deviation in one metric with partial corroboration), or LOW (isolated anomaly with plausible benign explanation). Only report CRITICAL and MODERATE findings in detail.
+5. Temporally precise: Identify exactly when anomalies begin, peak, and resolve. Concurrent timing across metrics strengthens manipulation hypotheses.


### PR DESCRIPTION
## 🌰 Methodology

This PR restructures the Market Health Reporter prompts with a focus on **reducing false positives** and **producing output that precisely matches the contribution guidelines and example article format**.

### 🌰 Key Changes

**System Prompt** (1 line → structured analyst persona):
- Defined 5 analytical standards: evidence-based, false-positive aware, multi-metric corroboration, severity-calibrated, temporally precise
- Added explicit instruction to never make claims without supporting data

**User Prompt** (10,500 chars prose → 6,300 chars structured framework):

1. **Phase 1 — Individual Metric Assessment**: Each of the 7 metrics now has explicit NORMAL / ELEVATED / ANOMALOUS thresholds with specific numeric benchmarks (e.g., vvcorrelation < 0.2 = ANOMALOUS, not just "below 0.4")
2. **Phase 2 — False-Positive Screening**: Explicit checks before concluding manipulation — low sample sizes, market-wide events, single-metric insufficiency
3. **Phase 3 — Cross-Metric Correlation**: Named 4 manipulation signatures (Wash Trading, Data Fabrication, Price Manipulation, Bot Activity) with their specific metric combinations in a reference table
4. **Phase 4 — Severity Classification**: CRITICAL / MODERATE / LOW framework requiring multi-metric corroboration — prevents over-interpretation of isolated anomalies
5. **Phase 5 — Article Generation**: Structured output template matching the example article format (frontmatter, numbered summary, per-metric analysis with figures, cross-metric synthesis, conclusion)

### 🌰 What This Improves

| Problem in Current Prompts | How This PR Fixes It |
|---|---|
| Single-line system prompt provides no analytical framework | 5 explicit analytical standards guide reasoning |
| No severity thresholds — model decides what's "suspicious" | 3-level numeric thresholds for every metric (NORMAL/ELEVATED/ANOMALOUS) |
| No false-positive awareness — model may over-interpret noise | Dedicated Phase 2 screening with benign-explanation checklist |
| Cross-metric patterns described in prose, easy to miss | Named signal table (Wash Trading, Data Fabrication, etc.) |
| Output format loosely described | Phase 5 maps directly to example article structure |
| 10,500 chars of dense prose | 6,300 chars in structured sections — 40% reduction, better LLM parsing |

### 🌰 Closes #427