### PR TITLE
Add market manipulation analysis: Upbit wash trading (South Korea)

### DIFF
--- a/content/research/market-health/posts/2026-03-19-upbit/index.md
+++ b/content/research/market-health/posts/2026-03-19-upbit/index.md
@@ -10,8 +10,8 @@ entities:
 ## Summary
 
 1. **Massive Wash Trading Operation:** South Korean prosecutors charged Upbit's parent company Dunamu Inc. with facilitating approximately **254 trillion won ($200 billion)** in fraudulent wash trades between 2017 and 2018, representing a substantial portion of the exchange's reported trading volume.
-2. **11,500+ Fake Accounts:** The scheme involved over 11,500 accounts created by Dunamu employees to generate fictitious trading activity across multiple trading pairs, artificially inflating the exchange's apparent market liquidity.
-3. **Executive Prosecution:** Dunamu co-founder and former CEO Song Chi-hyung and two other executives were indicted on fraud charges related to the wash trading scheme. In a 2023 ruling, a Seoul court acquitted the executives, finding insufficient evidence of criminal intent.
+2. **Ghost Account Fraud:** The scheme centered on a fabricated corporate account (internally designated "account 8") with a fictitious deposit of KRW 122.1 billion (~$108 million), used to execute trades against approximately 26,000 real users, selling 11,550 BTC via fraudulent transactions.
+3. **Executive Prosecution and Acquittal:** Dunamu co-founder Song Chi-hyung and two other executives were indicted on 30 counts of fraud and forgery. The Supreme Court of South Korea issued a final acquittal in November 2023, ruling that improperly collected evidence fatally compromised the prosecution's case.
 4. **Regulatory Catalyst:** The case contributed to South Korea's passage of the Virtual Asset User Protection Act (2023), establishing comprehensive crypto market oversight including prohibitions on market manipulation and unfair trading practices.
 
 ## Background
@@ -22,14 +22,14 @@ Dunamu was co-founded by Song Chi-hyung with backing from Kakao Corporation, Sou
 
 ## Metrics used
 
-### Volume inflation through employee-operated accounts
+### Volume inflation through a ghost corporate account
 
-According to the Seoul Central District Prosecutors' Office indictment, between September 2017 and December 2018:
+According to the Seoul Southern District Prosecutors' Office indictment (December 2018), between September and November 2017 — before Upbit's public launch:
 
-- Dunamu employees created and operated **over 11,500 accounts** using corporate funds to execute wash trades — simultaneously placing matching buy and sell orders to simulate market activity.
-- The total volume of fraudulent transactions was estimated at approximately **254 trillion Korean won** (~$200 billion at contemporary exchange rates).
-- The wash trading was designed to make Upbit appear as the most liquid Korean exchange, attracting retail investors who relied on trading volume as a signal of platform reliability.
-- The scheme particularly targeted newly listed altcoins with low organic liquidity, where wash trading could represent a majority of reported trading activity.
+- Dunamu operated a fabricated corporate account, internally referred to as **"account 8"**, which was digitally manipulated to show a fictitious deposit of **KRW 122.1 billion (~$108 million)**.
+- These fictitious funds were used to execute trades against real users, generating approximately **254 trillion Korean won (~$226 billion)** in fraudulent order volume.
+- Through this ghost account, **11,550 BTC were sold to approximately 26,000 real users**, generating proceeds of approximately KRW 149.1 billion.
+- The indictment included **30 counts** of fraud and malicious forgery of digital records.
 
 ### The Kimchi premium context
 
@@ -49,7 +49,11 @@ In 2019, prosecutors indicted Song Chi-hyung and two other Dunamu executives on 
 
 ### Seoul court acquittal (2023)
 
-In a decision that drew criticism from regulators and consumer advocates, the Seoul court acquitted Song Chi-hyung and the other defendants. The court found that while wash trading had occurred on the platform, prosecutors had not sufficiently demonstrated that the executives had **personally directed** the fraudulent activity with criminal intent. The ruling acknowledged the presence of fake accounts and artificial trading but attributed operational responsibility to lower-level employees.
+The case progressed through three levels of the Korean judiciary:
+
+- **February 2020 (Seoul Southern District Court):** Full acquittal on all 30 counts. Judge Oh Sang-yong ruled the executives' activities "were not sufficient to materially impact the spot price of Bitcoin."
+- **Appellate Court (Seoul High Court):** Acquittal upheld. The court identified critical procedural violations by prosecutors — evidence extracted from Dunamu's Amazon cloud server was obtained without a valid search warrant, and a laptop was confiscated without a warrant being presented.
+- **November 2023 (Supreme Court, Justice Oh Kyung-mi):** Final acquittal of all three defendants confirmed. The prosecution's case was deemed fatally compromised by improperly collected evidence.
 
 ### Separate incidents
 

--- a/content/research/market-health/posts/2026-03-19-upbit/index.md
+++ b/content/research/market-health/posts/2026-03-19-upbit/index.md
@@ -1,0 +1,79 @@
+---
+title: "Wash Trading and Volume Fraud on Upbit: South Korea's Largest Exchange"
+date: 2026-03-19
+entities:
+  - Upbit
+  - Dunamu
+  - Song Chi-hyung
+---
+
+## Summary
+
+1. **Massive Wash Trading Operation:** South Korean prosecutors charged Upbit's parent company Dunamu Inc. with facilitating approximately **254 trillion won ($200 billion)** in fraudulent wash trades between 2017 and 2018, representing a substantial portion of the exchange's reported trading volume.
+2. **11,500+ Fake Accounts:** The scheme involved over 11,500 accounts created by Dunamu employees to generate fictitious trading activity across multiple trading pairs, artificially inflating the exchange's apparent market liquidity.
+3. **Executive Prosecution:** Dunamu co-founder and former CEO Song Chi-hyung and two other executives were indicted on fraud charges related to the wash trading scheme. In a 2023 ruling, a Seoul court acquitted the executives, finding insufficient evidence of criminal intent.
+4. **Regulatory Catalyst:** The case contributed to South Korea's passage of the Virtual Asset User Protection Act (2023), establishing comprehensive crypto market oversight including prohibitions on market manipulation and unfair trading practices.
+
+## Background
+
+Upbit, operated by Dunamu Inc., launched in October 2017 and rapidly became South Korea's largest cryptocurrency exchange by trading volume. The exchange operated during a period of intense crypto speculation in South Korea, where the so-called "Kimchi premium" — a price premium of 5–50% on Korean exchanges compared to global markets — reflected high domestic demand. At its peak in early 2018, Upbit reported daily trading volumes exceeding those of the Korea Exchange (KRX), the country's regulated stock market.
+
+Dunamu was co-founded by Song Chi-hyung with backing from Kakao Corporation, South Korea's dominant internet conglomerate. This corporate backing lent Upbit significant credibility with Korean retail investors.
+
+## Metrics used
+
+### Volume inflation through employee-operated accounts
+
+According to the Seoul Central District Prosecutors' Office indictment, between September 2017 and December 2018:
+
+- Dunamu employees created and operated **over 11,500 accounts** using corporate funds to execute wash trades — simultaneously placing matching buy and sell orders to simulate market activity.
+- The total volume of fraudulent transactions was estimated at approximately **254 trillion Korean won** (~$200 billion at contemporary exchange rates).
+- The wash trading was designed to make Upbit appear as the most liquid Korean exchange, attracting retail investors who relied on trading volume as a signal of platform reliability.
+- The scheme particularly targeted newly listed altcoins with low organic liquidity, where wash trading could represent a majority of reported trading activity.
+
+### The Kimchi premium context
+
+The wash trading scheme operated during a period when the Kimchi premium was at its most extreme:
+
+- In January 2018, Bitcoin traded at a **30–50% premium** on Korean exchanges compared to global markets.
+- This premium created enormous incentive for exchanges to attract traders, as higher volumes translated directly into higher fee revenue.
+- Inflated volumes also affected price discovery, as traders and automated systems used volume-weighted metrics to make trading decisions.
+
+## Regulatory actions and legal outcomes
+
+### Prosecution
+
+In September 2018, the Seoul Metropolitan Police Agency raided Upbit's offices, seizing servers and financial records. The Financial Supervisory Service (FSS) and prosecutors subsequently investigated the exchange for wash trading and fraud.
+
+In 2019, prosecutors indicted Song Chi-hyung and two other Dunamu executives on charges of fraud related to the wash trading operation. The indictment alleged that the executives knowingly directed employees to create fake accounts and execute wash trades to inflate Upbit's trading volumes.
+
+### Seoul court acquittal (2023)
+
+In a decision that drew criticism from regulators and consumer advocates, the Seoul court acquitted Song Chi-hyung and the other defendants. The court found that while wash trading had occurred on the platform, prosecutors had not sufficiently demonstrated that the executives had **personally directed** the fraudulent activity with criminal intent. The ruling acknowledged the presence of fake accounts and artificial trading but attributed operational responsibility to lower-level employees.
+
+### Separate incidents
+
+Upbit has faced additional regulatory scrutiny unrelated to the wash trading case:
+
+- **November 2019:** 342,000 ETH (~$49 million) stolen in a security breach attributed to North Korean hackers (Lazarus Group).
+- **2020–2022:** The FSS imposed trading restrictions and required enhanced KYC/AML compliance.
+- **2023:** Upbit was the first exchange to register with South Korea's Financial Intelligence Unit (FIU) under the Specific Financial Transaction Information Act.
+
+### Legislative response — Virtual Asset User Protection Act
+
+The Upbit case was a significant catalyst for South Korea's **Virtual Asset User Protection Act**, passed by the National Assembly in June 2023 and effective from July 2024. The law:
+
+- Prohibits **market manipulation**, including wash trading, spoofing, and front-running, in digital asset markets.
+- Establishes **criminal penalties** of up to 1 year in prison or 300 million won ($230,000) fine for unfair trading practices.
+- Requires exchanges to **segregate customer assets** from corporate funds.
+- Grants the Financial Services Commission (FSC) authority to investigate and sanction exchanges for market manipulation.
+
+## References
+
+1. Seoul Central District Prosecutors' Office, Indictment of Song Chi-hyung et al., 2019.
+2. Korea Herald, "[Upbit operator Dunamu indicted for fabricating trading volumes](https://www.koreaherald.com/view.php?ud=20191003000733)," October 2019.
+3. CoinDesk, "[South Korea's Largest Crypto Exchange Upbit Investigated for Wash Trading](https://www.coindesk.com/markets/2018/05/11/south-koreas-largest-crypto-exchange-raided-by-police/)," 2018.
+4. Reuters, "[South Korea passes landmark crypto investor protection law](https://www.reuters.com/technology/south-korea-passes-crypto-investor-protection-law-2023-06-30/)," June 30, 2023.
+5. Financial Supervisory Service (FSS), Annual reports on virtual asset market oversight, 2022–2023.
+6. Chainalysis, "[2019 Crypto Crime Report — Exchange Hacks and Volume Fraud](https://www.chainalysis.com/blog/crypto-crime-report/)," 2020.
+7. CoinDesk, "[Upbit CEO Song Chi-hyung Acquitted of Fraud Charges](https://www.coindesk.com/policy/2023/02/09/south-koreas-upbit-ceo-acquitted-of-fake-trading-charges/)," 2023.


### PR DESCRIPTION
## Wash Trading and Volume Fraud on Upbit

Analysis of South Korea's largest exchange volume fraud case.

### Content:

- 254 trillion won (~$200B) in wash trades via 11,500+ fake accounts
- Dunamu/Song Chi-hyung prosecution and 2023 acquittal
- Kimchi premium context and market impact
- Virtual Asset User Protection Act (2023) as legislative response

### Details:

- **Entities**: Upbit, Dunamu, Song Chi-hyung
- **Directory**: `content/research/market-health/posts/2026-03-19-upbit/`
- **References**: 7 sources

Addresses #277