### PR TITLE
Add batch processing to Similarity Search API

### DIFF
--- a/tools/similarity_search/README.md
+++ b/tools/similarity_search/README.md
@@ -1,8 +1,76 @@
+# Similarity Search API
+
+Cloudflare Worker that looks up incoming messages in a vector database and returns similarity scores.
+
+## Setup
+
 ```
 npm install
 npm run dev
 ```
 
+## Deploy
+
 ```
 npm run deploy
+```
+
+## API
+
+### Single text (original)
+
+```
+POST /
+Content-Type: application/json
+X-API-Key: <key>
+
+{
+  "text": "sample text to check",
+  "namespace": "articles"
+}
+```
+
+Response:
+```json
+{ "similarity_score": 0.87 }
+```
+
+### Batch processing
+
+Process multiple texts in a single request. Texts are grouped by namespace and embeddings are computed in chunks for efficiency.
+
+```
+POST /batch
+Content-Type: application/json
+X-API-Key: <key>
+
+{
+  "items": [
+    { "text": "first text", "namespace": "articles", "id": "optional-id-1" },
+    { "text": "second text", "namespace": "articles" },
+    { "text": "third text", "namespace": "attacks" }
+  ]
+}
+```
+
+Response:
+```json
+{
+  "results": [
+    { "id": "optional-id-1", "text": "first text", "namespace": "articles", "similarity_score": 0.87 },
+    { "text": "second text", "namespace": "articles", "similarity_score": 0.42 },
+    { "text": "third text", "namespace": "attacks", "similarity_score": 0.15 }
+  ]
+}
+```
+
+**Limits:**
+- Max batch size: 100 items
+- Items are processed in embedding chunks of 20 (Cloudflare AI limit)
+- Same-namespace items are grouped to optimize vectorize queries
+
+## Tests
+
+```
+npm test
 ```

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,26 @@ type TextEntry = {
   namespace: string
 }
 
+type BatchEntry = {
+  text: string
+  namespace: string
+  id?: string
+}
+
+type BatchRequest = {
+  items: BatchEntry[]
+}
+
+type BatchResultItem = {
+  id?: string
+  text: string
+  namespace: string
+  similarity_score: number
+}
+
+const MAX_BATCH_SIZE = 100
+const EMBEDDING_CHUNK_SIZE = 20
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -27,6 +47,7 @@ app.use("*", async (c, next) => {
   return next()
 })
 
+// Single text similarity (backward compatible)
 app.post("/", async (c) => {
   const data = await c.req.json<TextEntry>()
   const { text, namespace } = data
@@ -35,17 +56,99 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+  const score = await computeSimilarity(c.env, text, namespace)
+  return c.json({ similarity_score: score })
+})
+
+// Batch processing endpoint
+app.post("/batch", async (c) => {
+  const data = await c.req.json<BatchRequest>()
+
+  if (!Array.isArray(data.items) || data.items.length === 0) {
+    return c.text("Invalid batch format: 'items' must be a non-empty array", 400)
+  }
+
+  if (data.items.length > MAX_BATCH_SIZE) {
+    return c.text(`Batch size exceeds maximum of ${MAX_BATCH_SIZE}`, 400)
+  }
+
+  for (const item of data.items) {
+    if (typeof item.text !== "string" || typeof item.namespace !== "string") {
+      return c.text("Each item must have 'text' and 'namespace' string fields", 400)
+    }
+  }
+
+  const results = await processBatch(c.env, data.items)
+  return c.json({ results })
+})
+
+async function computeSimilarity(
+  env: Env,
+  text: string,
+  namespace: string
+): Promise<number> {
+  const modelResp = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
     text: [text]
   })
   const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
+  const searchResponse = await env.VECTORIZE_INDEX.query(vector, {
     namespace,
     topK: 1
   })
-  const similarityScore = searchResponse.matches[0]?.score || 0
+  return searchResponse.matches[0]?.score || 0
+}
 
-  return c.json({ similarity_score: similarityScore })
-})
+async function processBatch(
+  env: Env,
+  items: BatchEntry[]
+): Promise<BatchResultItem[]> {
+  // Group items by namespace to optimize vectorize queries
+  const byNamespace = new Map<string, { index: number; item: BatchEntry }[]>()
+  for (let i = 0; i < items.length; i++) {
+    const ns = items[i].namespace
+    if (!byNamespace.has(ns)) byNamespace.set(ns, [])
+    byNamespace.get(ns)!.push({ index: i, item: items[i] })
+  }
+
+  const results: BatchResultItem[] = new Array(items.length)
+
+  // Process each namespace group
+  const namespacePromises = Array.from(byNamespace.entries()).map(
+    async ([namespace, entries]) => {
+      // Chunk embeddings to stay within AI model limits
+      for (let i = 0; i < entries.length; i += EMBEDDING_CHUNK_SIZE) {
+        const chunk = entries.slice(i, i + EMBEDDING_CHUNK_SIZE)
+        const texts = chunk.map((e) => e.item.text)
+
+        // Batch embedding call — single API call for multiple texts
+        const modelResp = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+          text: texts
+        })
+
+        // Query vectorize for each embedding in the chunk
+        const queryPromises = chunk.map(async (entry, j) => {
+          const vector = modelResp.data[j]
+          const searchResponse = await env.VECTORIZE_INDEX.query(vector, {
+            namespace,
+            topK: 1
+          })
+          const score = searchResponse.matches[0]?.score || 0
+
+          results[entry.index] = {
+            id: entry.item.id,
+            text: entry.item.text,
+            namespace: entry.item.namespace,
+            similarity_score: score
+          }
+        })
+
+        await Promise.all(queryPromises)
+      }
+    }
+  )
+
+  await Promise.all(namespacePromises)
+  return results
+}
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -19,4 +19,105 @@ describe("Authentication", () => {
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
   })
+
+  it("returns 401 for batch endpoint without API key", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        items: [{ text: "test", namespace: "ns" }]
+      })
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Single endpoint (backward compatibility)", () => {
+  it("returns 400 for invalid JSON format", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-key"
+      },
+      body: JSON.stringify({
+        text: 123,
+        namespace: "test"
+      })
+    })
+
+    expect(response.status).toBe(400)
+  })
+})
+
+describe("Batch endpoint", () => {
+  it("returns 400 when items is not an array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-key"
+      },
+      body: JSON.stringify({
+        items: "not-an-array"
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("non-empty array")
+  })
+
+  it("returns 400 when items is empty", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-key"
+      },
+      body: JSON.stringify({
+        items: []
+      })
+    })
+
+    expect(response.status).toBe(400)
+  })
+
+  it("returns 400 when batch exceeds max size", async () => {
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      text: `text-${i}`,
+      namespace: "test"
+    }))
+
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-key"
+      },
+      body: JSON.stringify({ items })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("maximum")
+  })
+
+  it("returns 400 when items have invalid format", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-key"
+      },
+      body: JSON.stringify({
+        items: [{ text: 123, namespace: "test" }]
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("string fields")
+  })
 })


### PR DESCRIPTION
## Batch processing for Similarity Search

Adds a `/batch` endpoint for processing multiple texts in a single request.

### Design decisions

**Namespace grouping:** Items are grouped by namespace before processing. This minimizes context switches on the Vectorize index and allows same-namespace queries to run in parallel.

**Chunked embeddings:** The CF AI embedding model (`bge-base-en-v1.5`) accepts arrays of text natively. Items are chunked into groups of 20 for embedding (CF AI limit), so a batch of 100 items requires only 5 AI calls instead of 100.

**Parallel execution:** Namespace groups run in parallel via `Promise.all`, and within each chunk, vectorize queries also run in parallel. This minimizes wall-clock time.

**Cost analysis:**
- Without batching: N items = N AI calls + N vectorize queries
- With batching: N items = ceil(N/20) AI calls + N vectorize queries (same vectorize cost, but 5-20x fewer AI calls)

### Changes

- `POST /batch` — accepts `{ items: [{ text, namespace, id? }] }`, max 100
- Original `POST /` — unchanged (backward compatible)
- Added validation tests for batch endpoint
- Updated README with batch API docs

Addresses #431