### PR TITLE
Add RAG context retrieval for Market Health Reporter

### DIFF
--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -8,6 +8,7 @@ import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.rag import build_rag_context
 
 
 REPO_NAME = "1712n/dn-institute"
@@ -38,6 +39,9 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
+    )
+    parser.add_argument(
+        "--search-api-key", dest="search_api_key", help="Brave Search API key for RAG", required=False, default=""
     )
     return parser.parse_args()
 
@@ -126,11 +130,14 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, rag_context: str = "") -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, data, and optional RAG context.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    prompt = f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    if rag_context:
+        prompt += rag_context
+    return prompt
 
 
 def main():
@@ -157,10 +164,17 @@ def main():
     try:
         data = fetch_or_load_market_data(querystring, headers, url, DATA_DIR, marketvenueid, pairid, start, end)
 
-        encoding = encoding_for_model("gpt-4")     
+        encoding = encoding_for_model("gpt-4")
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        # Fetch RAG context from external articles
+        rag_context = ""
+        if args.search_api_key:
+            rag_context = build_rag_context(marketvenueid, pairid, args.search_api_key)
+            if rag_context:
+                print(f'RAG context added: {len(rag_context)} chars')
+
+        prompt = create_prompt(article_example, data, human_prompt_content, rag_context)
         prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:

--- a/tools/market_health_reporter/rag.py
+++ b/tools/market_health_reporter/rag.py
@@ -1,0 +1,136 @@
+"""
+RAG module for the Market Health Reporter.
+Retrieves relevant external articles to provide additional context
+for market surveillance report generation.
+"""
+
+import json
+import os
+import requests
+from typing import Optional
+
+
+SEARCH_API_URL = "https://api.search.brave.com/res/v1/web/search"
+MAX_CONTEXT_CHARS = 4000
+MAX_RESULTS = 5
+
+
+def search_articles(
+    exchange: str,
+    pair: str,
+    api_key: str,
+    additional_terms: str = ""
+) -> list[dict]:
+    """Search for relevant market manipulation articles about the exchange."""
+    query = f"{exchange} wash trading market manipulation {pair} {additional_terms}".strip()
+
+    headers = {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "X-Subscription-Token": api_key
+    }
+    params = {
+        "q": query,
+        "count": MAX_RESULTS,
+        "freshness": "py"  # past year
+    }
+
+    try:
+        resp = requests.get(SEARCH_API_URL, headers=headers, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        results = data.get("web", {}).get("results", [])
+        return [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "description": r.get("description", ""),
+            }
+            for r in results
+        ]
+    except Exception as e:
+        print(f"[rag] Search failed: {e}")
+        return []
+
+
+def fetch_article_content(url: str, max_chars: int = 2000) -> str:
+    """Fetch and extract text content from a URL."""
+    try:
+        resp = requests.get(
+            url,
+            timeout=10,
+            headers={"User-Agent": "MarketHealthReporter/1.0"}
+        )
+        resp.raise_for_status()
+        text = resp.text
+
+        # Basic HTML stripping
+        import re
+        text = re.sub(r'<script[^>]*>.*?</script>', '', text, flags=re.DOTALL)
+        text = re.sub(r'<style[^>]*>.*?</style>', '', text, flags=re.DOTALL)
+        text = re.sub(r'<[^>]+>', ' ', text)
+        text = re.sub(r'\s+', ' ', text).strip()
+
+        return text[:max_chars]
+    except Exception as e:
+        print(f"[rag] Failed to fetch {url}: {e}")
+        return ""
+
+
+def build_rag_context(
+    exchange: str,
+    pair: str,
+    search_api_key: Optional[str] = None
+) -> str:
+    """Build RAG context string from external articles.
+
+    Searches for relevant articles about the exchange and pair,
+    fetches their content, and returns a formatted context block.
+    """
+    api_key = search_api_key or os.environ.get("BRAVE_SEARCH_API_KEY", "")
+    if not api_key:
+        print("[rag] No search API key configured, skipping RAG context")
+        return ""
+
+    print(f"[rag] Searching for context: {exchange} {pair}")
+    articles = search_articles(exchange, pair, api_key)
+
+    if not articles:
+        print("[rag] No articles found")
+        return ""
+
+    context_parts = []
+    total_chars = 0
+
+    for article in articles:
+        if total_chars >= MAX_CONTEXT_CHARS:
+            break
+
+        content = fetch_article_content(article["url"])
+        if not content:
+            content = article.get("description", "")
+
+        if content:
+            remaining = MAX_CONTEXT_CHARS - total_chars
+            snippet = content[:remaining]
+            context_parts.append(
+                f"Source: {article['title']}\n"
+                f"URL: {article['url']}\n"
+                f"Content: {snippet}\n"
+            )
+            total_chars += len(snippet)
+
+    if not context_parts:
+        return ""
+
+    context = "\n---\n".join(context_parts)
+    print(f"[rag] Built context from {len(context_parts)} articles ({total_chars} chars)")
+
+    return (
+        "\n\n<external_context>\n"
+        "The following are excerpts from external articles about this exchange "
+        "and its trading practices. Use them as additional context for your analysis, "
+        "but only reference them if they directly support findings from the data.\n\n"
+        f"{context}\n"
+        "</external_context>\n"
+    )


### PR DESCRIPTION
## RAG for Market Health Reporter

Adds external article retrieval to enrich LLM context when generating market surveillance reports.

### How it works

1. When the reporter runs, it searches Brave Search for articles about the target exchange and trading pair (e.g. "binance wash trading btc-usdt")
2. Fetches top 5 results and extracts text content (HTML stripped)
3. Builds a context block (max 4000 chars) injected into the prompt within `<external_context>` tags
4. The LLM can reference external findings only when they directly support data-driven conclusions

### Design choices

- **Brave Search API** — no rate limits on free tier, good quality results for technical content
- **Graceful degradation** — if no search API key is provided, RAG is skipped entirely (backward compatible)
- **Token budget** — context capped at 4000 chars to stay within the 125K token prompt limit
- **Separation of concerns** — RAG logic in standalone `rag.py` module, reporter unchanged except for integration point

### Usage

```bash
python -m tools.market_health_reporter.market_health_reporter \
  --llm-api-key $KEY \
  --search-api-key $BRAVE_KEY \   # optional, enables RAG
  --issue 123 \
  --comment-body "report: binance, btc-usdt, 2024-01-01, 2024-01-07" \
  --github-token $GH_TOKEN \
  --rapid-api $RAPID_KEY
```

Addresses #428