### PR TITLE
Add integration tests for Similarity Search API

### DIFF
--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,197 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const VALID_HEADERS = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key"
+}
+
+const NO_AUTH_HEADERS = {
+  "Content-Type": "application/json"
+}
+
+// --- Authentication ---
+
 describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
+  it("rejects requests without API key", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
+      headers: NO_AUTH_HEADERS,
+      body: JSON.stringify({ text: "test", namespace: "ns" })
     })
-
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("rejects requests with wrong API key", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: { ...NO_AUTH_HEADERS, "X-API-Key": "wrong-key" },
+      body: JSON.stringify({ text: "test", namespace: "ns" })
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it("accepts requests with valid API key", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "test", namespace: "ns" })
+    })
+    expect(response.status).toBe(200)
+  })
+})
+
+// --- Single endpoint ---
+
+describe("POST / (single text)", () => {
+  it("returns similarity score for valid input", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "sample query", namespace: "articles" })
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json() as { similarity_score: number }
+    expect(json).toHaveProperty("similarity_score")
+    expect(typeof json.similarity_score).toBe("number")
+    expect(json.similarity_score).toBeGreaterThanOrEqual(0)
+    expect(json.similarity_score).toBeLessThanOrEqual(1)
+  })
+
+  it("returns 400 for missing text field", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ namespace: "articles" })
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it("returns 400 for non-string text", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: 42, namespace: "articles" })
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it("returns 400 for missing namespace", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "sample" })
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it("handles empty string text gracefully", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "", namespace: "articles" })
+    })
+    // Empty string is still a valid string type
+    expect(response.status).toBe(200)
+  })
+
+  it("handles special characters in text", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        text: 'text with "quotes" & <html> tags and unicode: 日本語',
+        namespace: "articles"
+      })
+    })
+    expect(response.status).toBe(200)
+  })
+
+  it("handles long text input", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({
+        text: "x".repeat(10000),
+        namespace: "articles"
+      })
+    })
+    expect(response.status).toBe(200)
+  })
+})
+
+// --- Response format ---
+
+describe("Response format", () => {
+  it("returns JSON content type", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "test", namespace: "ns" })
+    })
+    expect(response.headers.get("content-type")).toContain("application/json")
+  })
+
+  it("similarity score is between 0 and 1", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "market manipulation analysis", namespace: "articles" })
+    })
+
+    const json = await response.json() as { similarity_score: number }
+    expect(json.similarity_score).toBeGreaterThanOrEqual(0)
+    expect(json.similarity_score).toBeLessThanOrEqual(1)
+  })
+})
+
+// --- HTTP methods ---
+
+describe("HTTP methods", () => {
+  it("rejects GET requests", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "GET",
+      headers: VALID_HEADERS
+    })
+    // Hono returns 404 for unmatched routes
+    expect(response.status).not.toBe(200)
+  })
+
+  it("rejects PUT requests", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "PUT",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "test", namespace: "ns" })
+    })
+    expect(response.status).not.toBe(200)
+  })
+})
+
+// --- Namespace isolation ---
+
+describe("Namespace isolation", () => {
+  it("queries with the provided namespace", async () => {
+    const resp1 = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "same text", namespace: "namespace-a" })
+    })
+
+    const resp2 = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: VALID_HEADERS,
+      body: JSON.stringify({ text: "same text", namespace: "namespace-b" })
+    })
+
+    expect(resp1.status).toBe(200)
+    expect(resp2.status).toBe(200)
+
+    // Both should return valid scores (mock returns same score regardless)
+    const json1 = await resp1.json() as { similarity_score: number }
+    const json2 = await resp2.json() as { similarity_score: number }
+    expect(typeof json1.similarity_score).toBe("number")
+    expect(typeof json2.similarity_score).toBe("number")
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -25,8 +25,10 @@ export default defineWorkersConfig({
               modules: true,
               script: `export default function() {
                 return {
-                  run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                  run: async (model, input) => {
+                    const texts = input.text || [];
+                    const vectors = texts.map(() => new Array(768).fill(0.1));
+                    return Promise.resolve({ data: vectors });
                   }
                 };
               };`


### PR DESCRIPTION
## Integration tests for Similarity Search

Comprehensive test suite using Cloudflare Vitest integration with miniflare mocks.

### Test coverage

| Category | Tests | Description |
|---|---|---|
| Authentication | 3 | Missing key, wrong key, valid key |
| Single endpoint | 5 | Valid input, missing fields, type errors, edge cases |
| Response format | 2 | JSON content type, score range [0,1] |
| HTTP methods | 2 | Reject GET/PUT, only POST allowed |
| Namespace isolation | 1 | Same text queried across different namespaces |

### Mock fixes

Fixed the AI mock to return proper 768-dimensional vector arrays matching `bge-base-en-v1.5` output format. The previous mock returned `{ data: {} }` which would cause runtime errors.

### Run tests

```bash
cd tools/similarity_search
npm install
npm test
```

Addresses #430