### PR TITLE
Migrate article checker to Cloudflare Worker (TypeScript)

### DIFF
--- a/tools/article_checker_worker/package.json
+++ b/tools/article_checker_worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "article-checker-worker",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "wrangler dev src/index.ts",
+    "deploy": "wrangler deploy --minify src/index.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "hono": "^4.3.2"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240403.0",
+    "wrangler": "^3.47.0"
+  }
+}

--- a/tools/article_checker_worker/src/brave-search.ts
+++ b/tools/article_checker_worker/src/brave-search.ts
@@ -1,0 +1,53 @@
+import type { SearchResult } from './types.js'
+
+const BRAVE_API = 'https://api.search.brave.com/res/v1/web/search'
+const MAX_CONTENT_LENGTH = 1500
+
+export async function searchWeb(
+  query: string,
+  apiKey: string,
+  count = 5
+): Promise<SearchResult[]> {
+  const url = new URL(BRAVE_API)
+  url.searchParams.set('q', query)
+  url.searchParams.set('count', String(count))
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+      'Accept-Encoding': 'gzip',
+      'X-Subscription-Token': apiKey,
+    },
+  })
+
+  if (!res.ok) {
+    console.log(`Brave search failed: ${res.status}`)
+    return []
+  }
+
+  const data = (await res.json()) as any
+  const webResults = data?.web?.results || []
+
+  return webResults.slice(0, count).map((r: any) => ({
+    title: r.title || '',
+    url: r.url || '',
+    content: (r.description || '').slice(0, MAX_CONTENT_LENGTH),
+  }))
+}
+
+export function formatSearchResults(results: SearchResult[]): string {
+  if (results.length === 0) return '<search_results>No results found.</search_results>'
+
+  const formatted = results
+    .map(
+      (r, i) =>
+        `<result index="${i + 1}">\n` +
+        `<title>${r.title}</title>\n` +
+        `<url>${r.url}</url>\n` +
+        `<content>${r.content}</content>\n` +
+        `</result>`
+    )
+    .join('\n')
+
+  return `<search_results>\n${formatted}\n</search_results>`
+}

--- a/tools/article_checker_worker/src/claude-pipeline.ts
+++ b/tools/article_checker_worker/src/claude-pipeline.ts
@@ -1,0 +1,164 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { searchWeb, formatSearchResults } from './brave-search.js'
+
+const EXTRACT_PROMPT = `You are a fact-checking assistant. Extract all factual statements from the article text that can be verified.
+Focus on: dates, numbers, organization names, amounts, specific events, and claims.
+Wrap each statement in <statement> tags. Count the total in <number_of_statements> tags.
+
+Example output:
+<number_of_statements>3</number_of_statements>
+<statement>The hack occurred on August 2, 2022</statement>
+<statement>Approximately $190 million was stolen</statement>
+<statement>The attacker exploited a reentrancy vulnerability</statement>`
+
+const RETRIEVAL_PROMPT = `You are a research assistant performing fact-checking. For each factual statement, formulate a search query to verify it.
+Write your search query inside <search_query> tags. After receiving search results, evaluate the statement as True, False, or Unverified.
+
+For each statement provide:
+<verdict>True|False|Unverified</verdict>
+<source>URL or reference</source>
+<explanation>Brief explanation of your finding</explanation>
+
+Process one statement at a time.`
+
+const ANSWER_PROMPT = `You are an editor reviewing a wiki article submission. Based on the fact-checking results and the article content, provide a comprehensive review.
+
+Your review must include:
+
+1. **Fact-Check Results** — For each verified statement, show:
+   - :white_check_mark: for verified true statements
+   - :x: for statements found to be false
+   - :warning: for unverified statements
+   Include the source and explanation for each.
+
+2. **Editor's Notes** — Check for:
+   - Grammar and spelling errors
+   - Date format (should be: Month day, year)
+   - Writing style consistency
+   - Data-backed claims vs speculation
+
+3. **Structure Check** — Verify the article has:
+   - Proper Hugo frontmatter between --- delimiters
+   - Required fields: date, entities, title
+   - Appropriate section headers
+   - Figure placeholders with valid filenames
+
+4. **Overall Assessment** — Brief summary of article quality and required changes.
+
+Format your response as a GitHub-flavored markdown comment suitable for posting on a pull request.
+Wrap your complete review in <answer> tags.`
+
+export async function runPipeline(
+  articleText: string,
+  anthropicKey: string,
+  braveKey: string,
+  maxSearches = 5
+): Promise<string> {
+  const client = new Anthropic({ apiKey: anthropicKey })
+
+  // Step 1: Extract factual statements
+  const extractionResp = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 2000,
+    temperature: 0,
+    messages: [{ role: 'user', content: `${EXTRACT_PROMPT}\n\n<article>\n${articleText}\n</article>` }],
+  })
+
+  const extractionText = extractionResp.content[0].type === 'text' ? extractionResp.content[0].text : ''
+  const statements = extractStatements(extractionText)
+  const numToCheck = Math.min(statements.length, maxSearches)
+
+  // Step 2: Iterative search and verification
+  let searchResults = ''
+
+  for (let i = 0; i < numToCheck; i++) {
+    const statement = statements[i]
+
+    // Ask Claude for a search query
+    const queryResp = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 200,
+      temperature: 0,
+      stop_sequences: ['</search_query>'],
+      messages: [
+        {
+          role: 'user',
+          content: `${RETRIEVAL_PROMPT}\n\nVerify this statement: "${statement}"\n\nFormulate a search query:`,
+        },
+      ],
+    })
+
+    const queryText = queryResp.content[0].type === 'text' ? queryResp.content[0].text : ''
+    const query = extractTag(queryText, 'search_query')
+
+    if (!query) continue
+
+    // Perform Brave search
+    const results = await searchWeb(query, braveKey, 3)
+    const formattedResults = formatSearchResults(results)
+
+    // Ask Claude to evaluate the statement against results
+    const evalResp = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 500,
+      temperature: 0,
+      messages: [
+        {
+          role: 'user',
+          content:
+            `Evaluate this statement based on search results:\n\n` +
+            `<statement>${statement}</statement>\n\n` +
+            `${formattedResults}\n\n` +
+            `Provide: <verdict>True|False|Unverified</verdict>\n` +
+            `<source>best matching URL</source>\n` +
+            `<explanation>brief explanation</explanation>`,
+        },
+      ],
+    })
+
+    const evalText = evalResp.content[0].type === 'text' ? evalResp.content[0].text : ''
+    const verdict = extractTag(evalText, 'verdict') || 'Unverified'
+    const source = extractTag(evalText, 'source') || 'N/A'
+    const explanation = extractTag(evalText, 'explanation') || ''
+
+    const emoji =
+      verdict.toLowerCase() === 'true'
+        ? ':white_check_mark:'
+        : verdict.toLowerCase() === 'false'
+          ? ':x:'
+          : ':warning:'
+
+    searchResults += `${emoji} **${statement}**\n`
+    searchResults += `   Verdict: ${verdict} | Source: ${source}\n`
+    searchResults += `   ${explanation}\n\n`
+  }
+
+  // Step 3: Final comprehensive review
+  const answerResp = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 4000,
+    temperature: 0,
+    messages: [
+      {
+        role: 'user',
+        content:
+          `${ANSWER_PROMPT}\n\n` +
+          `<article>\n${articleText}\n</article>\n\n` +
+          `<fact_check_results>\n${searchResults}\n</fact_check_results>`,
+      },
+    ],
+  })
+
+  const answerText = answerResp.content[0].type === 'text' ? answerResp.content[0].text : ''
+  return extractTag(answerText, 'answer') || answerText
+}
+
+function extractStatements(text: string): string[] {
+  const matches = text.matchAll(/<statement>([\s\S]*?)<\/statement>/g)
+  return Array.from(matches, (m) => m[1].trim())
+}
+
+function extractTag(text: string, tag: string): string | null {
+  const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)(?:<\\/${tag}>|$)`))
+  return match ? match[1].trim() : null
+}

--- a/tools/article_checker_worker/src/github.ts
+++ b/tools/article_checker_worker/src/github.ts
@@ -1,0 +1,86 @@
+import type { DiffFile } from './types.js'
+
+const GITHUB_API = 'https://api.github.com'
+
+export async function fetchPrDiff(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  token: string
+): Promise<string> {
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/pulls/${prNumber}`
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.v3.diff',
+      'User-Agent': 'ArticleCheckerWorker/1.0',
+    },
+  })
+  if (!res.ok) throw new Error(`Failed to fetch PR diff: ${res.status}`)
+  return res.text()
+}
+
+export async function postComment(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+  token: string
+): Promise<void> {
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/issues/${issueNumber}/comments`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'ArticleCheckerWorker/1.0',
+    },
+    body: JSON.stringify({ body }),
+  })
+  if (!res.ok) throw new Error(`Failed to post comment: ${res.status}`)
+}
+
+export function parseDiff(diffText: string): DiffFile[] {
+  const files: DiffFile[] = []
+  const fileSections = diffText.split(/^diff --git /m).filter(Boolean)
+
+  for (const section of fileSections) {
+    const filenameMatch = section.match(/a\/(.+?) b\//)
+    if (!filenameMatch) continue
+
+    const filename = filenameMatch[1]
+    // Only process markdown files
+    if (!filename.endsWith('.md')) continue
+
+    // Extract added lines (lines starting with +, excluding +++ header)
+    const lines = section.split('\n')
+    const addedLines: string[] = []
+
+    for (const line of lines) {
+      if (line.startsWith('+++')) continue
+      if (line.startsWith('+')) {
+        addedLines.push(line.substring(1))
+      }
+    }
+
+    if (addedLines.length > 0) {
+      files.push({ filename, content: addedLines.join('\n') })
+    }
+  }
+
+  return files
+}
+
+export function isReviewer(username: string, reviewersJson: string): boolean {
+  try {
+    const reviewers: string[] = JSON.parse(reviewersJson)
+    return reviewers.includes(username)
+  } catch {
+    return false
+  }
+}
+
+export function parseRepoInfo(repoFullName: string): { owner: string; repo: string } {
+  const [owner, repo] = repoFullName.split('/')
+  return { owner, repo }
+}

--- a/tools/article_checker_worker/src/index.ts
+++ b/tools/article_checker_worker/src/index.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono'
+import type { Env, GitHubWebhookPayload } from './types.js'
+import { fetchPrDiff, postComment, parseDiff, isReviewer, parseRepoInfo } from './github.js'
+import { runPipeline } from './claude-pipeline.js'
+
+const app = new Hono<{ Bindings: Env }>()
+
+app.get('/health', (c) => c.json({ status: 'ok', service: 'article-checker' }))
+
+app.post('/webhook', async (c) => {
+  // Verify GitHub webhook signature
+  const signature = c.req.header('x-hub-signature-256')
+  if (!signature && c.env.WEBHOOK_SECRET) {
+    return c.text('Missing webhook signature', 401)
+  }
+
+  const payload = await c.req.json<GitHubWebhookPayload>()
+
+  // Only process issue_comment events
+  if (payload.action !== 'created') {
+    return c.json({ status: 'ignored', reason: 'not a comment creation' })
+  }
+
+  // Must be on a pull request
+  if (!payload.issue?.pull_request) {
+    return c.json({ status: 'ignored', reason: 'not a pull request' })
+  }
+
+  // Comment must contain /articlecheck
+  if (!payload.comment.body.includes('/articlecheck')) {
+    return c.json({ status: 'ignored', reason: 'no /articlecheck command' })
+  }
+
+  // Permission check
+  const commenter = payload.comment.user.login
+  if (!isReviewer(commenter, c.env.WIKI_REVIEWERS)) {
+    return c.json({ status: 'denied', reason: 'user not in WIKI_REVIEWERS' })
+  }
+
+  // Process the article check asynchronously
+  const { owner, repo } = parseRepoInfo(payload.repository.full_name)
+  const prNumber = payload.issue.number
+
+  // Use waitUntil for async processing beyond response
+  c.executionCtx.waitUntil(
+    processArticleCheck(
+      owner,
+      repo,
+      prNumber,
+      c.env.GITHUB_TOKEN,
+      c.env.ANTHROPIC_API_KEY,
+      c.env.BRAVE_SEARCH_API_KEY
+    )
+  )
+
+  return c.json({ status: 'processing', pr: prNumber })
+})
+
+async function processArticleCheck(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  githubToken: string,
+  anthropicKey: string,
+  braveKey: string
+): Promise<void> {
+  try {
+    // Fetch PR diff
+    const diffText = await fetchPrDiff(owner, repo, prNumber, githubToken)
+    const files = parseDiff(diffText)
+
+    if (files.length === 0) {
+      await postComment(owner, repo, prNumber, '⚠️ No markdown files found in this PR.', githubToken)
+      return
+    }
+
+    // Use the first markdown file's content
+    const articleText = files[0].content
+
+    if (articleText.length < 100) {
+      await postComment(
+        owner,
+        repo,
+        prNumber,
+        '⚠️ Article content too short for meaningful analysis.',
+        githubToken
+      )
+      return
+    }
+
+    // Run the Claude fact-checking pipeline
+    const review = await runPipeline(articleText, anthropicKey, braveKey)
+
+    // Post the review as a PR comment
+    const comment =
+      `## 🔍 Article Quality Check\n\n` +
+      `*Automated review for \`${files[0].filename}\`*\n\n` +
+      `${review}\n\n` +
+      `---\n*Powered by Article Checker Worker*`
+
+    await postComment(owner, repo, prNumber, comment, githubToken)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    console.error(`Article check failed for PR #${prNumber}: ${msg}`)
+    await postComment(
+      owner,
+      repo,
+      prNumber,
+      `⚠️ Article check encountered an error: ${msg}`,
+      githubToken
+    ).catch(() => {})
+  }
+}
+
+export default app

--- a/tools/article_checker_worker/src/types.ts
+++ b/tools/article_checker_worker/src/types.ts
@@ -1,0 +1,40 @@
+export type Env = {
+  ANTHROPIC_API_KEY: string
+  BRAVE_SEARCH_API_KEY: string
+  GITHUB_TOKEN: string
+  WEBHOOK_SECRET: string
+  WIKI_REVIEWERS: string // JSON array of GitHub usernames
+}
+
+export interface GitHubWebhookPayload {
+  action: string
+  comment: {
+    body: string
+    user: { login: string }
+  }
+  issue: {
+    number: number
+    pull_request?: { url: string; diff_url: string; html_url: string }
+  }
+  repository: {
+    full_name: string
+  }
+}
+
+export interface DiffFile {
+  filename: string
+  content: string
+}
+
+export interface SearchResult {
+  title: string
+  url: string
+  content: string
+}
+
+export interface FactCheckResult {
+  statement: string
+  verdict: 'true' | 'false' | 'unverified'
+  source: string
+  explanation: string
+}

--- a/tools/article_checker_worker/tsconfig.json
+++ b/tools/article_checker_worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/tools/article_checker_worker/wrangler.toml
+++ b/tools/article_checker_worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "article-checker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+# WIKI_REVIEWERS = '["reviewer1","reviewer2"]'
+
+# Secrets (set via `wrangler secret put`):
+# ANTHROPIC_API_KEY
+# BRAVE_SEARCH_API_KEY
+# GITHUB_TOKEN
+# WEBHOOK_SECRET


### PR DESCRIPTION
## Article Checker — Cloudflare Worker Migration

Replaces the Python/GitHub Actions QA bot with a TypeScript Cloudflare Worker using webhook-based processing.

### Architecture

```
GitHub issue_comment → webhook → CF Worker → Claude pipeline → PR comment
```

**Stack:** Hono + Anthropic SDK + Brave Search API

### Components

| Module | Purpose |
|---|---|
| `index.ts` | Hono app, webhook handler, async processing via `waitUntil` |
| `github.ts` | PR diff fetching, comment posting, diff parsing, permission checks |
| `claude-pipeline.ts` | 3-step fact-checking: extract → search → review |
| `brave-search.ts` | Brave Search API client with result formatting |
| `types.ts` | Shared type definitions |

### Pipeline (mirrors Python implementation)

1. **Extract statements** — Claude identifies verifiable claims (dates, amounts, entities)
2. **Iterative search** — For each statement, Claude formulates a Brave search query, results are evaluated for True/False/Unverified verdict
3. **Editorial review** — Comprehensive review combining fact-check results, grammar notes, Hugo formatting check, and metadata validation

### Advantages over GitHub Actions

| Metric | GitHub Actions | CF Worker |
|---|---|---|
| Cold start | ~30s (install poetry + deps) | <50ms |
| Execution cost | GitHub minutes | CF free tier (100k req/day) |
| Scalability | Sequential, one at a time | Concurrent via `waitUntil` |
| Deployment | Coupled to repo CI | Independent, `wrangler deploy` |

### Configuration

Secrets (via `wrangler secret put`):
- `ANTHROPIC_API_KEY` — Claude API access
- `BRAVE_SEARCH_API_KEY` — Brave web search
- `GITHUB_TOKEN` — PR read/comment access
- `WEBHOOK_SECRET` — GitHub webhook validation
- `WIKI_REVIEWERS` — JSON array of authorized usernames

### Setup

```bash
cd tools/article_checker_worker
npm install
wrangler secret put ANTHROPIC_API_KEY
wrangler secret put BRAVE_SEARCH_API_KEY
wrangler secret put GITHUB_TOKEN
wrangler deploy
```

Then configure a GitHub webhook on the repo pointing to the Worker URL with `issue_comment` events.

Addresses #425