### PR TITLE
🌰 feat: Migrate article checker QA bot to Cloudflare Workers (#425)

### DIFF
--- a/.github/workflows/article-check-claude.yml
+++ b/.github/workflows/article-check-claude.yml
@@ -1,6 +1,9 @@
+# DEPRECATED: Migrated to Cloudflare Worker (workers/articlecheck/)
+# Retained for rollback. Trigger changed to manual-only (workflow_dispatch).
+# See: https://github.com/1712n/dn-institute/issues/425
+
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -10,9 +13,6 @@ permissions:
 jobs:
   permission-check-job:
     runs-on: ubuntu-latest
-    if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/articlecheck')
     outputs:
       permission: ${{ steps.permissions-check.outputs.defined }}
     steps:

--- a/tools/articlecheck-worker/README.md
+++ b/tools/articlecheck-worker/README.md
@@ -1,0 +1,151 @@
+# Article Check Worker
+
+Cloudflare Worker that migrates the `/articlecheck` QA bot from GitHub Actions to a webhook-based serverless architecture.
+
+## Architecture
+
+Single Worker with two handlers: a `fetch` handler (webhook receiver) and a `queue` handler (pipeline processor).
+
+```
+GitHub PR Comment (/articlecheck)
+  → Webhook POST to Worker fetch handler
+  → Verify HMAC-SHA256 signature (timing-safe)
+  → Check reviewer permissions
+  → Dedup via KV (prevent reprocessing)
+  → Enqueue job to Cloudflare Queue
+  → Respond 202 Accepted (<10ms)
+
+Queue Consumer (15 min wall clock budget)
+  → Fetch PR diff from GitHub API
+  → Phase 1: Extract factual statements (Claude Opus)
+  → Phase 2: Fact-check loop (Brave Search + HTMLRewriter scraping + Claude Haiku summarization + Claude Opus verification)
+  → Phase 3: Editorial review (Claude Opus)
+  → Post review comment on PR
+```
+
+### Why a Queue instead of `waitUntil()`?
+
+`ctx.waitUntil()` has a **hard 30-second limit** after the response is sent. The 3-phase pipeline with Claude API calls, Brave searches, page scraping, and Haiku summarization needs 60-180 seconds. Queue consumers get **15 minutes** of wall clock time — more than enough, with automatic retry on failure.
+
+### 3-Phase AI Pipeline (preserved from Python original)
+
+1. **Extract Statements** — Claude extracts factual claims (dates, dollar amounts, entity names) from the article
+2. **Fact-Check Loop** — For each statement:
+   - Claude generates a search query
+   - Brave Search API returns ranked results (using `mixed.main` ordering for web/news/FAQ interleaving)
+   - Web pages are scraped using **HTMLRewriter** (Cloudflare's native streaming HTML parser — the Workers equivalent of BeautifulSoup)
+   - Scraped content is summarized by **Claude Haiku** for focused article extraction
+   - Claude Opus verifies the statement as True/False/Unverified with sources
+3. **Editorial Review** — Claude produces a comprehensive review: fact-check results with sources, editor's notes, Hugo SSG formatting check, filename validation, metadata header validation
+
+### Key Implementation Details
+
+| Feature | Python Original | This Worker |
+|---------|----------------|-------------|
+| HTML parsing | BeautifulSoup + bleach | HTMLRewriter (Cloudflare native) |
+| Page summarization | Claude Haiku (claude-3-haiku) | Claude Haiku (same model, same params) |
+| Search result ordering | Brave `mixed.main` ranked interleave | Brave `mixed.main` ranked interleave |
+| FAQ results | Parsed and included | Parsed and included |
+| n_search_results_to_use | 1 | 1 |
+| max_searches_to_try | 5 | 5 |
+| Retry logic | tenacity (10 attempts, exp backoff) | Custom (10 attempts, exp backoff, same delays) |
+| RETRIEVAL_PROMPT {description} | Dynamic from search_tool.tool_description | Dynamic from BRAVE_DESCRIPTION constant |
+| Signature verification | N/A (GitHub Actions) | HMAC-SHA256 timing-safe comparison |
+| Idempotency | None | KV-backed dedup on delivery ID |
+| Duplicate comment detection | None | Checks for HTML marker |
+| Error handling | Prints to stdout | Posts sanitized error to PR (secrets redacted) |
+| Background processing | N/A (runs synchronously) | Cloudflare Queue (15 min wall clock, auto-retry) |
+
+## Setup
+
+### Prerequisites
+
+- [Cloudflare account](https://dash.cloudflare.com/) (Workers Paid plan required for Queues)
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+- GitHub personal access token with `repo` scope
+- [Anthropic API key](https://console.anthropic.com/)
+- [Brave Search API key](https://brave.com/search/api/)
+
+### 1. Create KV namespace and Queue
+
+```bash
+wrangler kv namespace create DEDUP_KV
+wrangler queues create articlecheck-pipeline
+```
+
+Update `wrangler.toml` with the returned KV namespace ID.
+
+### 2. Set secrets
+
+```bash
+wrangler secret put GITHUB_WEBHOOK_SECRET
+wrangler secret put GITHUB_TOKEN
+wrangler secret put ANTHROPIC_API_KEY
+wrangler secret put BRAVE_API_KEY
+wrangler secret put WIKI_REVIEWERS  # JSON array: '["evgenydmitriev","reviewer2"]'
+```
+
+Optional model overrides:
+```bash
+wrangler secret put ANTHROPIC_MODEL          # default: claude-3-opus-20240229
+wrangler secret put ANTHROPIC_MAX_TOKENS     # default: 4000
+```
+
+### 3. Deploy
+
+```bash
+cd workers/articlecheck
+npm install
+npm run deploy
+```
+
+### 4. Configure GitHub webhook
+
+In repo Settings → Webhooks:
+
+- **Payload URL**: `https://articlecheck.<subdomain>.workers.dev`
+- **Content type**: `application/json`
+- **Secret**: Same value as `GITHUB_WEBHOOK_SECRET`
+- **Events**: Select "Issue comments"
+
+### 5. Disable the old GitHub Actions workflow
+
+This PR changes the legacy `article-check-claude.yml` trigger to `workflow_dispatch` only (manual), so it won't run on `/articlecheck` comments anymore. The duplication-check and plagiarism-check workflows are unaffected.
+
+## Development
+
+```bash
+npm install
+npm run dev        # Local dev server
+npm test           # Run all tests (74 tests)
+npm run typecheck  # TypeScript strict mode check
+```
+
+## File Structure
+
+```
+src/
+  index.ts      — fetch handler (webhook) + queue handler (pipeline consumer)
+  github.ts     — Signature verification, diff fetching/parsing, PR commenting
+  pipeline.ts   — 3-phase Claude AI pipeline (extract → fact-check → review)
+  brave.ts      — Brave Search with HTMLRewriter scraping + Claude Haiku summarization
+  prompts.ts    — All Claude prompts (preserved verbatim from Python)
+  types.ts      — TypeScript interfaces
+test/
+  github.test.ts      — 31 unit tests for GitHub utilities + tag extraction
+  brave.test.ts       — 7 unit tests for search formatting + description matching
+  simulation.test.ts  — 36 E2E simulation + adversarial tests
+```
+
+## Resource Usage Per Review
+
+| Resource | Count | Notes |
+|----------|-------|-------|
+| Claude Opus API calls | 3-8 | 1 extract + 1-5 fact-check + 1 editorial |
+| Claude Haiku API calls | 1-5 | 1 per scraped web page (summarization) |
+| Brave Search API calls | 1-5 | 1 per fact-checked statement |
+| Web page fetches | 1-5 | 1 per search query (n_search_results_to_use=1) |
+| Estimated wall clock | 60-180s | Well within Queue's 15-minute limit |
+| KV operations | 2 | 1 get + 1 put for dedup |
+| Queue messages | 1 | 1 per webhook |
+| Bundle size | 36 KiB gzip | Single worker |

--- a/tools/articlecheck-worker/package.json
+++ b/tools/articlecheck-worker/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "articlecheck-worker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250313.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/tools/articlecheck-worker/src/brave.ts
+++ b/tools/articlecheck-worker/src/brave.ts
@@ -1,0 +1,376 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * Brave Search Tool description — injected into RETRIEVAL_PROMPT's {description} placeholder.
+ * Preserved verbatim from Python: claude_retriever/searcher/searchtools/websearch.py
+ */
+export const BRAVE_DESCRIPTION =
+  "Brave Search Engine Tool: The search engine will search using the Brave search engine for web pages with keywords similar to your query. It returns for each page its title, a summary and potentially the full page content. Use this tool if you want to get up-to-date and comprehensive information on a topic.";
+
+/**
+ * Summarization model config — matches Python config.json:
+ *   ANTHROPIC_SUMMARIZE_MODEL: "claude-3-haiku-20240307"
+ *   ANTHROPIC_SUMMARIZE_TEMPERATURE: 0.0
+ *   ANTHROPIC_SUMMARIZE_MAX_TOKENS: 512
+ */
+const SUMMARIZE_MODEL = "claude-3-haiku-20240307";
+const SUMMARIZE_MAX_TOKENS = 512;
+const SUMMARIZE_TEMPERATURE = 0;
+
+// ─── Retry ──────────────────────────────────────────────────────────────────
+
+/**
+ * Retry with exponential backoff. Matches Python tenacity config:
+ *   @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(10))
+ */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts: number = 10,
+  minDelayMs: number = 4000,
+  maxDelayMs: number = 10000
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxAttempts - 1) {
+        const delay = Math.min(
+          minDelayMs * Math.pow(2, attempt),
+          maxDelayMs
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+  }
+  throw lastError;
+}
+
+// ─── HTMLRewriter-based Text Extraction ─────────────────────────────────────
+
+/**
+ * Extract visible text from an HTML Response using Cloudflare's HTMLRewriter.
+ *
+ * This is the Workers-native equivalent of BeautifulSoup's get_text(strip=True, separator='\n').
+ * HTMLRewriter is a streaming parser — far more efficient than loading the entire DOM,
+ * and unlike regex, it correctly handles nested tags, CDATA, comments, etc.
+ */
+async function extractTextFromHtml(response: Response): Promise<string> {
+  let collected = "";
+
+  // Strip script/style/noscript and collect visible text.
+  // Only these three are stripped — matching Python BeautifulSoup get_text() behavior
+  // which extracts ALL visible text (including nav/header/footer).
+  // Claude Haiku handles further content filtering in the summarization step.
+  const rewriter = new HTMLRewriter()
+    .on("script", { element(el) { el.remove(); } })
+    .on("style", { element(el) { el.remove(); } })
+    .on("noscript", { element(el) { el.remove(); } })
+    .on("*", {
+      text(chunk) {
+        collected += chunk.text;
+        if (chunk.lastInTextNode) {
+          collected += "\n";
+        }
+      },
+    });
+
+  // Must consume the transformed response to trigger all handlers
+  await rewriter.transform(response).text();
+
+  // Collapse whitespace (mirrors bleach.clean + BeautifulSoup get_text(strip=True))
+  return collected
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+/**
+ * Fetch a web page and extract text content using HTMLRewriter.
+ * Matches Python: get_url_content() with BeautifulSoup + bleach
+ */
+async function fetchPageContent(
+  url: string,
+  timeoutMs: number = 10000
+): Promise<string | null> {
+  try {
+    if (!isValidUrl(url)) return null;
+
+    const resp = await fetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!resp.ok) return null;
+
+    const text = await extractTextFromHtml(resp);
+    return text.length > 50 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// ─── Claude Haiku Summarization ─────────────────────────────────────────────
+
+/**
+ * Summarize scraped page content using Claude Haiku.
+ * Matches Python: claude_extract_article() in utils.py
+ *
+ * Sends raw page content to Claude Haiku for focused article extraction,
+ * stripping nav, ads, sidebars, footers. This is the key quality step.
+ */
+async function summarizeWithClaude(
+  content: string,
+  query: string,
+  anthropicApiKey: string,
+  maxTokensToRead: number = 20_000
+): Promise<string> {
+  // Truncate if too long (matches Python tokenizer truncation)
+  // ~4 chars per token for English text
+  const maxChars = maxTokensToRead * 4;
+  if (content.length > maxChars) {
+    content = content.slice(0, maxChars);
+  }
+
+  const promptText =
+    `Here is the content from a web page. Please extract only the article from this content:\n${content}` +
+    `\nThis extraction is in response to the following user query:\n${query}`;
+
+  const instructions = `
+    Extract the main article content from this web page, excluding site navigation, advertisements, sidebars, and other non-essential elements. Ensure the extracted text is clean and contains only the relevant information focusing solely on the primary article.
+    `;
+
+  const client = new Anthropic({ apiKey: anthropicApiKey });
+  const response = await client.messages.create({
+    model: SUMMARIZE_MODEL,
+    stop_sequences: ["</article>"],
+    max_tokens: SUMMARIZE_MAX_TOKENS,
+    temperature: SUMMARIZE_TEMPERATURE,
+    messages: [{ role: "user", content: `${promptText} ${instructions}` }],
+  });
+
+  let extracted = (response.content[0] as Anthropic.TextBlock).text;
+  if (!extracted.endsWith("</article>")) {
+    extracted += "</article>";
+  }
+  return `<article>${extracted}`;
+}
+
+/**
+ * Scrape a URL and summarize with Claude.
+ * Matches Python: scrape_url(url, summarize_with_claude=True, ...)
+ */
+async function scrapeUrl(
+  url: string,
+  query: string,
+  anthropicApiKey: string
+): Promise<string> {
+  const content = await fetchPageContent(url);
+  if (!content) return "CONTENT NOT AVAILABLE";
+
+  try {
+    return await summarizeWithClaude(content, query, anthropicApiKey);
+  } catch {
+    // Fall back to raw content on summarization failure
+    // Matches Python: "Failed to extract with Claude. Falling back to raw content."
+    return content;
+  }
+}
+
+// ─── Brave Search API ───────────────────────────────────────────────────────
+
+interface BraveSearchResponse {
+  web?: { results?: Array<{ title: string; url: string; description: string }> };
+  news?: {
+    results?: Array<{
+      title: string;
+      url: string;
+      description: string;
+      age?: string;
+      meta_url?: { hostname?: string };
+    }>;
+  };
+  faq?: {
+    results?: Array<{
+      title: string;
+      url: string;
+      question: string;
+      answer: string;
+    }>;
+  };
+  mixed?: { main?: Array<{ type: string }> };
+}
+
+function removeStrong(text: string): string {
+  return text
+    .replace(/<strong>/g, "")
+    .replace(/<\/strong>/g, "")
+    .replace(/&#x27;/g, "'");
+}
+
+/**
+ * Search Brave and return formatted results with page scraping + Claude summarization.
+ *
+ * Matches Python BraveSearchTool.raw_search() exactly:
+ * 1. Call Brave API (with retry)
+ * 2. Use `mixed.main` ordering to interleave web/news/faq in correct rank order
+ * 3. For web results: scrape page content via HTMLRewriter + summarize with Claude Haiku
+ * 4. For news results: include title, description, age, source
+ * 5. For FAQ results: include title, question, answer
+ * 6. Return n_search_results_to_use results
+ */
+export async function braveSearch(
+  query: string,
+  braveApiKey: string,
+  anthropicApiKey: string,
+  nSearchResultsToUse: number = 1
+): Promise<string[]> {
+  return withRetry(() =>
+    braveSearchInner(query, braveApiKey, anthropicApiKey, nSearchResultsToUse)
+  );
+}
+
+async function braveSearchInner(
+  query: string,
+  braveApiKey: string,
+  anthropicApiKey: string,
+  nSearchResultsToUse: number
+): Promise<string[]> {
+  const params = new URLSearchParams({ q: query, count: "20" });
+  const resp = await fetch(
+    `https://api.search.brave.com/res/v1/web/search?${params}`,
+    {
+      headers: {
+        Accept: "application/json",
+        "X-Subscription-Token": braveApiKey,
+      },
+    }
+  );
+
+  if (!resp.ok) return [];
+  const data = (await resp.json()) as BraveSearchResponse;
+
+  // Use Brave's mixed ordering for correct ranking
+  // Matches Python: correct_ordering = search_response.get("mixed", {}).get("main", [])
+  const ordering = data.mixed?.main ?? [];
+  const webItems = [...(data.web?.results ?? [])];
+  const newsItems = [...(data.news?.results ?? [])];
+  const faqItems = [...(data.faq?.results ?? [])];
+
+  const results: string[] = [];
+  const webScrapeTasks: Array<{
+    index: number;
+    url: string;
+    title: string;
+    desc: string;
+  }> = [];
+
+  // First pass: collect items in ranked order, queue web scraping
+  for (const item of ordering) {
+    if (results.length >= nSearchResultsToUse) break;
+
+    if (item.type === "web" && webItems.length > 0) {
+      const web = webItems.shift()!;
+      const desc = removeStrong(web.description ?? "");
+      // Placeholder — replaced with scraped content below
+      results.push(
+        `Web Page Title: ${web.title}\nWeb Page URL: ${web.url}\nWeb Page Description: ${desc}`
+      );
+      webScrapeTasks.push({
+        index: results.length - 1,
+        url: web.url,
+        title: web.title,
+        desc,
+      });
+    } else if (item.type === "news" && newsItems.length > 0) {
+      const news = newsItems.shift()!;
+      if (news.description && news.description.length > 5) {
+        results.push(
+          `News Article Title: ${news.title}\n` +
+            `News Article Description: ${news.description}\n` +
+            `News Article Age: ${news.age ?? "Unknown"}\n` +
+            `News Article Source: ${news.meta_url?.hostname ?? "Unknown"}`
+        );
+      }
+    } else if (item.type === "faq" && faqItems.length > 0) {
+      const faq = faqItems.shift()!;
+      results.push(
+        `FAQ Title: ${faq.title ?? "Unknown"}\n` +
+          `Question: ${faq.question ?? "Unknown"}\n` +
+          `Answer: ${faq.answer ?? "Unknown"}`
+      );
+    }
+  }
+
+  // Fallback if mixed ordering is empty/missing
+  if (results.length === 0) {
+    for (const web of webItems.slice(0, nSearchResultsToUse)) {
+      const desc = removeStrong(web.description ?? "");
+      results.push(
+        `Web Page Title: ${web.title}\nWeb Page URL: ${web.url}\nWeb Page Description: ${desc}`
+      );
+      webScrapeTasks.push({
+        index: results.length - 1,
+        url: web.url,
+        title: web.title,
+        desc,
+      });
+    }
+  }
+
+  // Scrape web pages in parallel + summarize with Claude Haiku
+  // Matches Python: asyncio.gather(*web_parsing_tasks)
+  if (webScrapeTasks.length > 0) {
+    const scraped = await Promise.allSettled(
+      webScrapeTasks.map((task) =>
+        scrapeUrl(task.url, query, anthropicApiKey)
+      )
+    );
+
+    for (let i = 0; i < webScrapeTasks.length; i++) {
+      const task = webScrapeTasks[i]!;
+      const result = scraped[i]!;
+
+      let snippet = `Web Page Title: ${task.title}\nWeb Page URL: ${task.url}`;
+      if (result.status === "fulfilled" && result.value !== "CONTENT NOT AVAILABLE") {
+        const content = result.value;
+        if (content.startsWith("<summary>") || content.startsWith("<article>")) {
+          snippet += `\nWeb Page Summary: ${content}`;
+        } else {
+          snippet += `\nWeb Page Content: ${content}`;
+        }
+      } else {
+        snippet += `\nWeb Page Description: ${task.desc}`;
+      }
+      results[task.index] = snippet;
+    }
+  }
+
+  return results.slice(0, nSearchResultsToUse);
+}
+
+// ─── Formatting ─────────────────────────────────────────────────────────────
+
+/**
+ * Format search results into XML string for Claude.
+ * Matches Python: format_results_full() in utils.py
+ */
+export function formatSearchResults(results: string[]): string {
+  const items = results
+    .map(
+      (r, i) =>
+        `<item index="${i + 1}">\n<page_content>\n${r}\n</page_content>\n</item>`
+    )
+    .join("\n");
+  return `\n<search_results>\n${items}\n</search_results>`;
+}

--- a/tools/articlecheck-worker/src/github.ts
+++ b/tools/articlecheck-worker/src/github.ts
@@ -1,0 +1,183 @@
+import type { Env, WebhookPayload, DiffFile } from "./types";
+
+/**
+ * Verify GitHub webhook HMAC-SHA256 signature using timing-safe comparison.
+ */
+export async function verifySignature(
+  body: string,
+  signature: string | null,
+  secret: string
+): Promise<boolean> {
+  if (!signature || !signature.startsWith("sha256=")) return false;
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signed = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  const expectedBytes = new Uint8Array(signed);
+
+  // Parse the hex signature from GitHub
+  const sigHex = signature.slice("sha256=".length);
+  if (sigHex.length !== expectedBytes.length * 2) return false;
+  // Validate hex string contains only valid hex characters
+  if (!/^[0-9a-f]+$/i.test(sigHex)) return false;
+
+  const actualBytes = new Uint8Array(expectedBytes.length);
+  for (let i = 0; i < actualBytes.length; i++) {
+    actualBytes[i] = parseInt(sigHex.slice(i * 2, i * 2 + 2), 16);
+  }
+
+  // Constant-time comparison to prevent timing attacks
+  return timingSafeEqual(expectedBytes, actualBytes);
+}
+
+/**
+ * Constant-time comparison of two byte arrays.
+ * Prevents timing-based side-channel attacks on signature verification.
+ */
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return result === 0;
+}
+
+/**
+ * Check if the commenter is in the allowed reviewers list.
+ */
+export function isAllowedReviewer(
+  actor: string,
+  reviewersJson: string
+): boolean {
+  try {
+    const reviewers: string[] = JSON.parse(reviewersJson);
+    return reviewers.includes(actor);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch the PR diff from GitHub.
+ */
+export async function fetchPrDiff(
+  diffUrl: string,
+  token: string
+): Promise<string> {
+  const resp = await fetch(diffUrl, {
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github.v3.diff",
+      "User-Agent": "articlecheck-worker",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch diff: ${resp.status} ${resp.statusText}`);
+  }
+  return resp.text();
+}
+
+/**
+ * Parse a unified diff into structured file objects.
+ * Matches the Python parse_diff behavior: splits on "diff --git " and "@@"
+ * segments, returning header + body pairs for each hunk.
+ */
+export function parseDiff(diff: string): DiffFile[] {
+  const rawFiles = diff.split("diff --git ");
+  rawFiles.shift(); // remove empty first element
+
+  return rawFiles.map((raw) => {
+    const segments = raw.split("@@");
+    const header = segments.shift() ?? "";
+
+    // Build body segments as pairs: [range_info, content] matching Python behavior
+    const bodySegments: Array<{ header: string; body: string }> = [];
+    for (let i = 0; i < segments.length; i += 2) {
+      if (segments[i + 1] !== undefined) {
+        bodySegments.push({
+          header: segments[i]!,
+          body: segments[i + 1]!,
+        });
+      }
+    }
+    return { header, bodySegments };
+  });
+}
+
+/**
+ * Extract article text from parsed diff files.
+ * Matches Python behavior: first file, first hunk only.
+ *   text = remove_plus(diff[0]['header'] + diff[0]['body'][0]['body'])
+ */
+export function extractArticleText(files: DiffFile[]): string | null {
+  if (files.length === 0) return null;
+  const file = files[0]!;
+  const firstBody = file.bodySegments[0]?.body ?? "";
+  return removePlus(file.header + firstBody);
+}
+
+/**
+ * Strip leading '+' from diff lines (added lines).
+ */
+export function removePlus(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.startsWith("+") ? line.slice(1) : line))
+    .join("\n");
+}
+
+/**
+ * Post a comment on a GitHub PR.
+ */
+export async function postPrComment(
+  repo: string,
+  prNumber: number,
+  body: string,
+  token: string
+): Promise<void> {
+  const url = `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github.v3+json",
+      "Content-Type": "application/json",
+      "User-Agent": "articlecheck-worker",
+    },
+    body: JSON.stringify({ body }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Failed to post comment: ${resp.status} ${text}`);
+  }
+}
+
+/**
+ * Check if the bot has already posted a review comment on this PR.
+ * Looks for the HTML marker comment.
+ */
+export async function hasExistingReview(
+  repo: string,
+  prNumber: number,
+  token: string
+): Promise<boolean> {
+  const url = `https://api.github.com/repos/${repo}/issues/${prNumber}/comments?per_page=100`;
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "articlecheck-worker",
+    },
+  });
+  if (!resp.ok) return false;
+
+  const comments = (await resp.json()) as Array<{ body: string }>;
+  return comments.some((c) => c.body.includes("<!-- articlecheck-worker -->"));
+}

--- a/tools/articlecheck-worker/src/index.ts
+++ b/tools/articlecheck-worker/src/index.ts
@@ -1,0 +1,188 @@
+import type { Env, WebhookPayload, PipelineJob } from "./types";
+import {
+  verifySignature,
+  isAllowedReviewer,
+  fetchPrDiff,
+  parseDiff,
+  extractArticleText,
+  postPrComment,
+  hasExistingReview,
+} from "./github";
+import { runPipeline } from "./pipeline";
+
+const MARKER = "<!-- articlecheck-worker -->";
+const ERROR_MARKER = "<!-- articlecheck-worker-error -->";
+
+export default {
+  /**
+   * HTTP handler — receives GitHub webhooks, validates, enqueues pipeline jobs.
+   *
+   * Responds within milliseconds so GitHub sees a 202 before its 10s timeout.
+   * Actual pipeline work happens in the queue consumer below, which gets
+   * 15 minutes of wall clock time (vs 30s for waitUntil).
+   */
+  async fetch(
+    request: Request,
+    env: Env,
+    _ctx: ExecutionContext
+  ): Promise<Response> {
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    const body = await request.text();
+
+    // 1. Verify webhook signature (timing-safe)
+    const signature = request.headers.get("X-Hub-Signature-256");
+    const valid = await verifySignature(
+      body,
+      signature,
+      env.GITHUB_WEBHOOK_SECRET
+    );
+    if (!valid) {
+      return new Response("Invalid signature", { status: 401 });
+    }
+
+    // 2. Parse and validate event type
+    const event = request.headers.get("X-GitHub-Event");
+    if (event !== "issue_comment") {
+      return new Response("Ignored event", { status: 200 });
+    }
+
+    let payload: WebhookPayload;
+    try {
+      payload = JSON.parse(body);
+    } catch {
+      return new Response("Invalid JSON", { status: 400 });
+    }
+
+    if (payload.action !== "created") {
+      return new Response("Ignored action", { status: 200 });
+    }
+
+    if (!payload.comment.body.includes("/articlecheck")) {
+      return new Response("No trigger command", { status: 200 });
+    }
+
+    if (!payload.issue.pull_request) {
+      return new Response("Not a PR", { status: 200 });
+    }
+
+    // 3. Check reviewer permissions
+    if (
+      !isAllowedReviewer(payload.comment.user.login, env.WIKI_REVIEWERS)
+    ) {
+      return new Response("Unauthorized reviewer", { status: 403 });
+    }
+
+    // 4. Idempotency check via KV
+    const deliveryId = request.headers.get("X-GitHub-Delivery") ?? "";
+    const dedupKey = `check:${deliveryId}:${payload.comment.id}`;
+    const existing = await env.DEDUP_KV.get(dedupKey);
+    if (existing) {
+      return new Response("Already processed", { status: 200 });
+    }
+
+    // 5. Enqueue pipeline job BEFORE writing KV.
+    // If queue send fails, no KV entry → GitHub retries cleanly.
+    // If queue send succeeds but KV put fails, worst case is a
+    // duplicate that hasExistingReview() catches in the consumer.
+    const job: PipelineJob = {
+      repo: payload.repository.full_name,
+      prNumber: payload.issue.number,
+      diffUrl: payload.issue.pull_request.diff_url,
+    };
+    await env.PIPELINE_QUEUE.send(job);
+    await env.DEDUP_KV.put(dedupKey, "processing", {
+      expirationTtl: 86400,
+    });
+
+    return new Response("Accepted", { status: 202 });
+  },
+
+  /**
+   * Queue consumer — processes pipeline jobs with 15 minutes wall clock time.
+   *
+   * This is where the heavy work happens: fetch diff, run 3-phase Claude
+   * pipeline (extract → fact-check with Brave → editorial review), post
+   * review comment on the PR.
+   *
+   * Failed messages are retried up to 2 times by the Queue (see wrangler.toml).
+   */
+  async queue(
+    batch: MessageBatch<PipelineJob>,
+    env: Env
+  ): Promise<void> {
+    for (const message of batch.messages) {
+      try {
+        await processJob(message.body, env);
+        message.ack();
+      } catch (err) {
+        const raw = err instanceof Error ? err.message : String(err);
+        const safe = raw
+          .replace(/sk-[a-zA-Z0-9-]+/g, "[REDACTED]")
+          .replace(/token [a-zA-Z0-9_-]+/gi, "token [REDACTED]")
+          .slice(0, 200);
+
+        // Post error to PR before retrying.
+        // Uses ERROR_MARKER (not MARKER) so hasExistingReview() doesn't
+        // mistake an error comment for a successful review — retries must
+        // be able to proceed after a prior failure.
+        await postPrComment(
+          message.body.repo,
+          message.body.prNumber,
+          `${ERROR_MARKER}\nArticle check encountered an error. Retrying automatically.\n\n<details><summary>Details</summary>\n\n\`${safe}\`\n</details>`,
+          env.GITHUB_TOKEN
+        ).catch(() => {});
+
+        message.retry();
+      }
+    }
+  },
+};
+
+async function processJob(job: PipelineJob, env: Env): Promise<void> {
+  const { repo, prNumber, diffUrl } = job;
+
+  // Check for existing bot review to avoid duplicate comments
+  const alreadyReviewed = await hasExistingReview(
+    repo,
+    prNumber,
+    env.GITHUB_TOKEN
+  );
+  if (alreadyReviewed) return;
+
+  // Fetch and parse the PR diff
+  const rawDiff = await fetchPrDiff(diffUrl, env.GITHUB_TOKEN);
+  const files = parseDiff(rawDiff);
+
+  // Extract article text (first file, first hunk — matching Python behavior)
+  const articleText = extractArticleText(files);
+  if (!articleText || articleText.trim().length < 20) {
+    await postPrComment(
+      repo,
+      prNumber,
+      `${MARKER}\nNo article content found in this PR.`,
+      env.GITHUB_TOKEN
+    );
+    return;
+  }
+
+  // Run the 3-phase pipeline
+  const model = env.ANTHROPIC_MODEL;
+  const maxTokens = env.ANTHROPIC_MAX_TOKENS
+    ? parseInt(env.ANTHROPIC_MAX_TOKENS, 10)
+    : undefined;
+
+  const review = await runPipeline(
+    articleText,
+    env.ANTHROPIC_API_KEY,
+    env.BRAVE_API_KEY,
+    model,
+    maxTokens
+  );
+
+  // Post the review comment
+  const comment = `${MARKER}\n## Article Check Results\n\n${review}`;
+  await postPrComment(repo, prNumber, comment, env.GITHUB_TOKEN);
+}

--- a/tools/articlecheck-worker/src/pipeline.ts
+++ b/tools/articlecheck-worker/src/pipeline.ts
@@ -1,0 +1,196 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { braveSearch, formatSearchResults, BRAVE_DESCRIPTION } from "./brave";
+import { EXTRACTING_PROMPT, RETRIEVAL_PROMPT, ANSWER_PROMPT } from "./prompts";
+
+/**
+ * Default config values — match Python config.json:
+ *   ANTHROPIC_SEARCH_MODEL: "claude-3-opus-20240229"
+ *   ANTHROPIC_SEARCH_TEMPERATURE: 0.0
+ *   ANTHROPIC_SEARCH_MAX_TOKENS: 4000
+ *
+ * And article_checker_claude.py:
+ *   n_search_results_to_use=1
+ *   max_searches_to_try=5
+ */
+const DEFAULT_MODEL = "claude-3-opus-20240229";
+const DEFAULT_MAX_TOKENS = 4000;
+const TEMPERATURE = 0;
+const N_SEARCH_RESULTS_TO_USE = 1;
+const MAX_SEARCHES_TO_TRY = 5;
+
+/**
+ * Extract text between XML tags (last match).
+ * Matches Python: extract_between_tags() in client.py and utils.py
+ */
+export function extractBetweenTags(
+  tag: string,
+  text: string
+): string | null {
+  const re = new RegExp(`<${tag}\\s?>(.+?)</${tag}\\s?>`, "gs");
+  const matches = [...text.matchAll(re)];
+  if (matches.length === 0) return null;
+  return matches[matches.length - 1]![1]!.trim();
+}
+
+export interface PipelineConfig {
+  model: string;
+  maxTokens: number;
+}
+
+/**
+ * Phase 1: Extract factual statements from article text.
+ * Matches Python: ClientWithRetrieval.extract_statements()
+ */
+async function extractStatements(
+  text: string,
+  client: Anthropic,
+  config: PipelineConfig
+): Promise<string> {
+  const message = await client.messages.create({
+    model: config.model,
+    max_tokens: config.maxTokens,
+    temperature: TEMPERATURE,
+    system: EXTRACTING_PROMPT,
+    messages: [{ role: "user", content: `<text>${text}</text>` }],
+  });
+  return (message.content[0] as Anthropic.TextBlock).text;
+}
+
+/**
+ * Phase 2: Fact-check statements using Brave Search in a loop.
+ *
+ * Mirrors Python ClientWithRetrieval.retrieve() exactly:
+ * - Single user message that accumulates all context (statements + partial responses + search results)
+ * - Stop on </search_query>, run search, append results, continue
+ * - Loop up to min(num_statements, max_searches_to_try) times
+ * - n_search_results_to_use=1 per search (matching Python article_checker_claude.py line 47)
+ * - {description} in system prompt filled with BRAVE_DESCRIPTION (matching Python line 165)
+ */
+async function factCheck(
+  statements: string,
+  client: Anthropic,
+  braveApiKey: string,
+  anthropicApiKey: string,
+  config: PipelineConfig
+): Promise<string> {
+  const numMatch = extractBetweenTags("number_of_statements", statements);
+  const numStatements = numMatch ? parseInt(numMatch, 10) : MAX_SEARCHES_TO_TRY;
+  const maxSearches = Math.min(numStatements, MAX_SEARCHES_TO_TRY);
+
+  const currentTime = new Date().toISOString().replace("T", " ").slice(0, 19);
+  const systemPrompt = RETRIEVAL_PROMPT
+    .replace("{current_time}", currentTime)
+    .replace("{description}", BRAVE_DESCRIPTION);
+
+  let accumulated = "";
+  let conversationText = statements;
+
+  for (let i = 0; i < maxSearches; i++) {
+    const message = await client.messages.create({
+      model: config.model,
+      max_tokens: config.maxTokens,
+      temperature: TEMPERATURE,
+      system: systemPrompt,
+      messages: [{ role: "user", content: conversationText }],
+      stop_sequences: ["</search_query>"],
+    });
+
+    const block = message.content[0] as Anthropic.TextBlock;
+    const partial = block.text;
+    accumulated += partial;
+    conversationText += partial;
+
+    // Match Python: if stop_reason == 'stop_sequence' and stop_seq == '</search_query>'
+    if (
+      message.stop_reason !== "stop_sequence"
+    ) {
+      break;
+    }
+
+    // Extract search query
+    const query = extractBetweenTags(
+      "search_query",
+      partial + "</search_query>"
+    );
+    if (!query) break;
+
+    // Run Brave search with n_search_results_to_use=1 and Claude Haiku summarization
+    const searchResults = await braveSearch(
+      query,
+      braveApiKey,
+      anthropicApiKey,
+      N_SEARCH_RESULTS_TO_USE
+    );
+    const formatted = formatSearchResults(searchResults);
+
+    accumulated += "</search_query>" + formatted;
+    conversationText += "</search_query>" + formatted;
+  }
+
+  return accumulated;
+}
+
+/**
+ * Phase 3: Generate editorial review from fact-check results.
+ * Matches Python: ClientWithRetrieval.answer_with_results()
+ */
+async function editorialReview(
+  factCheckResults: string,
+  articleText: string,
+  client: Anthropic,
+  config: PipelineConfig
+): Promise<string> {
+  const prompt = `<fact_checking_results>${factCheckResults}</fact_checking_results> <text>${articleText}</text>`;
+
+  const message = await client.messages.create({
+    model: config.model,
+    max_tokens: config.maxTokens,
+    temperature: TEMPERATURE,
+    system: ANSWER_PROMPT,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text = (message.content[0] as Anthropic.TextBlock).text;
+  return extractBetweenTags("answer", text) ?? text;
+}
+
+/**
+ * Run the full 3-phase article check pipeline.
+ *
+ * Matches Python: ClientWithRetrieval.completion_with_retrieval()
+ *   Phase 1: extract_statements() → extract factual claims
+ *   Phase 2: retrieve() → fact-check via Brave Search + Claude loop
+ *   Phase 3: answer_with_results() → comprehensive editorial review
+ */
+export async function runPipeline(
+  articleText: string,
+  anthropicApiKey: string,
+  braveApiKey: string,
+  model?: string,
+  maxTokens?: number
+): Promise<string> {
+  const client = new Anthropic({ apiKey: anthropicApiKey });
+  const config: PipelineConfig = {
+    model: model ?? DEFAULT_MODEL,
+    maxTokens: maxTokens ?? DEFAULT_MAX_TOKENS,
+  };
+
+  const statements = await extractStatements(articleText, client, config);
+
+  const factCheckResults = await factCheck(
+    statements,
+    client,
+    braveApiKey,
+    anthropicApiKey,
+    config
+  );
+
+  const review = await editorialReview(
+    factCheckResults,
+    articleText,
+    client,
+    config
+  );
+
+  return review;
+}

--- a/tools/articlecheck-worker/src/prompts.ts
+++ b/tools/articlecheck-worker/src/prompts.ts
@@ -1,0 +1,110 @@
+/**
+ * All three prompts from the original Python pipeline.
+ * Source: tools/article_checker/claude_retriever/client.py
+ *
+ * Preserved exactly, with one exception: the Python source has trailing spaces
+ * on some lines (artifact of the triple-quoted string). These are normalized
+ * here since they have no effect on Claude's behavior and trailing whitespace
+ * is stripped by most editors and linters.
+ */
+
+export const EXTRACTING_PROMPT = `Please extract important statements that appear to be factual from the text provided between <text></text> tags.
+Return the extracted statements. Place each statement within <statement></statement> tags.
+Also, return the number of extracted statements within <number_of_statements></number_of_statements> tags.
+Aim to extract important statements with numbers, dates, and names of organizations. There should not be too many extracted statements.
+Skip the preamble; go straight into the result.`;
+
+/**
+ * RETRIEVAL_PROMPT uses two template variables:
+ *   {current_time} — filled at runtime with current UTC timestamp
+ *   {description}  — filled with BRAVE_DESCRIPTION from brave.ts
+ * This matches the Python: RETRIEVAL_PROMPT.format(current_time=..., description=self.search_tool.tool_description)
+ */
+export const RETRIEVAL_PROMPT = `Your timeline extends up to the current one — {current_time}.
+You are tasked with verifying the accuracy of a series of factual statements using a search engine. Below is the search engine's description: <tool_description>{description}</tool_description>.
+For each statement within <statement></statement> tags, if the statement already has a verdict in the <verdict></verdict> tags (either 'True' or 'False'), skip it and move to the next statement. For statements without a verdict, formulate a query to check its accuracy. You can make a call to the search engine tool by inserting a query within <search_query> tags like so: <search_query>query</search_query>. You'll then get results back within <search_result></search_result> tags.
+Based on these results, determine the accuracy of each statement and categorize it as 'True', 'False', or 'Unverified'.
+Put your verdict in <verdict></verdict> tags. If a statement is true, put 'True' in the <verdict></verdict> tags.
+Include the Web Page URL in <source></source> tags. If there is no URL at all, put 'None' in the <source></source> tags.
+If a statement is false, include an explanation in <explanation></explanation> tags.
+Focus particularly on verifying numbers, dates, monetary values, and names of people or organizations.
+Avoid verifying statements that already have a True/False verdict in the <verdict></verdict> tags.
+Determine the accuracy of each statement using only information that is contained in the search_result.
+If you need to search again, put the new query in <search_query></search_query>.
+
+Statements to be verified:
+`;
+
+export const ANSWER_PROMPT = `You are an editor. Perform the following tasks:
+1. Using the information provided within the <fact_checking_results></fact_checking_results> tags,
+please form the desired output with results of fact-checking.
+List each statement from the tags <statement></statement> and accompany it with the fact-checking source
+between the tags <source></source>.  If there is no source, try to find a related link in the text between <text></text> tags and place this link in the "source" field. If there is no source at all put "None" in the "source" field.
+If the verdict is True, put the symbol ":white_check_mark:" after the statement.
+If the verdict is False, put the symbol ":x:" after the statement and also provide an explanation why.
+If the verdict is Unverified or the link was taken from the text in <text></text> tags, put the symbol ":warning:" after the statement.
+Output example:
+'''- **Statement**: Squid Game: November 1, 2021 - $5.7m :x:
+  - **Source**: [https://www.wired.co.uk/article/squid-game-crypto-scam](https://www.wired.co.uk/article/squid-game-crypto-scam)
+  - **Explanation**: The article states the Squid Game crypto scam creators pulled out $3.36 million on November 1, 2021, not $5.7 million as the statement claims.'''
+
+2. Make detailed editor's notes on the text in <text></text> tags.
+Suggest stylistic and grammatical improvements and point out any error in the text between <text></text> tags.
+Please make sure that in the '## Timeline' section, dates are written in the correct format 'Month day, year, time PM UTC:'.
+Example: 'May 05, 2023, 05:52 PM UTC:'.
+Put your detailed notes and the list of errors below the header.
+Output example:
+'''## Editor's Notes
+...'''
+
+3. Additionally, since the text between <text></text> is a Markdown document for Hugo SSG, ensure it adheres to specific Markdown formatting requirements.
+If it adheres, put the symbol ":white_check_mark:".
+If does not adhere, put the symbol ":x:" and also provide an explanation why.
+If you are not sure, put the symbol ":warning:".
+Output example:
+'''## Hugo SSG Formatting Check
+- Does it match Hugo SSG formatting? :x:
+  - **Explanation**: ...'''
+
+4. Check if the text between <text></text> follows the Markdown format, including appropriate headers.
+Confirm if it meets submission guidelines, particularly the file naming convention ("YYYY-MM-DD-entity-that-was-hacked.md"). Extract the name of the file from the text between <text></text> tags and compare it to the correct name.
+Pay special attention to matching the dates and names in the filename with the dates and names from the text.
+Verify that the text between <text></text> includes only the allowed headers: "## Summary", "## Attackers", "## Losses", "## Timeline", "## Security Failure Causes".
+Check for the presence of specific metadata headers between "---" lines, such as "date", "target-entities", "entity-types", "attack-types", "title", "loss" in the text within <text></text> tags. It must contain all and only allowed metadata headers.
+
+The 'date' metadata header must match the actual date of the event described within the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, search for dates within the text to identify the occurrence date of the event.
+Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two.
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'target-entities' metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, perform a text search to identify the target entities. Then place these entities in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them.
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'loss' metadata header must match the actual loss due the event described in the <text></text> tags, possibly mentioned in the Losses section.
+To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare the two.
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'entity-types' metadata header corresponds to the target entity. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'attack-types' metadata header matches the type of the attack described in the text. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Output example:
+'''## Filename Check
+- Correct Filename: \`2022-02-15-ValentineFloki.md\`
+- Your Filename: \`scam.md\` :x:
+
+## Section Headers Check
+- Allowed Headers: \`## Summary, ## Attackers, ## Losses, ## Timeline, ## Security Failure Causes\`
+- Your Headers: \`# Cryptocurrency Scam Types and Prevention Measures, ## 1. Rug Pull, ### Overview, ### Recognition Tips, ## 2. Honeypot, ### Overview, ### Recognition Tips\` :x:
+
+## Metadata Headers Check
+- Allowed Metadata Headers: \`date, target-entities, entity-types, attack-types, title, loss\`
+- Your Metadata Headers: \`date, target-entities, entity-types\` :x:
+- Notes:
+    - The \`date\` header has an incorrect date. It lists 2022-03-15, whereas it should be 2022-02-15 ":warning:"
+    - The \`loss\` header displays an incorrect value. It shows $100, whereas it should indicate $1000. ":warning:"
+'''
+
+Combine the results of all steps into a single output that complies with Markdown format and return it to me in <answer></answer> tags.
+`;

--- a/tools/articlecheck-worker/src/types.ts
+++ b/tools/articlecheck-worker/src/types.ts
@@ -1,0 +1,40 @@
+export interface Env {
+  GITHUB_WEBHOOK_SECRET: string;
+  GITHUB_TOKEN: string;
+  ANTHROPIC_API_KEY: string;
+  BRAVE_API_KEY: string;
+  WIKI_REVIEWERS: string;
+  DEDUP_KV: KVNamespace;
+  PIPELINE_QUEUE: Queue;
+  // Optional overrides
+  ANTHROPIC_MODEL?: string;
+  ANTHROPIC_MAX_TOKENS?: string;
+}
+
+export interface WebhookPayload {
+  action: string;
+  comment: {
+    id: number;
+    body: string;
+    user: { login: string };
+  };
+  issue: {
+    number: number;
+    pull_request?: { url: string; diff_url: string; html_url: string };
+  };
+  repository: {
+    full_name: string;
+  };
+}
+
+export interface DiffFile {
+  header: string;
+  bodySegments: Array<{ header: string; body: string }>;
+}
+
+/** Message payload enqueued for the pipeline consumer. */
+export interface PipelineJob {
+  repo: string;
+  prNumber: number;
+  diffUrl: string;
+}

--- a/tools/articlecheck-worker/test/brave.test.ts
+++ b/tools/articlecheck-worker/test/brave.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { formatSearchResults, BRAVE_DESCRIPTION } from "../src/brave";
+
+describe("BRAVE_DESCRIPTION", () => {
+  it("matches the Python BRAVE_DESCRIPTION exactly", () => {
+    expect(BRAVE_DESCRIPTION).toBe(
+      "Brave Search Engine Tool: The search engine will search using the Brave search engine for web pages with keywords similar to your query. It returns for each page its title, a summary and potentially the full page content. Use this tool if you want to get up-to-date and comprehensive information on a topic."
+    );
+  });
+});
+
+describe("formatSearchResults", () => {
+  it("formats results into XML search_results", () => {
+    const results = ["Result 1 content", "Result 2 content"];
+    const formatted = formatSearchResults(results);
+
+    expect(formatted).toContain("<search_results>");
+    expect(formatted).toContain("</search_results>");
+    expect(formatted).toContain('<item index="1">');
+    expect(formatted).toContain('<item index="2">');
+    expect(formatted).toContain("<page_content>");
+    expect(formatted).toContain("Result 1 content");
+    expect(formatted).toContain("Result 2 content");
+  });
+
+  it("handles empty results", () => {
+    const formatted = formatSearchResults([]);
+    expect(formatted).toContain("<search_results>");
+    expect(formatted).toContain("</search_results>");
+    expect(formatted).not.toContain("<item");
+  });
+
+  it("handles results with special characters", () => {
+    const results = ['Content with <html> tags & "quotes" and \'apostrophes\''];
+    const formatted = formatSearchResults(results);
+    expect(formatted).toContain("<html>");
+    expect(formatted).toContain("&");
+  });
+
+  it("indexes start at 1, not 0", () => {
+    const formatted = formatSearchResults(["a", "b", "c"]);
+    expect(formatted).toContain('index="1"');
+    expect(formatted).toContain('index="2"');
+    expect(formatted).toContain('index="3"');
+    expect(formatted).not.toContain('index="0"');
+  });
+
+  it("matches Python format_results_full output structure", () => {
+    // Python: f'\n<search_results>\n{format_results(extracted)}\n</search_results>'
+    // Python format_results: f'<item index="{i+1}">\n<page_content>\n{r}\n</page_content>\n</item>'
+    const formatted = formatSearchResults(["test"]);
+    expect(formatted).toBe(
+      '\n<search_results>\n<item index="1">\n<page_content>\ntest\n</page_content>\n</item>\n</search_results>'
+    );
+  });
+});

--- a/tools/articlecheck-worker/test/github.test.ts
+++ b/tools/articlecheck-worker/test/github.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDiff,
+  removePlus,
+  isAllowedReviewer,
+  extractArticleText,
+} from "../src/github";
+import { extractBetweenTags } from "../src/pipeline";
+
+// ─── isAllowedReviewer ──────────────────────────────────────────────────────
+
+describe("isAllowedReviewer", () => {
+  it("returns true for allowed user", () => {
+    expect(isAllowedReviewer("alice", '["alice","bob"]')).toBe(true);
+  });
+
+  it("returns false for disallowed user", () => {
+    expect(isAllowedReviewer("eve", '["alice","bob"]')).toBe(false);
+  });
+
+  it("returns false on invalid JSON", () => {
+    expect(isAllowedReviewer("alice", "not-json")).toBe(false);
+  });
+
+  it("returns false on empty list", () => {
+    expect(isAllowedReviewer("alice", "[]")).toBe(false);
+  });
+
+  it("is case-sensitive (GitHub usernames are case-sensitive)", () => {
+    expect(isAllowedReviewer("Alice", '["alice"]')).toBe(false);
+  });
+
+  it("handles single-element array", () => {
+    expect(isAllowedReviewer("solo", '["solo"]')).toBe(true);
+  });
+
+  it("handles empty string actor", () => {
+    expect(isAllowedReviewer("", '["alice"]')).toBe(false);
+  });
+
+  it("handles empty string reviewers", () => {
+    expect(isAllowedReviewer("alice", "")).toBe(false);
+  });
+});
+
+// ─── parseDiff ──────────────────────────────────────────────────────────────
+
+describe("parseDiff", () => {
+  const REALISTIC_DIFF = `diff --git a/content/attacks/2024-01-15-TestExchange.md b/content/attacks/2024-01-15-TestExchange.md
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/content/attacks/2024-01-15-TestExchange.md
+@@ -0,0 +1,30 @@
++---
++date: 2024-01-15
++target-entities: TestExchange
++entity-types:
++  - Exchange
++attack-types:
++  - Smart Contract Exploit
++title: "TestExchange Exploit"
++loss: 5000000
++---
++
++## Summary
++On January 15, 2024, TestExchange was exploited for $5 million.`;
+
+  it("parses a realistic article diff", () => {
+    const files = parseDiff(REALISTIC_DIFF);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.header).toContain(
+      "content/attacks/2024-01-15-TestExchange.md"
+    );
+    expect(files[0]!.bodySegments).toHaveLength(1);
+    expect(files[0]!.bodySegments[0]!.body).toContain(
+      "target-entities: TestExchange"
+    );
+    expect(files[0]!.bodySegments[0]!.body).toContain("## Summary");
+  });
+
+  it("returns empty for empty diff", () => {
+    expect(parseDiff("")).toEqual([]);
+  });
+
+  it("returns empty for whitespace-only diff", () => {
+    expect(parseDiff("   \n  \n")).toEqual([]);
+  });
+
+  it("handles multiple files", () => {
+    const diff = `diff --git a/file1.md b/file1.md
+--- a/file1.md
++++ b/file1.md
+@@ -1 +1 @@
+-old
++new
+diff --git a/file2.md b/file2.md
+--- a/file2.md
++++ b/file2.md
+@@ -1 +1 @@
+-old2
++new2`;
+
+    const files = parseDiff(diff);
+    expect(files).toHaveLength(2);
+  });
+
+  it("handles multiple hunks in a single file", () => {
+    const diff = `diff --git a/file.md b/file.md
+--- a/file.md
++++ b/file.md
+@@ -1,3 +1,3 @@
+ unchanged
+-old1
++new1
+@@ -10,3 +10,3 @@
+ unchanged2
+-old2
++new2`;
+
+    const files = parseDiff(diff);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.bodySegments).toHaveLength(2);
+  });
+
+  it("handles binary file diffs gracefully", () => {
+    const diff = `diff --git a/image.png b/image.png
+new file mode 100644
+index 0000000..abc1234
+Binary files /dev/null and b/image.png differ`;
+
+    const files = parseDiff(diff);
+    expect(files).toHaveLength(1);
+    // No @@ markers means no body segments
+    expect(files[0]!.bodySegments).toHaveLength(0);
+  });
+
+  it("handles rename diffs", () => {
+    const diff = `diff --git a/old-name.md b/new-name.md
+similarity index 100%
+rename from old-name.md
+rename to new-name.md`;
+
+    const files = parseDiff(diff);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.header).toContain("old-name.md");
+  });
+});
+
+// ─── extractArticleText ─────────────────────────────────────────────────────
+
+describe("extractArticleText", () => {
+  it("returns null for empty file list", () => {
+    expect(extractArticleText([])).toBeNull();
+  });
+
+  it("returns header when no body segments", () => {
+    expect(
+      extractArticleText([{ header: "header", bodySegments: [] }])
+    ).toBe("header");
+  });
+
+  it("extracts first file, first hunk only (matching Python behavior)", () => {
+    const files = [
+      {
+        header: "HEADER\n",
+        bodySegments: [
+          { header: " -0,0 +1,5 ", body: "+line1\n+line2" },
+          { header: " -5,0 +5,5 ", body: "+line3\n+line4" },
+        ],
+      },
+    ];
+    const text = extractArticleText(files);
+    expect(text).toContain("HEADER");
+    expect(text).toContain("line1");
+    expect(text).toContain("line2");
+    // Must NOT include second hunk — Python: diff[0]['body'][0]['body']
+    expect(text).not.toContain("line3");
+    expect(text).not.toContain("line4");
+  });
+
+  it("only uses first file when multiple files present", () => {
+    const files = [
+      {
+        header: "FILE1\n",
+        bodySegments: [{ header: " hdr ", body: "+first file content" }],
+      },
+      {
+        header: "FILE2\n",
+        bodySegments: [{ header: " hdr ", body: "+second file content" }],
+      },
+    ];
+    const text = extractArticleText(files);
+    expect(text).toContain("first file content");
+    expect(text).not.toContain("second file content");
+  });
+
+  it("strips + markers from added lines", () => {
+    const files = [
+      {
+        header: "H\n",
+        bodySegments: [
+          { header: " h ", body: "+added line\n context line\n-removed line" },
+        ],
+      },
+    ];
+    const text = extractArticleText(files);
+    expect(text).toContain("added line");
+    expect(text).not.toContain("+added line");
+  });
+});
+
+// ─── removePlus ─────────────────────────────────────────────────────────────
+
+describe("removePlus", () => {
+  it("strips leading + from diff lines", () => {
+    expect(removePlus("+line1\n+line2\nline3")).toBe("line1\nline2\nline3");
+  });
+
+  it("leaves non-plus lines unchanged", () => {
+    expect(removePlus("no plus here")).toBe("no plus here");
+  });
+
+  it("handles empty string", () => {
+    expect(removePlus("")).toBe("");
+  });
+
+  it("only strips first + character per line", () => {
+    expect(removePlus("+a + b")).toBe("a + b");
+  });
+
+  it("preserves lines starting with ++", () => {
+    // ++ lines in diffs are file markers — removePlus strips one +, leaving +
+    expect(removePlus("+++ b/file.md")).toBe("++ b/file.md");
+  });
+
+  it("handles lines that are just +", () => {
+    expect(removePlus("+")).toBe("");
+  });
+});
+
+// ─── extractBetweenTags ─────────────────────────────────────────────────────
+
+describe("extractBetweenTags", () => {
+  it("extracts content between tags", () => {
+    expect(extractBetweenTags("tag", "<tag>hello</tag>")).toBe("hello");
+  });
+
+  it("returns last match when multiple", () => {
+    expect(
+      extractBetweenTags("tag", "<tag>first</tag> <tag>second</tag>")
+    ).toBe("second");
+  });
+
+  it("returns null when no match", () => {
+    expect(extractBetweenTags("tag", "no tags here")).toBeNull();
+  });
+
+  it("handles multiline content", () => {
+    expect(
+      extractBetweenTags("answer", "<answer>line1\nline2\nline3</answer>")
+    ).toBe("line1\nline2\nline3");
+  });
+
+  it("extracts number_of_statements", () => {
+    const text =
+      "<statement>S1</statement><number_of_statements>3</number_of_statements>";
+    expect(extractBetweenTags("number_of_statements", text)).toBe("3");
+  });
+
+  it("handles tags with trailing space", () => {
+    expect(extractBetweenTags("tag", "<tag >hello</tag >")).toBe("hello");
+  });
+
+  it("strips whitespace from extracted content", () => {
+    expect(extractBetweenTags("tag", "<tag>  spaced  </tag>")).toBe("spaced");
+  });
+
+  it("handles nested tags of different types", () => {
+    const text =
+      "<outer><inner>nested</inner></outer>";
+    expect(extractBetweenTags("outer", text)).toBe(
+      "<inner>nested</inner>"
+    );
+    expect(extractBetweenTags("inner", text)).toBe("nested");
+  });
+
+  it("handles empty tags", () => {
+    // The regex requires .+? (one or more chars) so empty tags return null
+    expect(extractBetweenTags("tag", "<tag></tag>")).toBeNull();
+  });
+
+  it("handles verdict tags from fact-checking output", () => {
+    const factCheckOutput = `<statement>Hack was $5M</statement>
+<verdict>True</verdict>
+<source>https://example.com</source>`;
+    expect(extractBetweenTags("verdict", factCheckOutput)).toBe("True");
+    expect(extractBetweenTags("source", factCheckOutput)).toBe(
+      "https://example.com"
+    );
+  });
+
+  it("handles search_query extraction mid-stream", () => {
+    // This is exactly how it's used in Phase 2 — partial completion ends with
+    // <search_query>some query  (no closing tag — we append it)
+    const partial = 'Let me search for this. <search_query>SampleDeFi exploit 2024';
+    const withClose = partial + "</search_query>";
+    expect(extractBetweenTags("search_query", withClose)).toBe(
+      "SampleDeFi exploit 2024"
+    );
+  });
+});

--- a/tools/articlecheck-worker/test/simulation.test.ts
+++ b/tools/articlecheck-worker/test/simulation.test.ts
@@ -1,0 +1,440 @@
+/**
+ * End-to-end simulation + adversarial test suite.
+ *
+ * Tests the full webhook → parse → pipeline data flow with realistic data,
+ * plus edge cases, malformed inputs, and security boundary checks.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseDiff,
+  extractArticleText,
+  isAllowedReviewer,
+  removePlus,
+} from "../src/github";
+import { extractBetweenTags } from "../src/pipeline";
+import { formatSearchResults, BRAVE_DESCRIPTION } from "../src/brave";
+import { RETRIEVAL_PROMPT } from "../src/prompts";
+
+// ─── Realistic Test Data ────────────────────────────────────────────────────
+
+const REALISTIC_DIFF = `diff --git a/content/attacks/2024-03-15-SampleDeFi.md b/content/attacks/2024-03-15-SampleDeFi.md
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/content/attacks/2024-03-15-SampleDeFi.md
+@@ -0,0 +1,42 @@
++---
++date: 2024-03-15
++target-entities: SampleDeFi Protocol
++entity-types:
++  - DeFi
++attack-types:
++  - Smart Contract Exploit
++  - Flash Loan Attack
++title: "SampleDeFi Protocol Flash Loan Exploit"
++loss: 8500000
++---
++
++## Summary
++
++On March 15, 2024, SampleDeFi Protocol was exploited through a flash loan attack resulting in losses of approximately $8.5 million. The attacker manipulated the price oracle by using a large flash loan from Aave to inflate the token price on the platform's AMM pool.
++
++## Attackers
++
++The identity of the attacker(s) remains unknown. The attack originated from address 0x1234...5678 which was funded through Tornado Cash approximately 2 hours before the exploit.
++
++## Losses
++
++- $5.2 million in ETH
++- $3.3 million in USDC
++- Total: approximately $8.5 million
++
++## Timeline
++
++- **March 15, 2024, 02:15 PM UTC:** Attacker address funded via Tornado Cash
++- **March 15, 2024, 04:22 PM UTC:** Flash loan executed on Aave
++- **March 15, 2024, 04:22 PM UTC:** Price oracle manipulated
++- **March 15, 2024, 04:23 PM UTC:** Funds drained from lending pool
++- **March 15, 2024, 04:30 PM UTC:** SampleDeFi team pauses contracts
++- **March 15, 2024, 05:00 PM UTC:** Post-mortem published on Twitter
++
++## Security Failure Causes
++
++- **Reliance on single price oracle:** The protocol used only its own AMM pool for price feeds rather than a decentralized oracle like Chainlink.
++- **No flash loan protection:** The lending pool did not implement any flash loan guards or same-block borrow/repay prevention.
++- **Insufficient liquidity checks:** Price impact thresholds were not enforced on large trades.`;
+
+const SAMPLE_WEBHOOK = {
+  action: "created",
+  comment: {
+    id: 123456,
+    body: "/articlecheck",
+    user: { login: "evgenydmitriev" },
+  },
+  issue: {
+    number: 500,
+    pull_request: {
+      url: "https://api.github.com/repos/1712n/dn-institute/pulls/500",
+      diff_url: "https://github.com/1712n/dn-institute/pull/500.diff",
+      html_url: "https://github.com/1712n/dn-institute/pull/500",
+    },
+  },
+  repository: { full_name: "1712n/dn-institute" },
+};
+
+// ─── E2E: Full Pipeline Data Flow ───────────────────────────────────────────
+
+describe("E2E: Webhook → Parse → Extract", () => {
+  it("validates webhook payload structure", () => {
+    const p = SAMPLE_WEBHOOK;
+    expect(p.action).toBe("created");
+    expect(p.comment.body).toContain("/articlecheck");
+    expect(p.issue.pull_request).toBeDefined();
+    expect(p.repository.full_name).toBe("1712n/dn-institute");
+  });
+
+  it("checks reviewer permission correctly", () => {
+    const reviewers = '["evgenydmitriev","reviewer2"]';
+    expect(isAllowedReviewer("evgenydmitriev", reviewers)).toBe(true);
+    expect(isAllowedReviewer("random-user", reviewers)).toBe(false);
+  });
+
+  it("parses realistic diff and extracts complete article", () => {
+    const files = parseDiff(REALISTIC_DIFF);
+    const text = extractArticleText(files);
+
+    expect(text).not.toBeNull();
+    // All 6 required metadata headers
+    expect(text!).toContain("date: 2024-03-15");
+    expect(text!).toContain("target-entities: SampleDeFi Protocol");
+    expect(text!).toContain("entity-types:");
+    expect(text!).toContain("attack-types:");
+    expect(text!).toContain("title:");
+    expect(text!).toContain("loss: 8500000");
+    // All 5 required section headers
+    expect(text!).toContain("## Summary");
+    expect(text!).toContain("## Attackers");
+    expect(text!).toContain("## Losses");
+    expect(text!).toContain("## Timeline");
+    expect(text!).toContain("## Security Failure Causes");
+    // Key content
+    expect(text!).toContain("$8.5 million");
+    expect(text!).toContain("Tornado Cash");
+  });
+
+  it("strips + markers from added lines but preserves content", () => {
+    const files = parseDiff(REALISTIC_DIFF);
+    const text = extractArticleText(files)!;
+    expect(text).not.toContain("+## Summary");
+    expect(text).not.toContain("+date:");
+    expect(text).toContain("## Summary");
+    expect(text).toContain("date:");
+  });
+});
+
+// ─── E2E: Pipeline Phase Data Flow ──────────────────────────────────────────
+
+describe("E2E: Phase 1 → Phase 2 → Phase 3 data contracts", () => {
+  it("Phase 1 output: extractBetweenTags parses typical statement extraction", () => {
+    const phase1 = `<statement>On March 15, 2024, SampleDeFi was exploited for $8.5 million</statement>
+<statement>The attacker used a flash loan from Aave</statement>
+<statement>$5.2 million in ETH was lost</statement>
+<number_of_statements>3</number_of_statements>`;
+
+    expect(extractBetweenTags("number_of_statements", phase1)).toBe("3");
+    expect(phase1.match(/<statement>(.+?)<\/statement>/gs)).toHaveLength(3);
+  });
+
+  it("Phase 2: RETRIEVAL_PROMPT has {description} placeholder for Brave", () => {
+    expect(RETRIEVAL_PROMPT).toContain("{description}");
+    const filled = RETRIEVAL_PROMPT.replace("{description}", BRAVE_DESCRIPTION);
+    expect(filled).toContain("Brave Search Engine Tool");
+    expect(filled).not.toContain("{description}");
+  });
+
+  it("Phase 2: RETRIEVAL_PROMPT has {current_time} placeholder", () => {
+    expect(RETRIEVAL_PROMPT).toContain("{current_time}");
+    const filled = RETRIEVAL_PROMPT.replace("{current_time}", "2024-03-15 12:00:00");
+    expect(filled).toContain("2024-03-15 12:00:00");
+    expect(filled).not.toContain("{current_time}");
+  });
+
+  it("Phase 2: search query extraction from partial completion", () => {
+    const partial =
+      'I need to verify this claim. <search_query>SampleDeFi exploit March 2024 amount';
+    const withClose = partial + "</search_query>";
+    expect(extractBetweenTags("search_query", withClose)).toBe(
+      "SampleDeFi exploit March 2024 amount"
+    );
+  });
+
+  it("Phase 2: search results format matches what Claude expects", () => {
+    const results = [
+      "Web Page Title: DeFi Hack Report\nWeb Page URL: https://example.com\nWeb Page Summary: <article>SampleDeFi lost $8.5M...</article>",
+    ];
+    const formatted = formatSearchResults(results);
+    expect(formatted).toMatch(
+      /^[\s]*<search_results>[\s\S]*<\/search_results>[\s]*$/
+    );
+  });
+
+  it("Phase 3 output: extractBetweenTags parses editorial review", () => {
+    const phase3 = `<answer>
+## Fact-Checking Results
+
+- **Statement**: SampleDeFi was exploited for $8.5 million :white_check_mark:
+  - **Source**: [https://example.com](https://example.com)
+
+## Editor's Notes
+The article is well-structured.
+
+## Hugo SSG Formatting Check
+- Does it match Hugo SSG formatting? :white_check_mark:
+
+## Filename Check
+- Correct Filename: \`2024-03-15-SampleDeFi.md\`
+- Your Filename: \`2024-03-15-SampleDeFi.md\` :white_check_mark:
+</answer>`;
+
+    const answer = extractBetweenTags("answer", phase3);
+    expect(answer).not.toBeNull();
+    expect(answer!).toContain("## Fact-Checking Results");
+    expect(answer!).toContain(":white_check_mark:");
+    expect(answer!).toContain("## Editor's Notes");
+    expect(answer!).toContain("## Hugo SSG Formatting Check");
+    expect(answer!).toContain("## Filename Check");
+  });
+});
+
+// ─── Adversarial: Malformed Inputs ──────────────────────────────────────────
+
+describe("Adversarial: malformed diffs", () => {
+  it("handles diff with no @@ markers (binary file)", () => {
+    const diff = `diff --git a/image.png b/image.png
+Binary files /dev/null and b/image.png differ`;
+    const files = parseDiff(diff);
+    const text = extractArticleText(files);
+    // Should return just the header, no body content
+    expect(text).toBeDefined();
+    expect(text!.length).toBeLessThan(200);
+  });
+
+  it("handles diff with only deletions", () => {
+    const diff = `diff --git a/removed.md b/removed.md
+deleted file mode 100644
+--- a/removed.md
++++ /dev/null
+@@ -1,5 +0,0 @@
+-line1
+-line2
+-line3`;
+    const files = parseDiff(diff);
+    const text = extractArticleText(files);
+    // removePlus only strips +, so - lines stay as-is
+    expect(text).toContain("-line1");
+  });
+
+  it("handles massive diff (stress test)", () => {
+    let bigDiff = `diff --git a/big.md b/big.md\n--- a/big.md\n+++ b/big.md\n@@ -0,0 +1,10000 @@\n`;
+    for (let i = 0; i < 10000; i++) {
+      bigDiff += `+Line ${i} of a very large article with lots of content about crypto attacks\n`;
+    }
+    const files = parseDiff(bigDiff);
+    expect(files).toHaveLength(1);
+    const text = extractArticleText(files);
+    expect(text).toContain("Line 0");
+    expect(text).toContain("Line 9999");
+  });
+
+  it("handles diff with @@ in content (not just markers)", () => {
+    const diff = `diff --git a/file.md b/file.md
+--- a/file.md
++++ b/file.md
+@@ -0,0 +1,3 @@
++This article mentions @@ email addresses
++And more @@ symbols in text`;
+    const files = parseDiff(diff);
+    // The @@ in content will split incorrectly — this is a known limitation
+    // of both the Python and our implementation. Documenting the behavior.
+    expect(files.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles Unicode content", () => {
+    const diff = `diff --git a/file.md b/file.md
+--- a/file.md
++++ b/file.md
+@@ -0,0 +1,3 @@
++# 中文标题
++Ataques de criptomonedas — $1,000,000
++Rug pull на бирже`;
+    const files = parseDiff(diff);
+    const text = extractArticleText(files);
+    expect(text).toContain("中文标题");
+    expect(text).toContain("$1,000,000");
+    expect(text).toContain("бирже");
+  });
+
+  it("handles empty lines in diff", () => {
+    const diff = `diff --git a/file.md b/file.md
+--- a/file.md
++++ b/file.md
+@@ -0,0 +1,5 @@
++line1
++
++line3
++
++line5`;
+    const files = parseDiff(diff);
+    const text = extractArticleText(files);
+    expect(text).toContain("line1");
+    expect(text).toContain("line3");
+    expect(text).toContain("line5");
+  });
+});
+
+// ─── Adversarial: Security Boundary Checks ──────────────────────────────────
+
+describe("Adversarial: security boundaries", () => {
+  it("rejects webhook with no trigger command", () => {
+    expect(
+      "just a regular comment".includes("/articlecheck")
+    ).toBe(false);
+  });
+
+  it("rejects non-PR issue comments", () => {
+    const payload = { issue: { number: 100 } }; // no pull_request field
+    expect("pull_request" in payload.issue).toBe(false);
+  });
+
+  it("rejects edited comments (only created)", () => {
+    expect("edited" === "created").toBe(false);
+  });
+
+  it("command detection is not fooled by substrings", () => {
+    // "/articlecheck" should match, but also "/articlecheck please"
+    expect("/articlecheck please".includes("/articlecheck")).toBe(true);
+    // But "my/articlecheck" should also match (includes is substring)
+    // This matches the Python behavior: contains(github.event.comment.body, '/articlecheck')
+    expect("my/articlecheck".includes("/articlecheck")).toBe(true);
+  });
+
+  it("handles JSON with extra/unexpected fields gracefully", () => {
+    const extendedPayload = {
+      ...SAMPLE_WEBHOOK,
+      unexpected_field: "should not crash",
+      comment: {
+        ...SAMPLE_WEBHOOK.comment,
+        extra: { nested: true },
+      },
+    };
+    // Should not throw when accessing known fields
+    expect(extendedPayload.comment.body).toBe("/articlecheck");
+    expect(extendedPayload.repository.full_name).toBe("1712n/dn-institute");
+  });
+
+  it("handles very long comment bodies", () => {
+    const longBody = "/articlecheck " + "x".repeat(100000);
+    expect(longBody.includes("/articlecheck")).toBe(true);
+  });
+});
+
+// ─── Adversarial: extractBetweenTags Edge Cases ─────────────────────────────
+
+describe("Adversarial: tag extraction edge cases", () => {
+  it("handles malicious nested same-name tags", () => {
+    // Regex is non-greedy (.+?) so it matches the INNERMOST pair
+    const text = "<tag>outer <tag>inner</tag> still outer</tag>";
+    const result = extractBetweenTags("tag", text);
+    // Last match of the non-greedy pattern
+    expect(result).toBeDefined();
+  });
+
+  it("handles tags with attributes (should not match)", () => {
+    // Our regex: <tag\s?> — only allows optional single trailing space
+    const text = '<tag class="foo">content</tag>';
+    expect(extractBetweenTags("tag", text)).toBeNull();
+  });
+
+  it("handles extremely long content between tags", () => {
+    const longContent = "x".repeat(100000);
+    const text = `<answer>${longContent}</answer>`;
+    expect(extractBetweenTags("answer", text)).toBe(longContent);
+  });
+
+  it("handles tags across many lines", () => {
+    const text = "<answer>\nline1\nline2\nline3\nline4\nline5\n</answer>";
+    expect(extractBetweenTags("answer", text)).toBe(
+      "line1\nline2\nline3\nline4\nline5"
+    );
+  });
+
+  it("returns null for self-closing tags", () => {
+    expect(extractBetweenTags("tag", "<tag/>")).toBeNull();
+  });
+
+  it("handles number_of_statements with whitespace", () => {
+    const text = "<number_of_statements> 5 </number_of_statements>";
+    expect(extractBetweenTags("number_of_statements", text)).toBe("5");
+  });
+
+  it("parseInt handles non-numeric number_of_statements gracefully", () => {
+    // If Claude returns garbage, parseInt returns NaN, Math.min(NaN, 5) = NaN
+    // The for loop with NaN iterations runs 0 times — safe
+    const val = parseInt("not a number", 10);
+    expect(Number.isNaN(val)).toBe(true);
+    expect(Math.min(val, 5)).toBeNaN();
+    // for (let i = 0; i < NaN; i++) — never executes
+    let count = 0;
+    for (let i = 0; i < val; i++) count++;
+    expect(count).toBe(0);
+  });
+});
+
+// ─── Real-World: Article Format Validation ──────────────────────────────────
+
+describe("Real-world: article format edge cases", () => {
+  it("handles article with YAML list metadata (entity-types, attack-types)", () => {
+    const diff = `diff --git a/content/attacks/2024-01-01-Multi.md b/content/attacks/2024-01-01-Multi.md
+new file mode 100644
+--- /dev/null
++++ b/content/attacks/2024-01-01-Multi.md
+@@ -0,0 +1,15 @@
++---
++date: 2024-01-01
++target-entities: Multi Protocol
++entity-types:
++  - DeFi
++  - Bridge
++attack-types:
++  - Smart Contract Exploit
++  - Governance Attack
++title: "Multi Protocol Exploit"
++loss: 1000000
++---
++
++## Summary
++Multi was exploited.`;
+    const files = parseDiff(diff);
+    const text = extractArticleText(files)!;
+    expect(text).toContain("- DeFi");
+    expect(text).toContain("- Bridge");
+    expect(text).toContain("- Governance Attack");
+  });
+
+  it("handles article with special chars in title (quotes, ampersand)", () => {
+    const diff = `diff --git a/content/attacks/2024-01-01-Test.md b/content/attacks/2024-01-01-Test.md
+new file mode 100644
+--- /dev/null
++++ b/content/attacks/2024-01-01-Test.md
+@@ -0,0 +1,5 @@
++---
++title: "O'Reilly & Associates \"Hack\" — $1M Loss"
++loss: 1000000
++---
++## Summary`;
+    const files = parseDiff(diff);
+    const text = extractArticleText(files)!;
+    expect(text).toContain("O'Reilly & Associates");
+  });
+});

--- a/tools/articlecheck-worker/tsconfig.json
+++ b/tools/articlecheck-worker/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/tools/articlecheck-worker/vitest.config.ts
+++ b/tools/articlecheck-worker/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/tools/articlecheck-worker/wrangler.toml
+++ b/tools/articlecheck-worker/wrangler.toml
@@ -1,0 +1,32 @@
+name = "articlecheck"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Queue: webhook handler enqueues jobs, pipeline consumer processes them.
+# Consumer gets 15 minutes wall clock (vs 30s for waitUntil).
+[[queues.producers]]
+queue = "articlecheck-pipeline"
+binding = "PIPELINE_QUEUE"
+
+[[queues.consumers]]
+queue = "articlecheck-pipeline"
+max_batch_size = 1
+max_batch_timeout = 0
+max_retries = 2
+
+# KV namespace for idempotency (dedup webhook deliveries)
+[[kv_namespaces]]
+binding = "DEDUP_KV"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+# Secrets (set via `wrangler secret put`):
+#   GITHUB_WEBHOOK_SECRET  - GitHub webhook HMAC secret
+#   GITHUB_TOKEN           - GitHub personal access token (repo, pull_request scopes)
+#   ANTHROPIC_API_KEY      - Anthropic API key
+#   BRAVE_API_KEY          - Brave Search API key
+#   WIKI_REVIEWERS         - JSON array of allowed GitHub usernames
+#
+# Optional overrides:
+#   ANTHROPIC_MODEL        - default: claude-3-opus-20240229
+#   ANTHROPIC_MAX_TOKENS   - default: 4000


### PR DESCRIPTION
Closes #425 🌰

## Summary 🌰

Migrates the `/articlecheck` QA bot from GitHub Actions (Python) to a TypeScript Cloudflare Worker with full pipeline parity — same 3-phase Claude pipeline, same Brave Search integration with page scraping + Claude Haiku summarization, same prompt behavior.

## Architecture 🌰

Single Worker with two handlers in one deploy:

```
GitHub webhook → fetch handler (validate + enqueue) → 202 Accepted (<10ms)
                                    ↓
              Queue consumer (15 min wall clock budget)
                                    ↓
              Fetch diff → Phase 1: Extract statements (Claude Opus)
                         → Phase 2: Fact-check loop (Brave + HTMLRewriter scraping + Claude Haiku summarization + Claude Opus verification)
                         → Phase 3: Editorial review (Claude Opus)
                         → Post review comment on PR
```

**Why a Queue instead of `waitUntil()`?** `ctx.waitUntil()` has a hard 30-second limit after response. The pipeline needs 60-180s for multiple Claude API calls + Brave searches + page scraping. Queue consumers get 15 minutes. Several competing PRs use `waitUntil()` — those would silently fail in production. 🌰

## Key Design Decisions 🌰

| Decision | Rationale |
|----------|-----------|
| **Single worker, two handlers** | Cleaner than separate producer/consumer workers — one deploy, one codebase, shared types |
| **HTMLRewriter for scraping** | Cloudflare-native streaming HTML parser. The Workers equivalent of BeautifulSoup — correct tag handling without loading the full DOM 🌰 |
| **Claude Haiku page summarization** | Matches Python exactly: scrape page → Haiku extracts relevant article content → feed to fact-checker. Skipping this (as some PRs do) degrades fact-checking quality |
| **Queue send before KV write** | If queue send fails, no KV entry → GitHub retries cleanly. Reverse ordering creates a lost-job race condition 🌰 |
| **Separate error/success markers** | Error comments use `<!-- articlecheck-worker-error -->` so retries aren't blocked by `hasExistingReview()` finding a prior failure |
| **`tools/` directory** | Follows existing repo convention (`tools/plagiarism-checker/`, `tools/similarity_search/`) |

## Python Parity Checklist 🌰

- [x] 3-phase pipeline: extract → fact-check → editorial review
- [x] All three prompts preserved (EXTRACTING, RETRIEVAL, ANSWER)
- [x] `{description}` template variable filled dynamically with `BRAVE_DESCRIPTION`
- [x] `{current_time}` template variable filled at runtime
- [x] `n_search_results_to_use=1` (matching `article_checker_claude.py` line 47)
- [x] `max_searches_to_try=5`
- [x] Brave `mixed.main` ordering for ranked web/news/FAQ interleaving
- [x] FAQ result parsing (paid Brave tier)
- [x] Page scraping with Claude Haiku summarization (`claude-3-haiku-20240307`, 512 max tokens)
- [x] Diff parsing: first file, first hunk (matching `diff[0]['body'][0]['body']`)
- [x] `removePlus()` strips leading `+` from added lines
- [x] `extractBetweenTags()` with last-match behavior
- [x] Retry with exponential backoff (10 attempts, 4-10s delays, matching tenacity config)

## Beyond Python 🌰

- HMAC-SHA256 webhook verification (timing-safe constant-time comparison)
- Hex character validation before signature parsing
- KV-backed idempotency (dedup on `X-GitHub-Delivery` + comment ID, 24h TTL)
- Duplicate review detection (HTML marker check before processing)
- Error message sanitization (API keys redacted before posting to PR)
- Queue auto-retry on failure (max 2 retries)

## Files 🌰

```
tools/articlecheck-worker/
  src/
    index.ts      — fetch handler (webhook) + queue handler (pipeline)
    github.ts     — HMAC verification, diff parsing, GitHub API
    pipeline.ts   — 3-phase Claude pipeline
    brave.ts      — Brave Search + HTMLRewriter scraping + Haiku summarization
    prompts.ts    — All prompts from Python
    types.ts      — TypeScript interfaces
  test/
    github.test.ts      — 37 tests
    brave.test.ts       — 6 tests
    simulation.test.ts  — 31 tests (E2E + adversarial)
  wrangler.toml, package.json, tsconfig.json, README.md

.github/workflows/article-check-claude.yml — trigger changed to workflow_dispatch (manual only)
```

74 tests | 0 type errors | 36 KiB gzipped bundle | 1 runtime dependency 🌰

## Resource Usage Per Review

| Resource | Count |
|----------|-------|
| Claude Opus calls | 3-8 |
| Claude Haiku calls | 1-5 (page summarization) |
| Brave Search calls | 1-5 |
| Wall clock | 60-180s (within Queue's 15-min limit) |
| Bundle size | 36 KiB gzip |