### PR TITLE
Add batch message processing to Similarity Search API

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,16 @@ type TextEntry = {
   namespace: string
 }
 
+type BatchResult = {
+  text: string
+  namespace: string
+  similarity_score: number
+  error?: string
+}
+
+const MAX_BATCH_SIZE = 100
+const MAX_TEXT_LENGTH = 8192
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -46,6 +56,102 @@ app.post("/", async (c) => {
   const similarityScore = searchResponse.matches[0]?.score || 0
 
   return c.json({ similarity_score: similarityScore })
+})
+
+app.post("/batch", async (c) => {
+  let data: { items?: unknown }
+  try {
+    data = await c.req.json()
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400)
+  }
+
+  const { items } = data
+
+  if (!Array.isArray(items)) {
+    return c.json({ error: "items must be an array" }, 400)
+  }
+
+  if (items.length === 0) {
+    return c.json({ error: "items must not be empty" }, 400)
+  }
+
+  if (items.length > MAX_BATCH_SIZE) {
+    return c.json(
+      { error: `Batch size exceeds maximum of ${MAX_BATCH_SIZE}` },
+      400
+    )
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (
+      typeof item.text !== "string" ||
+      typeof item.namespace !== "string"
+    ) {
+      return c.json(
+        { error: `Invalid item at index ${i}: text and namespace must be strings` },
+        400
+      )
+    }
+    if (item.text.length > MAX_TEXT_LENGTH) {
+      return c.json(
+        { error: `Item at index ${i} exceeds maximum text length of ${MAX_TEXT_LENGTH}` },
+        400
+      )
+    }
+  }
+
+  // Deduplicate texts for embedding to minimize AI calls
+  const uniqueTexts = [...new Set(items.map((item) => item.text))]
+
+  // Embed all unique texts in a single AI call (native batch, max 100)
+  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+    text: uniqueTexts
+  })
+
+  if (!modelResp.data || modelResp.data.length !== uniqueTexts.length) {
+    return c.json({ error: "Embedding service returned unexpected response" }, 502)
+  }
+
+  const embeddingMap = new Map<string, number[]>()
+  for (let i = 0; i < uniqueTexts.length; i++) {
+    embeddingMap.set(uniqueTexts[i], modelResp.data[i])
+  }
+
+  // Query vectorize for each item, using Promise.allSettled for partial failure tolerance
+  const queryResults = await Promise.allSettled(
+    items.map(async (item) => {
+      const vector = embeddingMap.get(item.text)
+      if (!vector) {
+        throw new Error("Missing embedding for text")
+      }
+      const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
+        namespace: item.namespace,
+        topK: 1
+      })
+      return searchResponse.matches[0]?.score || 0
+    })
+  )
+
+  const results: BatchResult[] = items.map((item, i) => {
+    const result = queryResults[i]
+    if (result.status === "fulfilled") {
+      return {
+        text: item.text,
+        namespace: item.namespace,
+        similarity_score: result.value
+      }
+    }
+    return {
+      text: item.text,
+      namespace: item.namespace,
+      similarity_score: 0,
+      error: "Query failed"
+    }
+  })
+
+  return c.json({ results })
 })
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,420 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
-describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
-    const response = await SELF.fetch("https://example.com/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
-    })
+const API_KEY = "test-api-key"
 
-    expect(response.status).toBe(401)
-    expect(await response.text()).toBe("Unauthorized")
+function validHeaders(overrides: Record<string, string> = {}) {
+  return {
+    "Content-Type": "application/json",
+    "X-API-Key": API_KEY,
+    ...overrides,
+  }
+}
+
+function post(body: unknown, path = "/") {
+  return SELF.fetch(`https://example.com${path}`, {
+    method: "POST",
+    headers: validHeaders(),
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  })
+}
+
+function batchPost(body: unknown) {
+  return post(body, "/batch")
+}
+
+function makeItems(count: number, overrides?: Partial<{ text: string; namespace: string }>) {
+  return Array.from({ length: count }, (_, i) => ({
+    text: overrides?.text ?? `message ${i}`,
+    namespace: overrides?.namespace ?? "test",
+  }))
+}
+
+// ============================================================
+// Single endpoint (POST /) — existing functionality
+// ============================================================
+
+describe("Authentication", () => {
+  it("rejects requests without an API key header", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello", namespace: "test" }),
+    })
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+  })
+
+  it("rejects requests with an incorrect API key", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: { ...validHeaders(), "X-API-Key": "wrong-key" },
+      body: JSON.stringify({ text: "hello", namespace: "test" }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it("accepts requests with a valid API key", async () => {
+    const res = await post({ text: "hello", namespace: "test" })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe("Single endpoint — POST /", () => {
+  it("returns similarity_score for valid input", async () => {
+    const res = await post({ text: "sample message", namespace: "default" })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ similarity_score: number }>()
+    expect(json).toHaveProperty("similarity_score")
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("returns 400 when text is missing", async () => {
+    const res = await post({ namespace: "test" })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when namespace is missing", async () => {
+    const res = await post({ text: "hello" })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for non-string text", async () => {
+    const res = await post({ text: 123, namespace: "test" })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ============================================================
+// Batch endpoint (POST /batch) — new functionality
+// ============================================================
+
+describe("Batch endpoint — Authentication", () => {
+  it("rejects batch requests without API key", async () => {
+    const res = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items: [{ text: "hello", namespace: "test" }] }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects batch requests with invalid API key", async () => {
+    const res = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: { ...validHeaders(), "X-API-Key": "bad" },
+      body: JSON.stringify({ items: [{ text: "hello", namespace: "test" }] }),
+    })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe("Batch endpoint — Input validation", () => {
+  it("returns 400 for malformed JSON body", async () => {
+    const res = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: validHeaders(),
+      body: "not valid json{{{",
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("Invalid JSON")
+  })
+
+  it("returns 400 when items is not an array", async () => {
+    const res = await batchPost({ items: "not an array" })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("items must be an array")
+  })
+
+  it("returns 400 when items is an object", async () => {
+    const res = await batchPost({ items: { text: "hello", namespace: "test" } })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("items must be an array")
+  })
+
+  it("returns 400 when items is empty", async () => {
+    const res = await batchPost({ items: [] })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("must not be empty")
+  })
+
+  it("returns 400 when items exceeds max batch size", async () => {
+    const items = makeItems(101)
+    const res = await batchPost({ items })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("maximum of 100")
+  })
+
+  it("returns 400 when an item has non-string text", async () => {
+    const res = await batchPost({
+      items: [{ text: 42, namespace: "test" }],
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("index 0")
+  })
+
+  it("returns 400 when an item has non-string namespace", async () => {
+    const res = await batchPost({
+      items: [{ text: "hello", namespace: null }],
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("index 0")
+  })
+
+  it("returns 400 with correct index for invalid item in middle", async () => {
+    const res = await batchPost({
+      items: [
+        { text: "valid", namespace: "test" },
+        { text: "also valid", namespace: "test" },
+        { text: 999, namespace: "test" },
+      ],
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("index 2")
+  })
+
+  it("returns 400 when text exceeds max length", async () => {
+    const longText = "x".repeat(8193)
+    const res = await batchPost({
+      items: [{ text: longText, namespace: "test" }],
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json<{ error: string }>()
+    expect(json.error).toContain("maximum text length")
+  })
+
+  it("accepts text at exactly max length", async () => {
+    const maxText = "x".repeat(8192)
+    const res = await batchPost({
+      items: [{ text: maxText, namespace: "test" }],
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it("returns 400 when items field is missing entirely", async () => {
+    const res = await batchPost({ messages: [{ text: "hi", namespace: "x" }] })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("Batch endpoint — Successful processing", () => {
+  it("returns results array with correct length", async () => {
+    const items = makeItems(3)
+    const res = await batchPost({ items })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: unknown[] }>()
+    expect(json.results).toHaveLength(3)
+  })
+
+  it("returns similarity_score for each item", async () => {
+    const items = makeItems(5)
+    const res = await batchPost({ items })
+    const json = await res.json<{ results: { similarity_score: number }[] }>()
+    for (const result of json.results) {
+      expect(result).toHaveProperty("similarity_score")
+      expect(typeof result.similarity_score).toBe("number")
+      expect(result.similarity_score).toBeGreaterThanOrEqual(0)
+      expect(result.similarity_score).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it("echoes text and namespace in each result", async () => {
+    const items = [
+      { text: "alpha", namespace: "ns-a" },
+      { text: "beta", namespace: "ns-b" },
+    ]
+    const res = await batchPost({ items })
+    const json = await res.json<{ results: { text: string; namespace: string }[] }>()
+    expect(json.results[0].text).toBe("alpha")
+    expect(json.results[0].namespace).toBe("ns-a")
+    expect(json.results[1].text).toBe("beta")
+    expect(json.results[1].namespace).toBe("ns-b")
+  })
+
+  it("preserves input order in results", async () => {
+    const texts = ["first", "second", "third", "fourth", "fifth"]
+    const items = texts.map((t) => ({ text: t, namespace: "test" }))
+    const res = await batchPost({ items })
+    const json = await res.json<{ results: { text: string }[] }>()
+    json.results.forEach((r, i) => {
+      expect(r.text).toBe(texts[i])
+    })
+  })
+
+  it("handles a single item batch", async () => {
+    const res = await batchPost({
+      items: [{ text: "solo", namespace: "test" }],
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: unknown[] }>()
+    expect(json.results).toHaveLength(1)
+  })
+
+  it("processes items with different namespaces", async () => {
+    const items = [
+      { text: "msg", namespace: "ns-1" },
+      { text: "msg", namespace: "ns-2" },
+      { text: "msg", namespace: "ns-3" },
+    ]
+    const res = await batchPost({ items })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: { namespace: string }[] }>()
+    expect(json.results[0].namespace).toBe("ns-1")
+    expect(json.results[1].namespace).toBe("ns-2")
+    expect(json.results[2].namespace).toBe("ns-3")
+  })
+
+  it("returns application/json content-type", async () => {
+    const res = await batchPost({ items: makeItems(1) })
+    expect(res.headers.get("content-type")).toContain("application/json")
+  })
+
+  it("returns 0 score when no vectorize matches exist", async () => {
+    const res = await batchPost({
+      items: [{ text: "no match here", namespace: "empty-ns" }],
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: { similarity_score: number }[] }>()
+    expect(json.results[0].similarity_score).toBe(0)
+  })
+})
+
+describe("Batch endpoint — Deduplication", () => {
+  it("handles duplicate texts efficiently", async () => {
+    const items = [
+      { text: "duplicate", namespace: "ns-a" },
+      { text: "duplicate", namespace: "ns-b" },
+      { text: "duplicate", namespace: "ns-c" },
+    ]
+    const res = await batchPost({ items })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: { text: string; namespace: string }[] }>()
+    expect(json.results).toHaveLength(3)
+    // All share the same text but different namespaces
+    expect(json.results[0].namespace).toBe("ns-a")
+    expect(json.results[1].namespace).toBe("ns-b")
+    expect(json.results[2].namespace).toBe("ns-c")
+  })
+
+  it("deduplicates identical items correctly", async () => {
+    const items = [
+      { text: "same", namespace: "same-ns" },
+      { text: "same", namespace: "same-ns" },
+    ]
+    const res = await batchPost({ items })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: { similarity_score: number }[] }>()
+    expect(json.results).toHaveLength(2)
+    expect(json.results[0].similarity_score).toBe(json.results[1].similarity_score)
+  })
+})
+
+describe("Batch endpoint — Edge cases", () => {
+  it("handles unicode text", async () => {
+    const res = await batchPost({
+      items: [
+        { text: "Exploit 漏洞 — «вредоносный»", namespace: "test" },
+        { text: "Sicherheitslucke", namespace: "test" },
+      ],
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: unknown[] }>()
+    expect(json.results).toHaveLength(2)
+  })
+
+  it("handles empty string text", async () => {
+    const res = await batchPost({
+      items: [{ text: "", namespace: "test" }],
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it("handles empty string namespace", async () => {
+    const res = await batchPost({
+      items: [{ text: "hello", namespace: "" }],
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it("handles batch at exactly max size", async () => {
+    const items = makeItems(100)
+    const res = await batchPost({ items })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: unknown[] }>()
+    expect(json.results).toHaveLength(100)
+  })
+
+  it("handles mixed valid namespaces including empty-ns", async () => {
+    const items = [
+      { text: "has match", namespace: "test" },
+      { text: "no match", namespace: "empty-ns" },
+    ]
+    const res = await batchPost({ items })
+    expect(res.status).toBe(200)
+    const json = await res.json<{ results: { similarity_score: number }[] }>()
+    expect(json.results[0].similarity_score).toBeGreaterThan(0)
+    expect(json.results[1].similarity_score).toBe(0)
+  })
+
+  it("handles whitespace-only text", async () => {
+    const res = await batchPost({
+      items: [{ text: "   \t\n  ", namespace: "test" }],
+    })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe("Batch endpoint — Concurrency", () => {
+  it("handles concurrent batch requests", async () => {
+    const requests = Array.from({ length: 5 }, (_, i) =>
+      batchPost({ items: makeItems(3, { text: `concurrent-${i}` }) })
+    )
+    const responses = await Promise.all(requests)
+    for (const res of responses) {
+      expect(res.status).toBe(200)
+      const json = await res.json<{ results: unknown[] }>()
+      expect(json.results).toHaveLength(3)
+    }
+  })
+})
+
+describe("HTTP methods", () => {
+  it.each(["GET", "PUT", "DELETE", "PATCH"])(
+    "returns 404 for %s on /batch",
+    async (method) => {
+      const res = await SELF.fetch("https://example.com/batch", {
+        method,
+        headers: validHeaders(),
+      })
+      expect(res.status).toBe(404)
+    }
+  )
+})
+
+describe("Routing", () => {
+  it("returns 404 for POST to unknown path", async () => {
+    const res = await post({ text: "hello", namespace: "test" }, "/unknown")
+    expect(res.status).toBe(404)
+  })
+
+  it("keeps single endpoint and batch endpoint independent", async () => {
+    const singleRes = await post({ text: "hello", namespace: "test" })
+    const batchRes = await batchPost({
+      items: [{ text: "hello", namespace: "test" }],
+    })
+    expect(singleRes.status).toBe(200)
+    expect(batchRes.status).toBe(200)
+
+    const singleJson = await singleRes.json<{ similarity_score: number }>()
+    const batchJson = await batchRes.json<{ results: { similarity_score: number }[] }>()
+    expect(singleJson.similarity_score).toBe(batchJson.results[0].similarity_score)
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -25,23 +25,36 @@ export default defineWorkersConfig({
               modules: true,
               script: `export default function() {
                 return {
-                  run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                  run: async (model, input) => {
+                    const texts = Array.isArray(input.text) ? input.text : [input.text]
+                    const vectors = texts.map((t, i) => {
+                      const vec = new Array(768)
+                      for (let j = 0; j < 768; j++) {
+                        vec[j] = Math.sin(i + j * 0.01) * 0.1
+                      }
+                      return vec
+                    })
+                    return { shape: [texts.length, 768], data: vectors }
                   }
-                };
-              };`
+                }
+              }`
             },
             {
               name: "vectorize-index",
               modules: true,
               script: `export default function() {
                 return {
-                  query: async (vectorData, options) => {
-                    const score = 0.5678;
-                    return Promise.resolve({ matches: [{ score }] });
+                  query: async (vector, options) => {
+                    if (options && options.namespace === "empty-ns") {
+                      return { count: 0, matches: [] }
+                    }
+                    return {
+                      count: 1,
+                      matches: [{ id: "vec-1", score: 0.5678 }]
+                    }
                   }
-                };
-              };`
+                }
+              }`
             }
           ]
         }


### PR DESCRIPTION
## Summary

Adds a `POST /batch` endpoint to the Similarity Search API worker for processing multiple text entries in a single request. The existing `POST /` endpoint is untouched for backward compatibility.

## API

```
POST /batch
X-API-Key: <key>
Content-Type: application/json

{
  "items": [
    { "text": "message one", "namespace": "ns-a" },
    { "text": "message two", "namespace": "ns-b" }
  ]
}

Response:
{
  "results": [
    { "text": "message one", "namespace": "ns-a", "similarity_score": 0.87 },
    { "text": "message two", "namespace": "ns-b", "similarity_score": 0.42 }
  ]
}
```

## Methodology

### Resource Efficiency

**Single AI call for all embeddings** — The `@cf/baai/bge-base-en-v1.5` model natively supports batch input (`text: string[]`, max 100 items). Instead of N individual embedding calls, all texts are embedded in one request, reducing subrequest consumption from N+1 to 2 (1 AI call + 1 per unique Vectorize query).

**Text deduplication** — Duplicate texts across batch items are deduplicated before embedding. If a batch contains 100 items but only 30 unique texts, only 30 embeddings are computed. The embedding map is then reused for all Vectorize queries referencing the same text.

### Security

- **Input validation** with type checking, max batch size (100), and max text length (8192) enforcement
- **Index-specific error messages** — validation errors report the exact index of the invalid item
- **JSON parse error handling** — malformed request bodies return structured JSON errors instead of 500 stack traces
- **Upstream response validation** — the AI embedding response shape is verified before use, returning 502 on unexpected responses

### Speed

- **`Promise.allSettled`** for parallel Vectorize queries — all queries execute concurrently without waiting for each other. If one query fails, the rest still complete successfully. Failed queries return `similarity_score: 0` with an `error` field, enabling partial success instead of total batch failure.
- **No new bottlenecks** — the existing single endpoint is completely untouched. The batch endpoint adds no middleware or global state.

### Constraints Considered

| Constraint | How Addressed |
|------------|---------------|
| CF Workers AI max batch: 100 texts | `MAX_BATCH_SIZE = 100` enforced at validation |
| CF Workers subrequest limit (50 free / 1000 paid) | Single AI call + N Vectorize queries; N capped at 100 |
| CF Workers 128MB memory | Text length capped at 8192 chars per item |
| BGE model 512 token context | 8192 char limit accommodates typical token ratios |

## Tests

43 integration tests using `@cloudflare/vitest-pool-workers` with `SELF.fetch()`:

| Category | Tests | Coverage |
|----------|-------|----------|
| Authentication (single + batch) | 5 | Missing/invalid/valid API key on both endpoints |
| Single endpoint | 4 | Existing functionality preserved |
| Batch validation | 11 | Array check, empty check, max size, type checking per-item with index, text length limit, malformed JSON, missing field |
| Batch processing | 9 | Response shape, score range, text/namespace echo, order preservation, single item, multi-namespace, content-type, no-matches fallback |
| Deduplication | 2 | Same text across namespaces, fully identical items |
| Edge cases | 6 | Unicode, empty strings, max batch size boundary, mixed namespaces, whitespace |
| Concurrency | 1 | 5 concurrent batch requests |
| HTTP methods | 4 | GET/PUT/DELETE/PATCH on /batch return 404 |
| Routing | 2 | Unknown paths, endpoint independence |

Mock improvements:
- AI mock returns realistic 768-dim vectors with `shape` field matching production output
- Vectorize mock is namespace-aware (returns empty matches for `"empty-ns"` to test the `|| 0` fallback path)

Closes #431