### PR TITLE
Add RAG functionality to Market Health Reporter

### DIFF
--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -8,6 +8,7 @@ import glob
 from github import Github
 from tools.python_modules.utils import read_file, extract_between_tags
 from tools.python_modules.report_graphics_tool import Visualization
+from tools.market_health_reporter.news_retriever import retrieve_news_context
 
 
 REPO_NAME = "1712n/dn-institute"
@@ -38,6 +39,10 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--rapid-api", dest="rapid_api", help="Rapid API key", required=True
+    )
+    parser.add_argument(
+        "--disable-rag", dest="disable_rag", action="store_true",
+        help="Disable external news retrieval"
     )
     return parser.parse_args()
 
@@ -126,11 +131,20 @@ def post_comment_to_issue(github_token, issue_number, repo_name, comment):
         issue.create_comment(comment)
 
 
-def create_prompt(article_example: str, data: dict, human_prompt_content: str) -> str:
+def create_prompt(article_example: str, data: dict, human_prompt_content: str, news_context: str = "") -> str:
     """
-    Creates a prompt string using article example and data.
+    Creates a prompt string using article example, data, and optional news context.
     """
-    return f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    prompt = f"<example> {article_example} </example>\n{human_prompt_content}\n<data> {json.dumps(data)} </data>"
+    if news_context:
+        prompt += (
+            "\n\nBelow are recent news articles and reports about this exchange and trading pair. "
+            "Use them to provide additional context, corroborate your findings with external evidence, "
+            "and reference relevant events or regulatory actions where appropriate. "
+            "Only include information from these sources if it is relevant to the anomalies found in the data.\n"
+            + news_context
+        )
+    return prompt
 
 
 def main():
@@ -157,11 +171,30 @@ def main():
     try:
         data = fetch_or_load_market_data(querystring, headers, url, DATA_DIR, marketvenueid, pairid, start, end)
 
-        encoding = encoding_for_model("gpt-4")     
+        encoding = encoding_for_model("gpt-4")
         print('num of data tokens: ', len(encoding.encode(str(data))))
 
-        prompt = create_prompt(article_example, data, human_prompt_content)
+        # Retrieve external news context (RAG)
+        news_context = ""
+        if not args.disable_rag:
+            try:
+                print("Retrieving external news context...")
+                news_context = retrieve_news_context(marketvenueid, pairid)
+                if news_context:
+                    print(f"Retrieved news context ({len(encoding.encode(news_context))} tokens)")
+                else:
+                    print("No relevant news articles found")
+            except Exception as e:
+                print(f"News retrieval failed (continuing without): {e}")
+
+        prompt = create_prompt(article_example, data, human_prompt_content, news_context)
         prompt_token_count = len(encoding.encode(prompt))
+
+        # If prompt exceeds limit with RAG context, retry without it
+        if prompt_token_count > MAX_TOKENS and news_context:
+            print("Prompt too long with news context, retrying without RAG...")
+            prompt = create_prompt(article_example, data, human_prompt_content)
+            prompt_token_count = len(encoding.encode(prompt))
 
         if prompt_token_count > MAX_TOKENS:
             error_message = "Your request is too long. It's possible that the period for the data is too broad. Please narrow it down."

--- a/tools/market_health_reporter/news_retriever.py
+++ b/tools/market_health_reporter/news_retriever.py
@@ -1,0 +1,192 @@
+"""
+Retrieves external news and article context for market health reports.
+
+Searches for recent news about the exchange and trading pair being analyzed,
+extracts article content, and formats it as structured context for the LLM.
+"""
+
+import logging
+from typing import List, Dict, Optional
+
+import requests
+from bs4 import BeautifulSoup
+from duckduckgo_search import DDGS
+from tiktoken import encoding_for_model
+
+logger = logging.getLogger(__name__)
+
+MAX_ARTICLE_TOKENS = 2000
+MAX_CONTEXT_TOKENS = 25000
+MAX_SEARCH_RESULTS = 8
+FETCH_TIMEOUT = 10
+
+EXCHANGE_ALIASES = {
+    "huobi": ["huobi", "htx"],
+    "htx": ["huobi", "htx"],
+    "okex": ["okex", "okx"],
+    "okx": ["okex", "okx"],
+    "gateio": ["gate.io", "gateio", "gate"],
+    "gate.io": ["gate.io", "gateio", "gate"],
+}
+
+
+def build_search_queries(exchange: str, pair: str) -> List[str]:
+    """Generate search queries for the exchange and trading pair."""
+    token = pair.split("/")[0] if "/" in pair else pair
+    aliases = EXCHANGE_ALIASES.get(exchange.lower(), [exchange])
+    primary = aliases[0]
+
+    return [
+        f"{primary} exchange wash trading",
+        f"{primary} exchange market manipulation",
+        f"{primary} {token} trading anomaly",
+        f"{primary} exchange regulatory investigation",
+    ]
+
+
+def search_news(query: str, max_results: int = MAX_SEARCH_RESULTS) -> List[Dict]:
+    """Search DuckDuckGo for news articles."""
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.news(
+                keywords=query,
+                region="wt-wt",
+                safesearch="off",
+                timelimit="y",
+                max_results=max_results,
+            ))
+        return results
+    except Exception as e:
+        logger.warning("News search failed for '%s': %s", query, e)
+        return []
+
+
+def search_web(query: str, max_results: int = MAX_SEARCH_RESULTS) -> List[Dict]:
+    """Search DuckDuckGo for web results."""
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.text(
+                keywords=query,
+                max_results=max_results,
+            ))
+        return results
+    except Exception as e:
+        logger.warning("Web search failed for '%s': %s", query, e)
+        return []
+
+
+def fetch_article_text(url: str) -> Optional[str]:
+    """Fetch and extract clean text content from a URL."""
+    try:
+        resp = requests.get(
+            url,
+            timeout=FETCH_TIMEOUT,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; DNI-MarketHealthReporter/1.0)"},
+        )
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        for tag in soup(["script", "style", "nav", "header", "footer", "aside", "iframe"]):
+            tag.decompose()
+
+        text = soup.get_text(separator="\n", strip=True)
+
+        # Remove excessive blank lines
+        lines = [line for line in text.splitlines() if line.strip()]
+        return "\n".join(lines)
+    except Exception as e:
+        logger.debug("Failed to fetch %s: %s", url, e)
+        return None
+
+
+def truncate_to_tokens(text: str, max_tokens: int, encoding) -> str:
+    """Truncate text to fit within a token budget."""
+    tokens = encoding.encode(text)
+    if len(tokens) <= max_tokens:
+        return text
+    return encoding.decode(tokens[:max_tokens])
+
+
+def deduplicate_results(results: List[Dict]) -> List[Dict]:
+    """Remove duplicate results by URL."""
+    seen = set()
+    unique = []
+    for r in results:
+        url = r.get("url") or r.get("href", "")
+        if url and url not in seen:
+            seen.add(url)
+            unique.append(r)
+    return unique
+
+
+def format_context(articles: List[Dict]) -> str:
+    """Format retrieved articles as XML-structured context for the LLM prompt."""
+    if not articles:
+        return ""
+
+    items = []
+    for i, article in enumerate(articles, 1):
+        items.append(
+            f'<source index="{i}">\n'
+            f'  <title>{article.get("title", "")}</title>\n'
+            f'  <date>{article.get("date", "")}</date>\n'
+            f'  <url>{article.get("url", "")}</url>\n'
+            f'  <content>\n{article.get("content", "")}\n  </content>\n'
+            f'</source>'
+        )
+    return "<external_context>\n" + "\n".join(items) + "\n</external_context>"
+
+
+def retrieve_news_context(
+    exchange: str,
+    pair: str,
+    max_context_tokens: int = MAX_CONTEXT_TOKENS,
+) -> str:
+    """
+    Full retrieval pipeline: search -> fetch -> deduplicate -> truncate -> format.
+
+    Returns an XML-formatted string of external article context, or an empty
+    string if no relevant articles are found.
+    """
+    encoding = encoding_for_model("gpt-4")
+    queries = build_search_queries(exchange, pair)
+
+    # Collect results from news and web searches
+    all_results = []
+    for query in queries:
+        all_results.extend(search_news(query, max_results=5))
+        all_results.extend(search_web(query, max_results=5))
+
+    unique_results = deduplicate_results(all_results)
+    logger.info("Found %d unique results across %d queries", len(unique_results), len(queries))
+
+    # Fetch and process articles within token budget
+    articles = []
+    token_count = 0
+
+    for result in unique_results:
+        url = result.get("url") or result.get("href", "")
+
+        # Try fetching full content, fall back to snippet
+        content = fetch_article_text(url) if url else None
+        if not content:
+            content = result.get("body", "")
+        if not content:
+            continue
+
+        content = truncate_to_tokens(content, MAX_ARTICLE_TOKENS, encoding)
+        content_tokens = len(encoding.encode(content))
+
+        if token_count + content_tokens > max_context_tokens:
+            break
+
+        articles.append({
+            "title": result.get("title", ""),
+            "date": result.get("date", ""),
+            "url": url,
+            "content": content,
+        })
+        token_count += content_tokens
+
+    logger.info("Retrieved %d articles (%d tokens)", len(articles), token_count)
+    return format_context(articles)

--- a/tools/market_health_reporter/tests/test_news_retriever.py
+++ b/tools/market_health_reporter/tests/test_news_retriever.py
@@ -1,0 +1,343 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.market_health_reporter.news_retriever import (
+    build_search_queries,
+    fetch_article_text,
+    truncate_to_tokens,
+    deduplicate_results,
+    format_context,
+    retrieve_news_context,
+    search_news,
+    search_web,
+)
+from tiktoken import encoding_for_model
+
+
+class TestBuildSearchQueries:
+    def test_basic_exchange_and_pair(self):
+        queries = build_search_queries("binance", "BTC/USDT")
+        assert len(queries) == 4
+        assert any("binance" in q.lower() for q in queries)
+        assert any("BTC" in q for q in queries)
+
+    def test_exchange_alias_huobi(self):
+        queries = build_search_queries("htx", "HT/USDT")
+        assert any("huobi" in q.lower() for q in queries)
+
+    def test_exchange_alias_okex(self):
+        queries = build_search_queries("okx", "ETH/USDT")
+        assert any("okex" in q.lower() for q in queries)
+
+    def test_pair_without_slash(self):
+        queries = build_search_queries("binance", "BTCUSDT")
+        assert any("BTCUSDT" in q for q in queries)
+
+    def test_unknown_exchange_uses_original_name(self):
+        queries = build_search_queries("kraken", "ETH/USD")
+        assert any("kraken" in q.lower() for q in queries)
+
+
+class TestFetchArticleText:
+    @patch("tools.market_health_reporter.news_retriever.requests.get")
+    def test_extracts_text_from_html(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.text = """
+        <html><body>
+            <nav>Menu</nav>
+            <article><p>Exchange was fined for wash trading.</p></article>
+            <footer>Copyright</footer>
+        </body></html>
+        """
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        text = fetch_article_text("https://example.com/article")
+        assert text is not None
+        assert "wash trading" in text
+        assert "Menu" not in text
+        assert "Copyright" not in text
+
+    @patch("tools.market_health_reporter.news_retriever.requests.get")
+    def test_removes_script_and_style(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.text = """
+        <html><body>
+            <script>alert('xss')</script>
+            <style>.hidden{display:none}</style>
+            <p>Relevant content here.</p>
+        </body></html>
+        """
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        text = fetch_article_text("https://example.com")
+        assert "alert" not in text
+        assert "hidden" not in text
+        assert "Relevant content" in text
+
+    @patch("tools.market_health_reporter.news_retriever.requests.get")
+    def test_returns_none_on_http_error(self, mock_get):
+        mock_get.side_effect = Exception("Connection refused")
+        result = fetch_article_text("https://unreachable.example.com")
+        assert result is None
+
+    @patch("tools.market_health_reporter.news_retriever.requests.get")
+    def test_returns_none_on_timeout(self, mock_get):
+        mock_get.side_effect = TimeoutError()
+        result = fetch_article_text("https://slow.example.com")
+        assert result is None
+
+
+class TestTruncateToTokens:
+    def test_short_text_unchanged(self):
+        enc = encoding_for_model("gpt-4")
+        text = "Short text."
+        result = truncate_to_tokens(text, 100, enc)
+        assert result == text
+
+    def test_long_text_truncated(self):
+        enc = encoding_for_model("gpt-4")
+        text = "word " * 500
+        result = truncate_to_tokens(text, 50, enc)
+        tokens = enc.encode(result)
+        assert len(tokens) <= 50
+
+
+class TestDeduplicateResults:
+    def test_removes_duplicate_urls(self):
+        results = [
+            {"url": "https://a.com", "title": "First"},
+            {"url": "https://a.com", "title": "Duplicate"},
+            {"url": "https://b.com", "title": "Second"},
+        ]
+        unique = deduplicate_results(results)
+        assert len(unique) == 2
+        assert unique[0]["title"] == "First"
+        assert unique[1]["title"] == "Second"
+
+    def test_handles_href_field(self):
+        results = [
+            {"href": "https://a.com", "title": "Web result"},
+            {"href": "https://a.com", "title": "Duplicate web"},
+        ]
+        unique = deduplicate_results(results)
+        assert len(unique) == 1
+
+    def test_skips_results_without_url(self):
+        results = [
+            {"title": "No URL"},
+            {"url": "https://a.com", "title": "Has URL"},
+        ]
+        unique = deduplicate_results(results)
+        assert len(unique) == 1
+        assert unique[0]["title"] == "Has URL"
+
+    def test_empty_input(self):
+        assert deduplicate_results([]) == []
+
+
+class TestFormatContext:
+    def test_formats_articles_as_xml(self):
+        articles = [
+            {"title": "Test Article", "date": "2024-01-01", "url": "https://example.com", "content": "Article body."},
+        ]
+        result = format_context(articles)
+        assert "<external_context>" in result
+        assert "</external_context>" in result
+        assert '<source index="1">' in result
+        assert "<title>Test Article</title>" in result
+        assert "Article body." in result
+
+    def test_multiple_articles_numbered(self):
+        articles = [
+            {"title": f"Article {i}", "content": f"Body {i}"} for i in range(3)
+        ]
+        result = format_context(articles)
+        assert '<source index="1">' in result
+        assert '<source index="2">' in result
+        assert '<source index="3">' in result
+
+    def test_empty_articles_returns_empty_string(self):
+        assert format_context([]) == ""
+
+    def test_handles_missing_fields(self):
+        articles = [{"content": "Just content"}]
+        result = format_context(articles)
+        assert "<title></title>" in result
+        assert "Just content" in result
+
+
+class TestSearchNews:
+    @patch("tools.market_health_reporter.news_retriever.DDGS")
+    def test_returns_results(self, mock_ddgs_class):
+        mock_ddgs = MagicMock()
+        mock_ddgs.__enter__ = MagicMock(return_value=mock_ddgs)
+        mock_ddgs.__exit__ = MagicMock(return_value=False)
+        mock_ddgs.news.return_value = [
+            {"title": "Breaking news", "url": "https://news.com/1", "body": "Content"},
+        ]
+        mock_ddgs_class.return_value = mock_ddgs
+
+        results = search_news("test query", max_results=5)
+        assert len(results) == 1
+        assert results[0]["title"] == "Breaking news"
+
+    @patch("tools.market_health_reporter.news_retriever.DDGS")
+    def test_returns_empty_on_error(self, mock_ddgs_class):
+        mock_ddgs_class.side_effect = Exception("API error")
+        results = search_news("failing query")
+        assert results == []
+
+
+class TestSearchWeb:
+    @patch("tools.market_health_reporter.news_retriever.DDGS")
+    def test_returns_results(self, mock_ddgs_class):
+        mock_ddgs = MagicMock()
+        mock_ddgs.__enter__ = MagicMock(return_value=mock_ddgs)
+        mock_ddgs.__exit__ = MagicMock(return_value=False)
+        mock_ddgs.text.return_value = [
+            {"title": "Web result", "href": "https://web.com/1", "body": "Content"},
+        ]
+        mock_ddgs_class.return_value = mock_ddgs
+
+        results = search_web("test query", max_results=5)
+        assert len(results) == 1
+        assert results[0]["title"] == "Web result"
+
+    @patch("tools.market_health_reporter.news_retriever.DDGS")
+    def test_returns_empty_on_error(self, mock_ddgs_class):
+        mock_ddgs_class.side_effect = Exception("Network error")
+        results = search_web("failing query")
+        assert results == []
+
+
+class TestRetrieveNewsContext:
+    @patch("tools.market_health_reporter.news_retriever.fetch_article_text")
+    @patch("tools.market_health_reporter.news_retriever.search_web")
+    @patch("tools.market_health_reporter.news_retriever.search_news")
+    def test_full_pipeline(self, mock_news, mock_web, mock_fetch):
+        mock_news.return_value = [
+            {"title": "News 1", "url": "https://news.com/1", "date": "2024-01-01", "body": "Summary"},
+        ]
+        mock_web.return_value = [
+            {"title": "Web 1", "href": "https://web.com/1", "body": "Web summary"},
+        ]
+        mock_fetch.return_value = "Full article content about exchange manipulation."
+
+        result = retrieve_news_context("huobi", "HT/USDT")
+        assert "<external_context>" in result
+        assert "News 1" in result
+        assert "Full article content" in result
+
+    @patch("tools.market_health_reporter.news_retriever.fetch_article_text")
+    @patch("tools.market_health_reporter.news_retriever.search_web")
+    @patch("tools.market_health_reporter.news_retriever.search_news")
+    def test_falls_back_to_snippet_when_fetch_fails(self, mock_news, mock_web, mock_fetch):
+        mock_news.return_value = [
+            {"title": "News", "url": "https://news.com/1", "body": "Snippet only", "date": "2024-01-01"},
+        ]
+        mock_web.return_value = []
+        mock_fetch.return_value = None  # fetch fails
+
+        result = retrieve_news_context("binance", "BTC/USDT")
+        assert "Snippet only" in result
+
+    @patch("tools.market_health_reporter.news_retriever.search_web")
+    @patch("tools.market_health_reporter.news_retriever.search_news")
+    def test_returns_empty_when_no_results(self, mock_news, mock_web):
+        mock_news.return_value = []
+        mock_web.return_value = []
+
+        result = retrieve_news_context("unknown_exchange", "XYZ/USD")
+        assert result == ""
+
+    @patch("tools.market_health_reporter.news_retriever.fetch_article_text")
+    @patch("tools.market_health_reporter.news_retriever.search_web")
+    @patch("tools.market_health_reporter.news_retriever.search_news")
+    def test_deduplicates_across_searches(self, mock_news, mock_web, mock_fetch):
+        shared_result = {"title": "Same article", "url": "https://same.com/1", "body": "Content", "date": "2024-01-01"}
+        mock_news.return_value = [shared_result]
+        mock_web.return_value = [shared_result]
+        mock_fetch.return_value = "Full content"
+
+        result = retrieve_news_context("binance", "ETH/USDT")
+        assert result.count('<source index="1">') == 1
+        assert '<source index="2">' not in result
+
+    @patch("tools.market_health_reporter.news_retriever.fetch_article_text")
+    @patch("tools.market_health_reporter.news_retriever.search_web")
+    @patch("tools.market_health_reporter.news_retriever.search_news")
+    def test_respects_token_budget(self, mock_news, mock_web, mock_fetch):
+        # Generate many results
+        mock_news.return_value = [
+            {"title": f"Article {i}", "url": f"https://news.com/{i}", "body": f"Body {i}", "date": "2024-01-01"}
+            for i in range(50)
+        ]
+        mock_web.return_value = []
+        mock_fetch.return_value = "x " * 5000  # large article
+
+        result = retrieve_news_context("exchange", "TOKEN/USD", max_context_tokens=5000)
+        enc = encoding_for_model("gpt-4")
+        token_count = len(enc.encode(result))
+        # Should be within budget (with some overhead for XML tags)
+        assert token_count < 8000  # generous buffer for XML formatting
+
+
+class TestCreatePromptIntegration:
+    """Test the create_prompt function's news_context integration.
+
+    These tests import create_prompt which requires openai and other deps.
+    We mock them at the module level to avoid ImportError in CI.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _mock_deps(self):
+        """Mock heavy dependencies that may not be installed in test env."""
+        import sys
+        mocked = {}
+        for mod in [
+            "openai", "github", "github.Github",
+            "matplotlib", "matplotlib.pyplot", "matplotlib.ticker",
+            "matplotlib.dates", "pandas",
+        ]:
+            if mod not in sys.modules:
+                mocked[mod] = sys.modules[mod] = MagicMock()
+        yield
+        for mod in mocked:
+            sys.modules.pop(mod, None)
+
+    def test_prompt_includes_news_context(self):
+        from tools.market_health_reporter.market_health_reporter import create_prompt
+
+        result = create_prompt(
+            article_example="Example article",
+            data={"metric": "value"},
+            human_prompt_content="Analyze this data",
+            news_context="<external_context><source>News</source></external_context>",
+        )
+        assert "<external_context>" in result
+        assert "<example>" in result
+        assert "<data>" in result
+        assert "corroborate" in result
+
+    def test_prompt_without_news_context(self):
+        from tools.market_health_reporter.market_health_reporter import create_prompt
+
+        result = create_prompt(
+            article_example="Example",
+            data={"metric": "value"},
+            human_prompt_content="Analyze",
+        )
+        assert "<external_context>" not in result
+        assert "<example>" in result
+
+    def test_prompt_with_empty_news_context(self):
+        from tools.market_health_reporter.market_health_reporter import create_prompt
+
+        result = create_prompt(
+            article_example="Example",
+            data={"metric": "value"},
+            human_prompt_content="Analyze",
+            news_context="",
+        )
+        assert "corroborate" not in result


### PR DESCRIPTION
## Summary

Adds Retrieval Augmented Generation (RAG) to the Market Health Reporter, enabling it to incorporate recent news articles and external reports about the exchange and trading pair being analyzed.

## Methodology

### Design Principles

1. **Up-to-date external sources** — Uses DuckDuckGo search (news + web) to find recent articles about the exchange, following the maintainer's guidance on PR #480 that "MH reporter is more concerned with leveraging up-to-date information than a private knowledgebase."

2. **Clean text extraction** — Strips scripts, styles, navigation, headers, footers, and iframes from fetched pages. No raw HTML in prompts, addressing the feedback that "dumping raw html code into prompts significantly decreases the attention LLMs pay to the meaningful data."

3. **Zero new API keys** — Uses DuckDuckGo (free, no key) and existing project dependencies (`duckduckgo-search`, `beautifulsoup4`, `requests`, `tiktoken`). No Brave API key, no CryptoPanic token, no OpenAI embeddings.

4. **Graceful degradation** — Search failures are caught and logged; the reporter continues without RAG context. If the prompt exceeds the token limit after adding news context, it automatically retries without RAG.

### Architecture

New module: `tools/market_health_reporter/news_retriever.py`

```
Exchange + Pair
      |
  Build search queries (4 queries with alias expansion)
      |
  DuckDuckGo news search + web search (parallel)
      |
  Deduplicate by URL
      |
  Fetch full article content (BS4 extraction)
      |  (falls back to search snippet if fetch fails)
      |
  Truncate per-article (2000 tokens) + total budget (25000 tokens)
      |
  Format as <external_context> XML block
      |
  Inject into prompt with instructions to corroborate findings
```

### Integration Points

- `market_health_reporter.py`: Added `--disable-rag` CLI flag, news retrieval call before prompt creation, automatic fallback on token overflow
- `create_prompt()`: Accepts optional `news_context` parameter, appends with instructions to use external evidence only when relevant to data anomalies
- Exchange alias mapping: Handles huobi/htx, okex/okx, gateio/gate.io name variations

### How It Improves Output

The LLM now receives relevant external context alongside the market data:
- Regulatory actions and investigations against the exchange
- Prior reports of wash trading or manipulation
- Market events that may explain anomalies in the data
- Cross-references that strengthen or contextualize findings

The prompt instructs the model to use external context only when relevant, preventing hallucination or over-attribution.

## Tests

31 pytest tests across 9 test classes:

| Class | Tests | Coverage |
|-------|-------|----------|
| `TestBuildSearchQueries` | 5 | Exchange aliases, pair parsing, unknown exchanges |
| `TestFetchArticleText` | 4 | HTML extraction, script removal, HTTP errors, timeouts |
| `TestTruncateToTokens` | 2 | Short text unchanged, long text truncated |
| `TestDeduplicateResults` | 4 | URL dedup, href field, missing URLs, empty input |
| `TestFormatContext` | 4 | XML formatting, numbering, empty list, missing fields |
| `TestSearchNews` | 2 | Successful search, error handling |
| `TestSearchWeb` | 2 | Successful search, error handling |
| `TestRetrieveNewsContext` | 5 | Full pipeline, snippet fallback, empty results, dedup, token budget |
| `TestCreatePromptIntegration` | 3 | Context inclusion, exclusion, empty context |

Run: `python -m pytest tools/market_health_reporter/tests/ -v`

Closes #428