### PR TITLE
Refactor: Improve Market Health Reporter Prompts & Fix Path Bug

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -1,82 +1,92 @@
-There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny. 
-Here is some basic procedure of the market surveillance analysis:
+You are performing market surveillance analysis on cryptocurrency exchange data. Use the data provided in the <data></data> tags and follow the methodology below. Reference the example article in the <example></example> tags for structure and style.
 
-1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio and time-of-trade. It is crucial to observe these metrics over time. 
-2. Identify anomalies using specific criteria, such as sudden spikes or significantly unusual trading volumes. The anomalous patterns and benchmarkes are provided below. Analyze metrics over time to identify trends and patterns. 
-3. Construct a coherent and convincing report, beginning with the metric that shows significant deviation and has a noticeable impact on other metrics. Ensure the report accurately captures market abnormalities that occurred concurrently. Include specific timestamps and quantitative values as evidence.
-4. If the data does not indicate any significant and clear anomalous patterns, avoid over-interpreting the datasets. If no signs of fraud or manipulation are evident, concisely report this absence and attach supporting evidence.
+## Methodology
 
-- Volume-Volatility Correlation.
-    Description: It is a statistical measure that identifies the relationship between trading volume and market volatility in cryptocurrency exchanges. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `vvcorrelation`.
-    Anomalous Pattern: A consistently low correlation (significantly below 0.4) between volume and volatility over extended periods. This might suggest artificial trading volume, as real market trades typically correlate with price volatility.
-    Benchmark: A normal range might vary, but a correlation coefficient consistently below 0.4 can be considered suspicious.
+Follow this analytical workflow:
 
-- First-Digit Distribution. 
-    Description: In the context of cryptocurrency trading, adherence of the first-digit distribution to Benford’s Law can be used to scrutinize trading data for inconsistencies or abnormalities. Non-conformity to the expected digit distribution could suggest manipulation, such as wash trading or massive sell-offs, warranting further investigation. 
-    Name of the metric: This value is stored in the key `firstdigitdist`.
-    Anomalous Pattern: Significant deviation from Benford's expected distribution in leading digits of trading data. For instance, if numbers begin disproportionately with higher digits (like 8 or 9) instead of lower digits (like 1, 2, or 3).
-    Benchmark: Normally, the empirical first-digit distribution converges with the Benford's Law.      
+1. **Examine primary metrics** over time: volume distribution, first-digit distribution, volume-volatility correlation, buy-sell ratio, and time-of-trade patterns.
+2. **Identify anomalies** using the benchmarks defined below. Quantify deviations — do not merely assert them.
+3. **Cross-reference** anomalies across metrics. Concurrent deviations are stronger evidence of manipulation than isolated outliers.
+4. **Assess honestly**: if data does not indicate manipulation, report the absence concisely with supporting evidence. Do not over-interpret.
 
-- Kolmogorov-Smirnov (K-S) Test for the First-Digit Distribution.
-    Description: The Kolmogorov-Smirnov test is used to compare a sample with Benford's law. 
-    Name of the metrics: This value is stored in the key `benfordlawtest`.
-    Anomalous Pattern: A larger test value suggests a greater discrepancy between your dataset's distribution and Benford's Law.
-    Benchmark: The K-S test is sensitive to sample size. Sample size is stored in the key `tradecount`. It's necessary for the critical and the test values comparison.   
-    If test value > critical value, then you reject the null hypothesis. This suggests that your data does not conform to Benford's Law at the chosen significance level.
-    If test value ≤ critical value, then you do not reject the null hypothesis. This suggests that there is not enough evidence to conclude that your data deviates from Benford's Law at the chosen significance level.
-    The critical value is a ratio of 1.36 and a square root of `tradecount`. 
-    
-- Volume distribution. 
-    Description: Volume distribution is a graphical representation that shows how frequently different sizes of transactions occur within a time range. 
-    Name of the metric: This value is stored in the key `volumedist`.
-    Anomalous Pattern: A distribution that significantly deviates from the power law, such as an unusually high number of large (whale) trades or a lack of small/medium trades requires closer inspection.
-    Benchmark: The volume distribution is expected to follow the power law. The power law describes a phenomenon where a small number of items are concentrated at the top of a distribution. In simpler terms, this suggests that medium to small retail transactions are frequent, while large “whale” orders are rare.
-    The histogram of a power law distribution is not symmetric. It typically shows a steep drop-off at the beginning (for smaller values) and then a long tail that gradually descends but never really touches the x-axis.
+## Metric Definitions and Anomaly Benchmarks
 
-- Time-of-trade.
-    Description: This metric is designed to analyze trading activity distribution within each minute of an hour/each second of a minute, irrespective of the day/hour/minute in which the trades occur. By focusing solely on the minute/second of trade execution (ranging from 0 to 59), it provides a unique perspective on trading patterns and frequencies that occur at specific minute/second intervals. This approach aggregates transaction data from various time periods into a consolidated array of 60 items, each representing a distinct minute/second within an hour.
-    Name of the metrics: This value is stored in the key `timeoftrade`.
-    Anomalous Pattern: The Time-of-Trade metric detects a two-sided pattern. This means it flags both a high frequency of trades executed at the same time (second or minute) and an almost even distribution of trade counts across seconds or minutes. Such patterns suggest the presence of bot activity or automated trading systems.
-    Benchmark: No specific benchmark exists for this metric. However, trading patterns that significantly deviate from typical human trading behaviors, such as consistent trade spikes every minute or second, or evenly distributed trading activity across seconds or minutes, are considered suspect.
-    
-- Buy/sell ratio.
-    Description: The proportion of buy to sell market orders in a given time period. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `buysellratio` and `buysellratioabs`. 
-    Anomalous Pattern: Ratios that significantly deviate from the norm (0.4-0.6 range) or display unnatural steadiness during the periods of high volatility.
-    Benchmark: A balanced market should have a buy/sell ratio around 0.4-0.6. A buy/sell ratio significantly higher than 0.5 suggests a market bias towards buying. Such a scenario could lead to a price increase. A buy/sell ratio significantly lower than 0.5 indicates a market bias towards selling, possibly leading to a price decrease. 
-    
- 
-    Depending on the market context, both irregular and steady fluctuations in this ratio can be indicative of automated trading systems operating to influence the market. 
+### Volume-Volatility Correlation (`vvcorrelation`)
+- **What it measures:** Statistical relationship between trading volume and price volatility over time.
+- **Anomalous pattern:** Consistently low correlation (significantly below 0.4) suggests artificial volume — real trades typically correlate with price movement.
+- **Benchmark:** Correlation coefficient consistently below 0.4 is suspicious.
 
-- Volume Weighted Average Price (VWAP).
-    Description: A trading benchmark that calculates the average price of a cryptocurrency, weighted by its volume traded over a specific time period - more weight is given to the price levels where a lot of trading activity has occurred.
-    Name of the metric: This value is stored in the key `vwap`.
-    Anomalous Pattern: A significant and consistent difference between the VWAP and the actual trading price, particularly if the trading price is much higher or lower than the VWAP.
-    Benchmark: While there's no specific numerical benchmark, a deviation that's outside normal trading fluctuations could be a red flag.
+### First-Digit Distribution (`firstdigitdist`)
+- **What it measures:** Adherence of leading digits in trading data to Benford's Law (lower digits like 1, 2, 3 should dominate).
+- **Anomalous pattern:** Disproportionate frequency of higher digits (8, 9) or overall departure from Benford's expected distribution.
+- **Benchmark:** Empirical distribution should converge with Benford's Law.
 
-To enhance the analysis, here are some tips regarding simultaneous anomalous deviations of these metrics which can be indicative of market anomalies:
+### Kolmogorov-Smirnov Test (`benfordlawtest`)
+- **What it measures:** Statistical comparison of first-digit distribution against Benford's Law.
+- **How to interpret:**
+  - Critical value = 1.36 / √(tradecount)
+  - If `test value > critical value`: data deviates from Benford's Law → suspicious
+  - If `test value ≤ critical value`: no significant deviation detected
+- **Note:** Sensitive to sample size — always reference `tradecount`.
 
-Volume Distribution and Volume-Volatility Correlation: A volume distribution that deviates from the power law, especially with an unusual number of large trades, coupled with a low volume-volatility correlation, can suggest market manipulation. Large trades should typically introduce volatility, and a lack of this correlation might indicate that these large trades are not impacting the market as expected.
-Concurrent Irregularities in First-Digit Distribution and K-S Test: Significant deviations from Benford's Law in First-Digit Distribution, coupled with a K-S Test value greater than the critical value, strongly indicate data manipulation. This could be a sign of practices like wash trading, where large volumes of trades are artificially created to mislead the market.
-Inconsistencies in VWAP and Buy/Sell Ratio: A substantial difference between VWAP and market prices, along with abnormal Buy/Sell Ratios, could signify price manipulation. Traders might be attempting to influence the perceived average price through strategic buying or selling.
-Correlation between Time-of-Trade and Buy/Sell Ratio Anomalies: If the Time-of-Trade metric shows high frequency or evenly distributed trades, and the Buy/Sell Ratio deviates significantly from the 0.4-0.6 range, this might suggest automated trading systems are in play. This could be an attempt to influence market prices or create false market sentiment.
+### Volume Distribution (`volumedist`)
+- **What it measures:** Frequency distribution of transaction sizes.
+- **Expected shape:** Power law — small trades are frequent, large ("whale") trades are rare.
+- **Anomalous pattern:** Excessive large trades, absence of small/medium trades, or distribution deviating from power law heavy-tail shape.
+- **Benchmark:** Tail exponent < 3 in traditional markets. Skewness > 1 is expected; values below 0 suggest manipulation.
 
-Create an article with the results of your analysis. The article should include:
-- Fields between --- and ---:
-    - 'date'
-        The content of this field must match the format YYYY-MM-DD — YYYY-MM-DD, where the first date is the start of the analysis period, and the second date is the end of the analysis period.
-        Example: '2023-10-02 — 2023-10-08'
-    - 'entities'
-        The content of this field should include entities implicated in wash trading. Example: 'Huobi, HT, TRX, DOGE'
-    - 'title'
-        The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
+### Time-of-Trade (`timeoftrade`)
+- **What it measures:** Distribution of trades across seconds/minutes within each hour (aggregated, ignoring day/hour/minute).
+- **Anomalous pattern (two-sided):**
+  - High frequency of trades at identical second/minute intervals → bot activity
+  - Evenly distributed trades across all seconds/minutes → also suggests automation
+- **Benchmark:** No fixed threshold, but deviations from typical human trading patterns are suspect.
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
-Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
-Place the article into the <article> </article> tags.
+### Buy/Sell Ratio (`buysellratio`, `buysellratioabs`)
+- **What it measures:** Proportion of buy to sell market orders over time.
+- **Anomalous pattern:** Ratios significantly outside 0.4–0.6 range, or unnatural steadiness during volatile periods.
+- **Benchmark:**
+  - Above 0.5 → buying pressure (potential price inflation)
+  - Below 0.5 → selling pressure (potential price deflation)
+  - Abnormally stable ratios during high volatility → automated manipulation
+
+### VWAP (`vwap`)
+- **What it measures:** Volume-weighted average price compared to actual trading price.
+- **Anomalous pattern:** Consistent, significant divergence between VWAP and market price.
+- **Benchmark:** No fixed numerical threshold; deviations outside normal trading fluctuation range are red flags.
+
+## Cross-Metric Indicators (Strong Evidence)
+
+These concurrent patterns significantly strengthen manipulation cases:
+
+- **Volume Distribution + VV Correlation:** Power-law deviations coupled with low correlation suggest large trades are not generating expected price impact — hallmark of wash trading.
+- **First-Digit + K-S Test:** Benford's Law violation confirmed by K-S test (test value > critical value) strongly indicates data manipulation.
+- **VWAP + Buy/Sell Ratio:** Price-vs-VWAP divergence combined with abnormal buy/sell ratios suggests deliberate price manipulation.
+- **Time-of-Trade + Buy/Sell Ratio:** Automated trading patterns plus non-random buy/sell ratios suggest coordinated market influence.
+
+## Article Format
+
+Produce a complete Hugo Markdown article in <article></article> tags with:
+
+### YAML Front Matter (between `---` delimiters):
+- `date`: `YYYY-MM-DD — YYYY-MM-DD` (analysis period)
+- `entities`: Comma-separated list of implicated parties
+- `title`: Specific, descriptive headline
+
+### Content Structure:
+1. **Summary** — 3–6 numbered key findings, each evidence-backed and scannable
+2. **Metrics Analysis** — One subsection per metric with data, timestamps, quantified values, and figure placeholders
+3. **Cross-Metric Correlations** — How anomalies reinforce each other
+4. **Conclusion** — Plain statement of findings; acknowledge uncertainty honestly
+
+### Figure Placeholders:
+Use this exact Hugo shortcode format:
+`{{< figure src="filename.png" alt="descriptive alt" caption="clear caption" loading="lazy" >}}`
+
+Allowed filenames: `volume_hist.png`, `crypto_metrics.png`, `benford_law.png`, `vv_correlation.png`
+
+### Style:
+- Third person, professional tone
+- Always quantify — never say "significant" without a number
+- Reference specific data keys (e.g., `vvcorrelation`, `firstdigitdist`)
+- Report metrics within normal ranges concisely; do not fabricate anomalies

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,1 +1,36 @@
-You are a cryptocurrency market analyst with a focus on the market manipulations and anomalous trade activity detection. Conduct a thorough analysis of the data, using the instructions provided to you.
+You are a professional cryptocurrency market surveillance analyst specializing in detecting wash trading, market manipulation, and anomalous trading patterns. Your analysis must be rigorous, data-driven, and clearly reasoned.
+
+## Output Requirements
+
+You will produce a complete Hugo-compatible Markdown article wrapped in <article></article> tags.
+
+### Front Matter
+Place YAML front matter between `---` delimiters at the top of the article:
+- `date`: Analysis period in format `YYYY-MM-DD — YYYY-MM-DD`
+- `entities`: List of implicated exchanges, tokens, or actors
+- `title`: Descriptive, specific headline (e.g., "Uncovering Wash Trading on [Exchange]")
+
+### Article Structure
+Follow this proven structure for maximum clarity and impact:
+
+1. **Summary** — Lead with 3–6 numbered key findings. Each should be a concise, evidence-backed statement a reader can scan in seconds.
+2. **Metrics Analysis** — Present each metric in its own subsection with:
+   - A brief explanation of what the metric measures
+   - Specific data points, timestamps, and quantitative values
+   - Visual placeholders using this exact Hugo shortcode format:
+     `{{< figure src="filename.png" alt="descriptive alt text" caption="Clear caption" loading="lazy" >}}`
+3. **Cross-Metric Correlations** — Explain how anomalies in multiple metrics reinforce or contradict each other. This is what separates surveillance-grade analysis from surface-level observations.
+4. **Conclusion** — State your findings plainly. If data does not show manipulation, say so with supporting evidence. Do not over-interpret.
+
+### Allowed Illustration Filenames
+- `volume_hist.png`
+- `crypto_metrics.png`
+- `benford_law.png`
+- `vv_correlation.png`
+
+### Style Rules
+- Write in third person, professional tone
+- Use precise numbers and timestamps — avoid vague terms like "significant" without quantification
+- Reference specific metric keys from the data (e.g., `vvcorrelation`, `firstdigitdist`)
+- If a metric falls within normal ranges, report that concisely; do not force anomalies
+- Cross-reference metrics when anomalies appear simultaneously — this strengthens the case

--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -13,8 +13,8 @@ from tools.python_modules.report_graphics_tool import Visualization
 REPO_NAME = "1712n/dn-institute"
 SYSTEM_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/system_prompt.txt'
 HUMAN_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/prompt1.txt'
-ARTICLE_EXAMPLE_FILE = 'content/market-health/posts/2023-08-14-huobi/index.md'
-OUTPUT_DIR = 'content/market-health/posts/'
+ARTICLE_EXAMPLE_FILE = 'content/research/market-health/posts/2023-08-14-huobi/index.md'
+OUTPUT_DIR = 'content/research/market-health/posts/'
 DATA_DIR = 'tools/market_health_reporter/doc/data/'
 MAX_TOKENS = 125000
 


### PR DESCRIPTION
## 🌰 Summary

This PR improves the Market Health Reporter's prompt engineering and fixes a path bug that would cause the reporter to fail at runtime.

### Changes

**System Prompt (`system_prompt.txt`):**
- Expanded from 2 sentences to a comprehensive role definition with structured output requirements
- Added explicit article structure guidelines (Summary → Metrics → Cross-Metric Correlations → Conclusion)
- Defined style rules: third-person tone, quantified assertions, specific data key references
- Clarified Hugo figure shortcode formatting requirements
- Added guidance on honest reporting when data shows no anomalies

**Human Prompt (`prompt1.txt`):**
- Reorganized metric definitions with consistent structure: What it measures → Anomalous pattern → Benchmark
- Added explicit **Methodology** section with a 4-step analytical workflow
- Extracted **Cross-Metric Indicators** into a dedicated section for stronger evidence assessment
- Separated article format instructions into a clear, scannable section
- Reduced redundancy and improved readability with consistent formatting
- Emphasized honest assessment — avoiding over-interpretation when data is clean

**Python Code (`market_health_reporter.py`):**
- Fixed path bug: `content/market-health/` → `content/research/market-health/`
- The old paths would fail at runtime since the actual directory structure uses `content/research/market-health/`
- Both `ARTICLE_EXAMPLE_FILE` and `OUTPUT_DIR` are now correct

### Why these improvements matter

The original prompts were functional but:
1. The system prompt was a single generic sentence — the model had no guidance on output structure
2. The human prompt mixed methodology, metric definitions, and format instructions without clear separation
3. Cross-metric analysis (the strongest evidence for manipulation) was buried in a paragraph
4. The path bug meant the tool would crash on first use

These changes produce more structured, data-driven, and honestly assessed reports while fixing a critical runtime bug.

🌰

/cc @1712n
