### PR TITLE
feat: Replace static matplotlib charts with dynamic Chart.js rendering

### DIFF
--- a/assets/js/metric-charts.js
+++ b/assets/js/metric-charts.js
@@ -1,0 +1,188 @@
+/**
+ * metric-charts.js — Dynamic Chart.js renderer for market health report charts.
+ *
+ * Initializes Chart.js charts from JSON data embedded in metric_chart shortcodes.
+ * Uses IntersectionObserver for lazy initialization so charts only render when
+ * scrolled into view, improving page load performance for reports with many charts.
+ *
+ * Depends on chart.js already present in assets/js/chart.js.
+ */
+
+(function () {
+  "use strict";
+
+  /**
+   * Default chart options shared across all chart types.
+   * Supports light and dark mode via CSS media query detection.
+   */
+  function getDefaultOptions() {
+    var isDark =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var textColor = isDark ? "#c9d1d9" : "#333";
+    var gridColor = isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
+
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 600 },
+      plugins: {
+        legend: {
+          position: "bottom",
+          labels: { color: textColor, padding: 16 },
+        },
+        title: {
+          display: false,
+          color: textColor,
+          font: { size: 14, weight: "bold" },
+        },
+        tooltip: {
+          mode: "index",
+          intersect: false,
+        },
+      },
+      elements: {
+        point: { radius: 0, hoverRadius: 4 },
+        line: { tension: 0.2, borderWidth: 2 },
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: textColor,
+            maxRotation: 45,
+            autoSkip: true,
+            maxTicksLimit: 15,
+          },
+          grid: { color: gridColor },
+        },
+        y: {
+          ticks: { color: textColor },
+          grid: { color: gridColor },
+        },
+      },
+    };
+  }
+
+  /**
+   * Deep merge two objects. Values in `src` override those in `target`.
+   */
+  function deepMerge(target, src) {
+    var result = {};
+    var key;
+    for (key in target) {
+      if (target.hasOwnProperty(key)) {
+        result[key] = target[key];
+      }
+    }
+    for (key in src) {
+      if (src.hasOwnProperty(key)) {
+        if (
+          typeof src[key] === "object" &&
+          src[key] !== null &&
+          !Array.isArray(src[key]) &&
+          typeof result[key] === "object" &&
+          result[key] !== null &&
+          !Array.isArray(result[key])
+        ) {
+          result[key] = deepMerge(result[key], src[key]);
+        } else {
+          result[key] = src[key];
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Initialize a single metric chart from a container element.
+   * Reads chart configuration from the data-chart-config attribute.
+   */
+  function initChart(container) {
+    if (container.dataset.chartInitialized === "true") return;
+
+    var canvas = container.querySelector("canvas");
+    if (!canvas) return;
+
+    var configStr = container.getAttribute("data-chart-config");
+    if (!configStr) return;
+
+    var config;
+    try {
+      config = JSON.parse(configStr);
+    } catch (e) {
+      console.error("metric-charts: invalid JSON config for", canvas.id, e);
+      return;
+    }
+
+    var chartType = config.type || "line";
+    var chartData = config.data || {};
+    var customOptions = config.options || {};
+    var defaults = getDefaultOptions();
+
+    // Merge custom options on top of defaults
+    var mergedOptions = deepMerge(defaults, customOptions);
+
+    // If title is provided in config, enable it
+    if (config.title) {
+      mergedOptions.plugins = mergedOptions.plugins || {};
+      mergedOptions.plugins.title = {
+        display: true,
+        text: config.title,
+        color: mergedOptions.plugins.title
+          ? mergedOptions.plugins.title.color
+          : "#333",
+        font: { size: 14, weight: "bold" },
+      };
+    }
+
+    var ctx = canvas.getContext("2d");
+    new Chart(ctx, {
+      type: chartType,
+      data: chartData,
+      options: mergedOptions,
+    });
+
+    container.dataset.chartInitialized = "true";
+  }
+
+  /**
+   * Initialize all metric charts on the page, using IntersectionObserver
+   * for lazy loading when available.
+   */
+  function initAllCharts() {
+    var containers = document.querySelectorAll(".metric-chart-container");
+    if (!containers.length) return;
+
+    if ("IntersectionObserver" in window) {
+      var observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              initChart(entry.target);
+              observer.unobserve(entry.target);
+            }
+          });
+        },
+        { rootMargin: "200px" }
+      );
+
+      containers.forEach(function (container) {
+        observer.observe(container);
+      });
+    } else {
+      // Fallback: initialize all immediately
+      containers.forEach(function (container) {
+        initChart(container);
+      });
+    }
+  }
+
+  // Run on DOM ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAllCharts, {
+      passive: true,
+    });
+  } else {
+    initAllCharts();
+  }
+})();

--- a/layouts/shortcodes/metric_chart.html
+++ b/layouts/shortcodes/metric_chart.html
@@ -1,0 +1,57 @@
+{{/*
+  metric_chart shortcode — renders an interactive Chart.js chart from inline JSON.
+
+  This shortcode replaces static matplotlib PNG images in market health reports
+  with dynamic, interactive charts rendered in the browser via Chart.js.
+
+  Usage (paired shortcode):
+    {{< metric_chart id="volume-hist" >}}
+    {
+      "type": "bar",
+      "title": "Transaction Volume Distribution",
+      "data": { "labels": [...], "datasets": [...] },
+      "options": { ... }
+    }
+    {{< /metric_chart >}}
+
+  Parameters:
+    id       — unique DOM id for the canvas element (required)
+    height   — canvas container height in px (default: 400)
+    caption  — figure caption text displayed below the chart (optional)
+
+  The inner JSON must contain:
+    type     — Chart.js chart type: "line", "bar", "scatter", etc.
+    data     — Chart.js data object with labels and datasets
+    title    — (optional) chart title string
+    options  — (optional) Chart.js options to merge with defaults
+
+  Chart.js and the metric-charts.js module are loaded once per page (deduped).
+*/}}
+
+{{ $id := .Get "id" | default "chart" }}
+{{ $height := .Get "height" | default "400" }}
+{{ $caption := .Get "caption" | default "" }}
+
+{{/* Load Chart.js and metric-charts.js once per page via Scratch */}}
+{{ if not (.Page.Scratch.Get "chartjsLoaded") }}
+  {{ .Page.Scratch.Set "chartjsLoaded" true }}
+  {{ $chartLib := resources.Get "/js/chart.js" }}
+  {{ $metricCharts := resources.Get "/js/metric-charts.js" }}
+  <script src="{{ $chartLib.Permalink }}"></script>
+  <script src="{{ $metricCharts.Permalink }}" defer></script>
+{{ end }}
+
+<figure class="metric-chart-figure" style="margin: 1.5em 0;">
+  <div
+    class="metric-chart-container"
+    data-chart-config='{{ .Inner }}'
+    style="position: relative; width: 100%; height: {{ $height }}px;"
+  >
+    <canvas id="{{ $id }}"></canvas>
+  </div>
+  {{ with $caption }}
+  <figcaption style="text-align: center; font-size: 0.9em; color: #666; margin-top: 0.5em;">
+    {{ . }}
+  </figcaption>
+  {{ end }}
+</figure>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ markdown2 = "^2.4.10"
 bs4 = "^0.0.1"
 anthropic = "^0.25.1"
 tenacity = "^8.2.3"
-matplotlib = "3.6.0"
 pandas = "2.0.1"
 bleach = "^6.1.0"
 

--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -73,10 +73,11 @@ Create an article with the results of your analysis. The article should include:
         The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
 
 Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
-Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
+Charts are generated automatically by the visualization tool and injected into the article after LLM generation. Do NOT include any `{{< figure >}}` image shortcodes for charts in your output. Instead, add the following placeholder comments where each chart should appear — the tool will replace them with interactive Chart.js charts:
+
+- `<!-- CHART: volume_hist -->` — Transaction volume distribution histogram
+- `<!-- CHART: crypto_metrics -->` — Multi-metric time series (volume, trade count, avg tx size, buy/sell ratio)
+- `<!-- CHART: benford_law -->` — Benford's Law K-S test score vs critical value
+- `<!-- CHART: vv_correlation -->` — Volume-volatility correlation over time
+
 Place the article into the <article> </article> tags.

--- a/tools/python_modules/report_graphics_tool.py
+++ b/tools/python_modules/report_graphics_tool.py
@@ -1,92 +1,363 @@
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-import matplotlib.dates as mdates
+"""
+report_graphics_tool.py — Generate interactive Chart.js charts via Hugo shortcodes.
+
+Replaces the previous matplotlib-based static PNG generation with dynamic,
+browser-rendered charts using the ``{{< metric_chart >}}`` Hugo shortcode.
+
+Each chart method produces a Hugo shortcode string with an embedded JSON config
+that the metric-charts.js module will parse at render time.  The JSON contains
+the Chart.js *type*, *data*, an optional *title*, and any extra *options*
+(e.g. multi-axis scales, threshold annotations).
+
+The public interface (``Visualization.generate_report(data, directory)``)
+remains unchanged so the existing ``market_health_reporter.py`` pipeline
+works without modification.
+"""
+
+import json
+import math
 import os
+import re
+
+import pandas as pd
 
 
 class Visualization:
+    """Generate interactive Chart.js chart shortcodes for market health reports."""
+
     def __init__(self):
         pass
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
-    def _make_volume_hist(self, data, directory):
-        plt.figure(figsize=(10, 6))
-        plt.hist(data['volume'], bins=30, color='skyblue', edgecolor='black')
-        plt.xlabel('Transaction Volume')
-        plt.ylabel('Frequency')
-        plt.title('Transaction Volume Distribution')
-        plt.grid(True, which='both', linestyle='--', linewidth=0.5)
-        plt.savefig(os.path.join(directory, 'volume_hist.png'))
-        plt.close()
+    @staticmethod
+    def _fmt_ts(timestamps):
+        """Format a DatetimeIndex to short human-readable labels."""
+        return [t.strftime("%Y-%m-%d %H:%M") for t in timestamps]
 
+    @staticmethod
+    def _shortcode(chart_id, config, caption=""):
+        """Wrap a Chart.js config dict into a Hugo metric_chart shortcode."""
+        caption_attr = f' caption="{caption}"' if caption else ""
+        inner = json.dumps(config, default=str)
+        return (
+            f'{{{{< metric_chart id="{chart_id}"{caption_attr} >}}}}\n'
+            f"{inner}\n"
+            "{{< /metric_chart >}}"
+        )
 
-    def _make_crypto_metrics(self, data, directory):
-        fig, axs = plt.subplots(4, 1, figsize=(15, 10), sharex=True)
+    # ------------------------------------------------------------------
+    # Chart builders
+    # ------------------------------------------------------------------
 
-        axs[0].plot(data.index, data['volume'], label='Volume', color='blue')
-        axs[0].set_ylabel('Volume')
+    def _make_volume_hist(self, data):
+        """Transaction volume distribution histogram."""
+        volumes = data["volume"].dropna().tolist()
+        num_bins = 30
+        min_v = min(volumes) if volumes else 0
+        max_v = max(volumes) if volumes else 1
+        bin_width = (max_v - min_v) / num_bins if max_v != min_v else 1
 
-        axs[1].plot(data.index, data['tradecount'], label='Trade Count', color='green')
-        axs[1].set_ylabel('Trade Count')
+        bins = [0] * num_bins
+        for v in volumes:
+            idx = min(int((v - min_v) / bin_width), num_bins - 1)
+            bins[idx] += 1
 
-        axs[2].plot(data.index, data['avgtransactionsize'], label='Avg Transaction Size', color='orange')
-        axs[2].set_ylabel('Avg Transaction Size')
+        labels = [f"{min_v + i * bin_width:.0f}" for i in range(num_bins)]
 
-        axs[3].plot(data.index, data['buysellratio'], label='Buy/Sell Ratio', color='red')
-        axs[3].set_ylabel('Buy/Sell Ratio')
+        config = {
+            "type": "bar",
+            "title": "Transaction Volume Distribution",
+            "data": {
+                "labels": labels,
+                "datasets": [
+                    {
+                        "label": "Frequency",
+                        "data": bins,
+                        "backgroundColor": "rgba(135, 206, 235, 0.7)",
+                        "borderColor": "rgba(0, 0, 0, 0.3)",
+                        "borderWidth": 1,
+                    }
+                ],
+            },
+            "options": {
+                "scales": {
+                    "x": {"title": {"display": True, "text": "Transaction Volume"}},
+                    "y": {"title": {"display": True, "text": "Frequency"}},
+                }
+            },
+        }
+        return self._shortcode(
+            "volume-hist",
+            config,
+            caption="Distribution of transaction volumes over the analysis period",
+        )
 
-        axs[3].set_xlabel('Timestamp')
+    def _make_crypto_metrics(self, data):
+        """Multi-panel time-series: volume, trade count, avg tx size, buy/sell ratio.
 
-        fig.suptitle('Cryptocurrency Metrics Over Time')
+        Uses four independent Y axes so that each metric has its own scale,
+        matching the original four-subplot matplotlib layout.
+        """
+        labels = self._fmt_ts(data.index)
 
-        for ax in axs:
-            plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
+        config = {
+            "type": "line",
+            "title": "Cryptocurrency Metrics Over Time",
+            "data": {
+                "labels": labels,
+                "datasets": [
+                    {
+                        "label": "Volume",
+                        "data": data["volume"].tolist(),
+                        "borderColor": "rgb(54, 162, 235)",
+                        "yAxisID": "yVolume",
+                    },
+                    {
+                        "label": "Trade Count",
+                        "data": data["tradecount"].tolist(),
+                        "borderColor": "rgb(75, 192, 192)",
+                        "yAxisID": "yTradeCount",
+                    },
+                    {
+                        "label": "Avg Transaction Size",
+                        "data": data["avgtransactionsize"].tolist(),
+                        "borderColor": "rgb(255, 159, 64)",
+                        "yAxisID": "yAvgTx",
+                    },
+                    {
+                        "label": "Buy/Sell Ratio",
+                        "data": data["buysellratio"].tolist(),
+                        "borderColor": "rgb(255, 99, 132)",
+                        "yAxisID": "yBSR",
+                    },
+                ],
+            },
+            "options": {
+                "interaction": {"mode": "index", "intersect": False},
+                "scales": {
+                    "yVolume": {
+                        "type": "linear",
+                        "position": "left",
+                        "title": {"display": True, "text": "Volume"},
+                        "grid": {"drawOnChartArea": True},
+                    },
+                    "yTradeCount": {
+                        "type": "linear",
+                        "position": "left",
+                        "title": {"display": True, "text": "Trade Count"},
+                        "grid": {"drawOnChartArea": False},
+                    },
+                    "yAvgTx": {
+                        "type": "linear",
+                        "position": "right",
+                        "title": {"display": True, "text": "Avg Tx Size"},
+                        "grid": {"drawOnChartArea": False},
+                    },
+                    "yBSR": {
+                        "type": "linear",
+                        "position": "right",
+                        "title": {"display": True, "text": "Buy/Sell Ratio"},
+                        "grid": {"drawOnChartArea": False},
+                    },
+                },
+            },
+        }
+        return self._shortcode(
+            "crypto-metrics",
+            config,
+            caption="Volume, trade count, average transaction size, and buy/sell ratio over time",
+        )
 
-        plt.tight_layout()
-        plt.savefig(os.path.join(directory, 'crypto_metrics.png'))
-        plt.close()
-        
+    def _make_benfordlaw(self, data):
+        """Benford's Law K-S test score vs critical threshold over time.
 
-    def _make_benfordlaw(self, data, directory):
-        fig, ax1 = plt.subplots(figsize=(15, 10), layout='constrained')
-        ax1.plot(data.index, data['benfordlawtest'], color='blue', linestyle='-', label='Benford Law Test Score')
-        ax1.set_xlabel('Timestamp')
-        ax1.set_ylabel('Benford Law Test Score', color='blue')
-        ax1.xaxis.set_major_locator(mdates.HourLocator(interval=24))
-        ax1.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-        ax2 = ax1.twinx()
-        ax2.plot(data.index, 1.36 / np.sqrt(data['tradecount']), color='green', linestyle='-', label='Trade Count')
-        ax2.set_ylabel('Trade Count', color='green')
-        ax1.set_title('Benford Law Test Score and Trade Count Over Time')
-        lines = ax1.get_lines() + ax2.get_lines()
-        labels = [line.get_label() for line in lines]
-        ax1.legend(lines, labels, loc='upper left')
-        plt.savefig(os.path.join(directory, 'benford_law.png'))
-        plt.close()
+        The critical value is ``1.36 / sqrt(tradecount)``; data points above
+        this threshold indicate deviation from Benford's Law.
+        """
+        labels = self._fmt_ts(data.index)
+        benford_scores = data["benfordlawtest"].tolist()
+        critical_values = [
+            round(1.36 / math.sqrt(tc), 6) if tc > 0 else 0
+            for tc in data["tradecount"].tolist()
+        ]
 
+        config = {
+            "type": "line",
+            "title": "Benford's Law Test: K-S Statistic vs Critical Value",
+            "data": {
+                "labels": labels,
+                "datasets": [
+                    {
+                        "label": "K-S Test Statistic",
+                        "data": benford_scores,
+                        "borderColor": "rgb(54, 162, 235)",
+                    },
+                    {
+                        "label": "Critical Value (1.36/\u221an)",
+                        "data": critical_values,
+                        "borderColor": "rgb(255, 99, 132)",
+                        "borderDash": [6, 3],
+                    },
+                ],
+            },
+            "options": {
+                "interaction": {"mode": "index", "intersect": False},
+                "scales": {
+                    "y": {
+                        "title": {"display": True, "text": "Statistic Value"},
+                    },
+                },
+            },
+        }
+        return self._shortcode(
+            "benford-law",
+            config,
+            caption="K-S test statistic vs critical value; points above the threshold "
+            "indicate deviation from Benford's Law",
+        )
 
-    def _make_vvcorrelation(self, data, directory):
-        fig, ax = plt.subplots(figsize=(15, 10), layout='constrained')
-        ax.plot(data.index, data['vvcorrelation'], color='purple', linestyle='-', marker='o', label='VV Correlation')
-        ax.xaxis.set_major_locator(mdates.HourLocator(interval=24))
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-        ax.set_xlabel('Timestamp')
-        ax.set_ylabel('VV Correlation')
-        ax.set_title('VV Correlation Over Time')
-        ax.legend()
-        plt.xticks(rotation=45)
-        plt.savefig(os.path.join(directory, 'vv_correlation.png'))
-        plt.close()
+    def _make_vvcorrelation(self, data):
+        """Volume-volatility correlation over time.
+
+        Low correlation (below ~0.4) over extended periods suggests artificial
+        volume that does not impact price discovery.
+        """
+        labels = self._fmt_ts(data.index)
+        vv_values = data["vvcorrelation"].tolist()
+
+        # Add a reference threshold line at 0.4
+        threshold = [0.4] * len(labels)
+
+        config = {
+            "type": "line",
+            "title": "Volume-Volatility Correlation Over Time",
+            "data": {
+                "labels": labels,
+                "datasets": [
+                    {
+                        "label": "VV Correlation",
+                        "data": vv_values,
+                        "borderColor": "rgb(153, 102, 255)",
+                        "backgroundColor": "rgba(153, 102, 255, 0.1)",
+                        "fill": True,
+                    },
+                    {
+                        "label": "Anomaly Threshold (0.4)",
+                        "data": threshold,
+                        "borderColor": "rgba(255, 99, 132, 0.6)",
+                        "borderDash": [6, 3],
+                        "borderWidth": 1,
+                        "pointRadius": 0,
+                        "fill": False,
+                    },
+                ],
+            },
+            "options": {
+                "scales": {
+                    "y": {
+                        "title": {"display": True, "text": "Correlation Coefficient"},
+                        "suggestedMin": -1,
+                        "suggestedMax": 1,
+                    },
+                },
+            },
+        }
+        return self._shortcode(
+            "vv-correlation",
+            config,
+            caption="Correlation between trading volume and price volatility; "
+            "values persistently below 0.4 suggest artificial volume",
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def generate_report(self, data, directory):
+        """Generate interactive chart shortcodes and inject them into the article.
+
+        Maintains the same public interface as the previous matplotlib version.
+
+        Args:
+            data: Raw API response data (list of dicts or dict-of-lists).
+            directory: Path to the article output directory.
+
+        Returns:
+            str: Combined shortcode markdown for all generated charts.
+        """
         if not os.path.exists(directory):
             os.makedirs(directory)
-        data = pd.DataFrame(data)
-        data['timestamp'] = pd.to_datetime(data['timestamp'])
-        data.set_index('timestamp', inplace=True)
 
-        self._make_volume_hist(data, directory)
-        self._make_crypto_metrics(data, directory)
-        self._make_benfordlaw(data, directory)
-        self._make_vvcorrelation(data, directory)
+        df = pd.DataFrame(data)
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df.set_index("timestamp", inplace=True)
+
+        charts = [self._make_volume_hist(df), self._make_crypto_metrics(df)]
+
+        if "benfordlawtest" in df.columns:
+            charts.append(self._make_benfordlaw(df))
+
+        if "vvcorrelation" in df.columns:
+            charts.append(self._make_vvcorrelation(df))
+
+        chart_block = "\n\n".join(charts)
+
+        # Inject charts into the article markdown if it exists in the directory
+        index_files = sorted(
+            [
+                f
+                for f in os.listdir(directory)
+                if f.startswith("index") and f.endswith(".md")
+            ]
+        )
+        if index_files:
+            article_path = os.path.join(directory, index_files[-1])
+            with open(article_path, "r", encoding="utf-8") as fh:
+                content = fh.read()
+
+            # Build a map of placeholder patterns to chart shortcodes.
+            # Supports three formats:
+            #   1. Old static PNG figure shortcodes (backward compat)
+            #   2. New <!-- CHART: name --> HTML comment placeholders
+            #   3. Bare PNG filenames referenced in any shortcode
+            chart_map = {
+                "volume_hist": charts[0],
+                "crypto_metrics": charts[1],
+            }
+            if len(charts) > 2:
+                chart_map["benford_law"] = charts[2]
+            if len(charts) > 3:
+                chart_map["vv_correlation"] = charts[3]
+
+            modified = False
+            for name, shortcode in chart_map.items():
+                # Replace {{< figure src="<name>.png" ... >}}
+                pattern_fig = (
+                    r'\{\{<\s*figure\s+[^>]*src="' + re.escape(name) + r'\.png"[^>]*>\}\}'
+                )
+                new_content = re.sub(pattern_fig, shortcode, content)
+                if new_content != content:
+                    content = new_content
+                    modified = True
+
+                # Replace <!-- CHART: <name> -->
+                pattern_comment = r'<!--\s*CHART:\s*' + re.escape(name) + r'\s*-->'
+                new_content = re.sub(pattern_comment, shortcode, content)
+                if new_content != content:
+                    content = new_content
+                    modified = True
+
+            # If no replacements were made (article doesn't reference PNGs),
+            # append charts section
+            if not modified and "metric_chart" not in content:
+                content += f"\n\n## Interactive Charts\n\n{chart_block}\n"
+                modified = True
+
+            if modified:
+                with open(article_path, "w", encoding="utf-8") as fh:
+                    fh.write(content)
+
+        return chart_block


### PR DESCRIPTION
Replaces static matplotlib PNG image generation with interactive Chart.js charts via new Hugo shortcode. Closes #415. Changes: (1) New metric_chart shortcode with deduped script loading, (2) New metric-charts.js with lazy init via IntersectionObserver and dark mode support, (3) Rewritten report_graphics_tool.py outputting shortcodes with multi-axis Y scales and threshold lines, (4) Updated LLM prompt with CHART placeholders, (5) Removed matplotlib from pyproject.toml. cc @Kseymur @evgenydmitriev