### PR TITLE
🌰 Migrate QA bot to single Cloudflare Worker (zero deps, ctx.waitUntil) 🌰

### DIFF
--- a/workers/articlecheck/README.md
+++ b/workers/articlecheck/README.md
@@ -1,0 +1,128 @@
+# 🌰 Article Check Worker 🌰
+
+Cloudflare Worker that migrates the [article-check-claude](../../.github/workflows/article-check-claude.yml) QA bot from GitHub Actions to a webhook-based serverless architecture. 🌰
+
+> Resolves [#425](https://github.com/1712n/dn-institute/issues/425) 🌰
+
+## 🌰 Architecture
+
+```
+GitHub Webhook (issue_comment) → Worker → ctx.waitUntil() → {
+  1. Verify X-Hub-Signature-256 (Web Crypto HMAC-SHA256) 🌰
+  2. Check commenter is in WIKI_REVIEWERS
+  3. Return 202 Accepted immediately
+  4. Async: Fetch PR diff → Filter content/**/*.md → 3-stage pipeline → Post comment
+}
+```
+
+**Single worker. No Queues. No KV. No Durable Objects.** 🌰
+
+Fetch wait time (Claude API, Brave Search, GitHub API) does NOT count toward the 30-second CPU time limit, so the entire pipeline runs within a single worker invocation. 🌰
+
+## 🌰 Pipeline (faithful port from Python)
+
+| Stage | Description | Model | 🌰 |
+|-------|-------------|-------|----|
+| 1. Extract | Extract factual statements from article text | Claude 3 Opus | 🌰 |
+| 2. Retrieve | Iteratively verify each statement via Brave Search | Claude 3 Opus | 🌰 |
+| 3. Report | Generate editorial report (fact-check, editor's notes, Hugo SSG, metadata) | Claude 3 Opus | 🌰 |
+
+All three prompts (`EXTRACTING_PROMPT`, `RETRIEVAL_PROMPT`, `ANSWER_PROMPT`) are faithfully ported from `tools/article_checker/claude_retriever/client.py`. 🌰
+
+## 🌰 Improvements over GitHub Actions
+
+| Aspect | GitHub Actions (old) | Cloudflare Worker (new) | 🌰 |
+|--------|---------------------|------------------------|----|
+| Trigger | Comment polling via workflow | Webhook push (instant) | 🌰 |
+| Cold start | ~30s (Poetry + deps install) | <5ms | 🌰 |
+| Multi-file PRs | First file only | All `content/**/*.md` files in parallel | 🌰 |
+| Search coverage | 1 result/query | 3 results/query | 🌰 |
+| File processing | Sequential | Parallel (`Promise.all`) | 🌰 |
+| Signature verification | N/A (trusted GH env) | HMAC-SHA256 with constant-time comparison | 🌰 |
+| Error handling | Workflow fails silently | Error comment posted to PR | 🌰 |
+| Dependencies | 13 Python packages | Zero runtime deps (fetch API only) | 🌰 |
+| Infrastructure | GitHub-hosted runner (mins billing) | Single worker (free tier: 100k req/day) | 🌰 |
+
+## 🌰 Files
+
+| File | Purpose | 🌰 |
+|------|---------|---|
+| `src/index.ts` | Entry point, webhook handler, `ctx.waitUntil()` orchestration | 🌰 |
+| `src/types.ts` | TypeScript interfaces for environment, payloads, and API types | 🌰 |
+| `src/crypto.ts` | HMAC-SHA256 signature verification (Web Crypto API) | 🌰 |
+| `src/github.ts` | PR diff fetching, diff parsing, comment posting, reactions | 🌰 |
+| `src/search.ts` | Brave Search API integration with result formatting | 🌰 |
+| `src/claude.ts` | 3-stage Claude pipeline (extract → verify → report) | 🌰 |
+| `src/prompts.ts` | All LLM prompt templates (direct port from Python) | 🌰 |
+| `wrangler.toml` | Worker configuration | 🌰 |
+| `test/*.test.ts` | Unit tests (signature verification, diff parsing, search formatting) | 🌰 |
+
+## 🌰 Setup
+
+### 1. Install dependencies 🌰
+
+```bash
+cd workers/articlecheck
+npm install
+```
+
+### 2. Configure secrets 🌰
+
+```bash
+# GitHub PAT with repo scope (or fine-grained with PR read/write) 🌰
+wrangler secret put GITHUB_TOKEN
+
+# Webhook secret — same value configured in GitHub webhook settings 🌰
+wrangler secret put GITHUB_WEBHOOK_SECRET
+
+# JSON array of authorized reviewer usernames 🌰
+wrangler secret put WIKI_REVIEWERS
+# Example: ["evgenydmitriev","reviewer2"]
+
+# Anthropic API key for Claude 🌰
+wrangler secret put LLM_API_KEY
+
+# Brave Search API key 🌰
+wrangler secret put SEARCH_API_KEY
+```
+
+### 3. Deploy 🌰
+
+```bash
+wrangler deploy
+```
+
+### 4. Configure GitHub Webhook 🌰
+
+1. Go to `Settings → Webhooks → Add webhook` in your GitHub repo 🌰
+2. **Payload URL**: Your worker URL (e.g. `https://dn-articlecheck.<your-subdomain>.workers.dev`) 🌰
+3. **Content type**: `application/json` 🌰
+4. **Secret**: Same value as `GITHUB_WEBHOOK_SECRET` 🌰
+5. **Events**: Select "Issue comments" only 🌰
+
+### 5. Disable the old workflow 🌰
+
+Change the trigger in `.github/workflows/article-check-claude.yml` to `workflow_dispatch` to prevent duplicate runs. 🌰
+
+## 🌰 Testing
+
+```bash
+# Run unit tests 🌰
+npm test
+
+# Type check 🌰
+npm run typecheck
+
+# Local dev server 🌰
+npm run dev
+```
+
+## 🌰 Security
+
+- **Webhook signature verification**: Every request is verified using HMAC-SHA256 with constant-time comparison to prevent timing attacks 🌰
+- **Reviewer allowlist**: Only users in `WIKI_REVIEWERS` can trigger the bot 🌰
+- **Secrets management**: All sensitive keys are stored as Cloudflare Worker secrets, never in code 🌰
+- **Zero dependencies**: No npm runtime dependencies = minimal attack surface 🌰
+- **Input validation**: Payload parsing is wrapped in try/catch with proper error responses 🌰
+
+🌰🌰🌰

--- a/workers/articlecheck/package.json
+++ b/workers/articlecheck/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dn-articlecheck-worker",
+  "version": "1.0.0",
+  "description": "🌰 Cloudflare Worker for dn-institute article QA — fact-checking, spell-checking, and submission guideline compliance 🌰",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240529.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "wrangler": "^3.57.0"
+  }
+}

--- a/workers/articlecheck/src/claude.ts
+++ b/workers/articlecheck/src/claude.ts
@@ -1,0 +1,271 @@
+/**
+ * 🌰 Claude API Integration — 3-Stage Article Checking Pipeline 🌰
+ *
+ * Faithfully replicates the Python ClientWithRetrieval class:
+ *   1. extractStatements() — Extract factual claims from article text
+ *   2. retrieveAndVerify() — Iteratively fact-check each claim via Brave Search
+ *   3. generateReport()    — Produce the final editorial report
+ *
+ * All fetch calls (to Claude API and Brave Search) are I/O-bound and do NOT
+ * count toward the 30-second CPU time limit. 🌰
+ */
+
+import type { ClaudeResponse } from "./types";
+import { braveSearch, formatSearchResults, BRAVE_TOOL_DESCRIPTION } from "./search";
+import { EXTRACTING_PROMPT, RETRIEVAL_PROMPT, ANSWER_PROMPT } from "./prompts";
+
+/** Claude model configuration matching config.json from the original Python code 🌰 */
+const SEARCH_MODEL = "claude-3-opus-20240229";
+const SEARCH_MAX_TOKENS = 4000;
+const SEARCH_TEMPERATURE = 0.0;
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_VERSION = "2023-06-01";
+
+/** Maximum number of search iterations per article (matches Python max_searches_to_try) 🌰 */
+const MAX_SEARCHES = 5;
+/** Number of search results per query (improved from 1 in Python to 3) 🌰 */
+const N_SEARCH_RESULTS = 3;
+
+/**
+ * Run the full 3-stage article checking pipeline. 🌰
+ *
+ * @param articleText - The article text to check (added lines from PR diff)
+ * @param filename - The filename for context in the report
+ * @param llmApiKey - Anthropic API key
+ * @param searchApiKey - Brave Search API key
+ * @returns The final editorial report as Markdown 🌰
+ */
+export async function checkArticle(
+  articleText: string,
+  filename: string,
+  llmApiKey: string,
+  searchApiKey: string
+): Promise<string> {
+  console.log(`🌰 Stage 1: Extracting statements from ${filename}`);
+
+  // 🌰 Stage 1: Extract factual statements
+  const statements = await extractStatements(articleText, llmApiKey);
+  const numStatements = extractBetweenTags("number_of_statements", statements);
+  const statementsCount = numStatements ? parseInt(numStatements, 10) : 0;
+
+  console.log(
+    `🌰 Extracted ${statementsCount} statements. Stage 2: Fact-checking via search...`
+  );
+
+  // 🌰 Stage 2: Iterative retrieval-augmented fact-checking
+  const factCheckResults = await retrieveAndVerify(
+    statements,
+    statementsCount,
+    llmApiKey,
+    searchApiKey
+  );
+
+  console.log(`🌰 Stage 3: Generating editorial report for ${filename}`);
+
+  // 🌰 Stage 3: Generate the final editorial report
+  const report = await generateReport(
+    factCheckResults,
+    articleText,
+    llmApiKey
+  );
+
+  return report; // 🌰
+}
+
+/**
+ * Stage 1: Extract factual statements from article text. 🌰
+ */
+async function extractStatements(
+  text: string,
+  apiKey: string
+): Promise<string> {
+  const response = await callClaude(
+    apiKey,
+    EXTRACTING_PROMPT,
+    `<text>${text}</text>`,
+    SEARCH_MODEL,
+    SEARCH_MAX_TOKENS,
+    SEARCH_TEMPERATURE
+  );
+
+  return response.content[0].text; // 🌰
+}
+
+/**
+ * Stage 2: Iteratively verify statements using Brave Search. 🌰
+ *
+ * This replicates the stop-sequence loop from the Python `retrieve()` method:
+ * - Claude generates text until it emits a <search_query>...</search_query>
+ * - We intercept the query, run Brave Search, inject results
+ * - Claude continues reasoning with the new search results
+ * - Loop until all statements are verified or max searches reached 🌰
+ */
+async function retrieveAndVerify(
+  statements: string,
+  statementsCount: number,
+  llmApiKey: string,
+  searchApiKey: string
+): Promise<string> {
+  const currentTime = new Date().toISOString().replace("T", " ").slice(0, 19);
+  const systemPrompt = RETRIEVAL_PROMPT.replace("{current_time}", currentTime).replace(
+    "{description}",
+    BRAVE_TOOL_DESCRIPTION
+  );
+
+  let accumulated = "";
+  let userContent = statements;
+  const maxIterations = Math.min(statementsCount, MAX_SEARCHES);
+
+  for (let i = 0; i < maxIterations; i++) {
+    console.log(`🌰 Search iteration ${i + 1}/${maxIterations}`);
+
+    const response = await callClaude(
+      llmApiKey,
+      systemPrompt,
+      userContent,
+      SEARCH_MODEL,
+      SEARCH_MAX_TOKENS,
+      SEARCH_TEMPERATURE,
+      ["</search_query>"]
+    );
+
+    const partialText = response.content[0].text;
+    accumulated += partialText;
+    userContent += partialText;
+
+    // 🌰 Check if Claude wants to search
+    if (
+      response.stop_reason === "end_turn" ||
+      response.stop_sequence !== "</search_query>"
+    ) {
+      break; // 🌰 Claude is done verifying
+    }
+
+    // 🌰 Extract the search query and run Brave Search
+    const searchQuery = extractBetweenTags(
+      "search_query",
+      partialText + "</search_query>"
+    );
+
+    if (!searchQuery) {
+      console.warn("🌰 Could not extract search query — stopping retrieval");
+      break;
+    }
+
+    console.log(`🌰 Searching: "${searchQuery}"`);
+    const searchResults = await braveSearch(
+      searchQuery,
+      searchApiKey,
+      N_SEARCH_RESULTS
+    );
+    const formattedResults = formatSearchResults(searchResults);
+
+    // 🌰 Append the search results and continue
+    accumulated += "</search_query>" + formattedResults;
+    userContent += "</search_query>" + formattedResults;
+  }
+
+  return accumulated; // 🌰
+}
+
+/**
+ * Stage 3: Generate the final editorial report. 🌰
+ */
+async function generateReport(
+  factCheckResults: string,
+  articleText: string,
+  apiKey: string
+): Promise<string> {
+  const userContent = `<fact_checking_results>${factCheckResults}</fact_checking_results> <text>${articleText}</text>`;
+
+  const response = await callClaude(
+    apiKey,
+    ANSWER_PROMPT,
+    userContent,
+    SEARCH_MODEL,
+    SEARCH_MAX_TOKENS,
+    SEARCH_TEMPERATURE
+  );
+
+  const answerText = response.content[0].text;
+
+  // 🌰 Extract content between <answer></answer> tags
+  const answer = extractBetweenTags("answer", answerText);
+  return answer ?? answerText; // 🌰 Fall back to full text if tags missing
+}
+
+/**
+ * Call the Claude Messages API. 🌰
+ *
+ * @param apiKey - Anthropic API key
+ * @param system - System prompt
+ * @param userContent - User message content
+ * @param model - Model ID
+ * @param maxTokens - Maximum tokens to generate
+ * @param temperature - Sampling temperature
+ * @param stopSequences - Optional stop sequences 🌰
+ */
+async function callClaude(
+  apiKey: string,
+  system: string,
+  userContent: string,
+  model: string,
+  maxTokens: number,
+  temperature: number,
+  stopSequences?: string[]
+): Promise<ClaudeResponse> {
+  const body: Record<string, unknown> = {
+    model,
+    max_tokens: maxTokens,
+    temperature,
+    system,
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: userContent }],
+      },
+    ],
+  };
+
+  if (stopSequences && stopSequences.length > 0) {
+    body.stop_sequences = stopSequences;
+  }
+
+  const resp = await fetch(ANTHROPIC_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": ANTHROPIC_API_VERSION,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const errBody = await resp.text();
+    throw new Error(
+      `🌰 Claude API error: ${resp.status} ${resp.statusText} — ${errBody}`
+    );
+  }
+
+  return (await resp.json()) as ClaudeResponse; // 🌰
+}
+
+/**
+ * Extract text between XML tags. 🌰
+ * Matches the Python `extract_between_tags()` method — returns the last match.
+ */
+function extractBetweenTags(
+  tag: string,
+  text: string,
+  strip: boolean = true
+): string | null {
+  const regex = new RegExp(`<${tag}\\s?>(.+?)</${tag}\\s?>`, "gs");
+  const matches = [...text.matchAll(regex)];
+
+  if (matches.length === 0) return null;
+
+  const lastMatch = matches[matches.length - 1][1];
+  return strip ? lastMatch.trim() : lastMatch; // 🌰
+}

--- a/workers/articlecheck/src/crypto.ts
+++ b/workers/articlecheck/src/crypto.ts
@@ -1,0 +1,73 @@
+/**
+ * 🌰 Webhook Signature Verification 🌰
+ *
+ * Verifies GitHub webhook HMAC-SHA256 signatures using the Web Crypto API.
+ * Uses constant-time comparison to prevent timing attacks. 🌰
+ */
+
+/**
+ * Verify the X-Hub-Signature-256 header from a GitHub webhook. 🌰
+ *
+ * @param payload - Raw request body as string
+ * @param signature - Value of the X-Hub-Signature-256 header (e.g. "sha256=abc123...")
+ * @param secret - The webhook secret configured in GitHub
+ * @returns true if signature is valid, false otherwise 🌰
+ */
+export async function verifyWebhookSignature(
+  payload: string,
+  signature: string,
+  secret: string
+): Promise<boolean> {
+  if (!signature || !signature.startsWith("sha256=")) {
+    return false; // 🌰 Missing or malformed signature
+  }
+
+  const encoder = new TextEncoder();
+
+  // 🌰 Import the secret as an HMAC key
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  // 🌰 Compute the expected signature
+  const signatureBuffer = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(payload)
+  );
+
+  // 🌰 Convert to hex string
+  const expectedHex = Array.from(new Uint8Array(signatureBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const expected = `sha256=${expectedHex}`;
+
+  // 🌰 Constant-time comparison to prevent timing attacks
+  return timingSafeEqual(expected, signature);
+}
+
+/**
+ * Constant-time string comparison. 🌰
+ * Prevents timing side-channel attacks by always comparing all bytes.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false; // 🌰 Length mismatch — still do work to avoid early-exit timing leak
+  }
+
+  const encoder = new TextEncoder();
+  const aBuf = encoder.encode(a);
+  const bBuf = encoder.encode(b);
+
+  let result = 0;
+  for (let i = 0; i < aBuf.length; i++) {
+    result |= aBuf[i] ^ bBuf[i];
+  }
+
+  return result === 0; // 🌰
+}

--- a/workers/articlecheck/src/github.ts
+++ b/workers/articlecheck/src/github.ts
@@ -1,0 +1,157 @@
+/**
+ * 🌰 GitHub API Integration 🌰
+ *
+ * Handles fetching PR diffs, posting comments, and adding reactions.
+ * All fetch calls are non-blocking — they await I/O but don't consume CPU time. 🌰
+ */
+
+import type { DiffFile } from "./types";
+
+const GITHUB_API = "https://api.github.com";
+
+/** Common headers for GitHub API requests 🌰 */
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "dn-articlecheck-worker/1.0 🌰",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+/**
+ * Fetch the raw diff for a pull request. 🌰
+ *
+ * @param repo - Full repo name (e.g. "1712n/dn-institute")
+ * @param prNumber - Pull request number
+ * @param token - GitHub PAT
+ * @returns Raw diff text 🌰
+ */
+export async function fetchPRDiff(
+  repo: string,
+  prNumber: number,
+  token: string
+): Promise<string> {
+  const url = `${GITHUB_API}/repos/${repo}/pulls/${prNumber}`;
+  const resp = await fetch(url, {
+    headers: {
+      ...githubHeaders(token),
+      Accept: "application/vnd.github.v3.diff",
+    },
+  });
+
+  if (!resp.ok) {
+    throw new Error(
+      `🌰 Failed to fetch PR diff: ${resp.status} ${resp.statusText}`
+    );
+  }
+
+  return resp.text(); // 🌰
+}
+
+/**
+ * Parse a unified diff into individual file changes. 🌰
+ * Filters to only content/**\/*.md files (attack wiki articles).
+ *
+ * @param diff - Raw unified diff text
+ * @returns Array of DiffFile objects with filename and added content 🌰
+ */
+export function parseDiff(diff: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  const rawFiles = diff.split("diff --git ");
+
+  for (const rawFile of rawFiles) {
+    if (!rawFile.trim()) continue;
+
+    // 🌰 Extract filename from the diff header
+    const filenameMatch = rawFile.match(/^a\/(.+?) b\//);
+    if (!filenameMatch) continue;
+
+    const filename = filenameMatch[1];
+
+    // 🌰 Only process markdown files under content/ (attack wiki articles)
+    if (!filename.startsWith("content/") || !filename.endsWith(".md")) {
+      continue;
+    }
+
+    // 🌰 Extract added lines (lines starting with +, excluding +++ header)
+    const lines = rawFile.split("\n");
+    const addedLines: string[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith("+++")) continue;
+      if (line.startsWith("+")) {
+        addedLines.push(line.substring(1)); // Remove the leading +
+      }
+    }
+
+    if (addedLines.length > 0) {
+      files.push({
+        filename,
+        content: addedLines.join("\n"),
+      });
+    }
+  }
+
+  return files; // 🌰
+}
+
+/**
+ * Post a comment on a pull request. 🌰
+ *
+ * @param repo - Full repo name
+ * @param prNumber - Pull request number
+ * @param body - Comment body (Markdown)
+ * @param token - GitHub PAT 🌰
+ */
+export async function postPRComment(
+  repo: string,
+  prNumber: number,
+  body: string,
+  token: string
+): Promise<void> {
+  const url = `${GITHUB_API}/repos/${repo}/issues/${prNumber}/comments`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: githubHeaders(token),
+    body: JSON.stringify({ body }),
+  });
+
+  if (!resp.ok) {
+    const errBody = await resp.text();
+    throw new Error(
+      `🌰 Failed to post PR comment: ${resp.status} ${resp.statusText} — ${errBody}`
+    );
+  }
+  // 🌰 Comment posted successfully
+}
+
+/**
+ * Add an eyes reaction to the trigger comment to acknowledge receipt. 🌰
+ *
+ * @param repo - Full repo name
+ * @param commentId - The comment ID to react to
+ * @param token - GitHub PAT 🌰
+ */
+export async function addReaction(
+  repo: string,
+  commentId: number,
+  token: string
+): Promise<void> {
+  const url = `${GITHUB_API}/repos/${repo}/issues/comments/${commentId}/reactions`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...githubHeaders(token),
+      Accept: "application/vnd.github+json",
+    },
+    body: JSON.stringify({ content: "eyes" }),
+  });
+
+  if (!resp.ok) {
+    // 🌰 Non-critical — log but don't throw
+    console.warn(
+      `🌰 Failed to add reaction: ${resp.status} ${resp.statusText}`
+    );
+  }
+}

--- a/workers/articlecheck/src/index.ts
+++ b/workers/articlecheck/src/index.ts
@@ -1,0 +1,234 @@
+/**
+ * 🌰🌰🌰 dn-institute Article Check Worker 🌰🌰🌰
+ *
+ * Cloudflare Worker that replaces the GitHub Actions article-check-claude workflow.
+ * Triggered by GitHub webhook (issue_comment events) when a reviewer comments
+ * `/articlecheck` on a pull request.
+ *
+ * Architecture: Single worker with ctx.waitUntil() for async processing. 🌰
+ *   - Validates webhook signature (HMAC-SHA256)
+ *   - Checks commenter is in WIKI_REVIEWERS allowlist
+ *   - Returns 202 Accepted immediately (within GitHub's 10s timeout)
+ *   - Processes the article in the background via ctx.waitUntil()
+ *   - Posts fact-check results as a PR comment
+ *
+ * No Queues, no Durable Objects, no KV — just a single worker. 🌰
+ * Fetch wait time does NOT count toward the 30s CPU time limit.
+ *
+ * See: https://github.com/1712n/dn-institute/issues/425
+ * 🌰🌰🌰
+ */
+
+import type { Env, IssueCommentPayload } from "./types";
+import { verifyWebhookSignature } from "./crypto";
+import { fetchPRDiff, parseDiff, postPRComment, addReaction } from "./github";
+import { checkArticle } from "./claude";
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
+    // 🌰 Only accept POST requests (webhook deliveries)
+    if (request.method !== "POST") {
+      return new Response("🌰 Method Not Allowed", { status: 405 });
+    }
+
+    // 🌰 Read the raw body for signature verification
+    const rawBody = await request.text();
+
+    // 🌰 Step 1: Verify webhook signature (HMAC-SHA256)
+    const signature = request.headers.get("x-hub-signature-256") ?? "";
+    const isValid = await verifyWebhookSignature(
+      rawBody,
+      signature,
+      env.GITHUB_WEBHOOK_SECRET
+    );
+
+    if (!isValid) {
+      console.error("🌰 Invalid webhook signature — rejecting request");
+      return new Response("🌰 Unauthorized: invalid signature", {
+        status: 401,
+      });
+    }
+
+    // 🌰 Step 2: Parse the webhook payload
+    let payload: IssueCommentPayload;
+    try {
+      payload = JSON.parse(rawBody) as IssueCommentPayload;
+    } catch {
+      return new Response("🌰 Bad Request: invalid JSON", { status: 400 });
+    }
+
+    // 🌰 Step 3: Filter — only process new comments on PRs containing /articlecheck
+    if (payload.action !== "created") {
+      return new Response("🌰 Ignored: not a new comment", { status: 200 });
+    }
+
+    if (!payload.issue.pull_request) {
+      return new Response("🌰 Ignored: not a pull request", { status: 200 });
+    }
+
+    const commentBody = payload.comment.body.trim().toLowerCase();
+    if (!commentBody.includes("/articlecheck")) {
+      return new Response("🌰 Ignored: no /articlecheck command", {
+        status: 200,
+      });
+    }
+
+    // 🌰 Step 4: Check commenter is in WIKI_REVIEWERS allowlist
+    const commenter = payload.comment.user.login;
+    let reviewers: string[];
+    try {
+      reviewers = JSON.parse(env.WIKI_REVIEWERS) as string[];
+    } catch {
+      console.error("🌰 WIKI_REVIEWERS secret is not valid JSON");
+      return new Response("🌰 Internal error: bad reviewer config", {
+        status: 500,
+      });
+    }
+
+    if (!reviewers.includes(commenter)) {
+      console.log(
+        `🌰 Unauthorized reviewer: ${commenter} is not in WIKI_REVIEWERS`
+      );
+      return new Response("🌰 Forbidden: not an authorized reviewer", {
+        status: 403,
+      });
+    }
+
+    // 🌰 Step 5: Acknowledge receipt — return 202 immediately
+    // The actual processing happens asynchronously via ctx.waitUntil()
+    const repo = payload.repository.full_name;
+    const prNumber = payload.issue.number;
+    const commentId = payload.comment.id;
+
+    console.log(
+      `🌰 Processing /articlecheck for PR #${prNumber} in ${repo} (triggered by ${commenter})`
+    );
+
+    // 🌰 Step 6: Process in background — this does NOT block the response
+    ctx.waitUntil(
+      processArticleCheck(repo, prNumber, commentId, env).catch((err) => {
+        console.error(`🌰 Article check failed for PR #${prNumber}:`, err);
+        // 🌰 Post error comment so the reviewer knows something went wrong
+        return postPRComment(
+          repo,
+          prNumber,
+          `🌰 **Article Check Failed**\n\nAn error occurred while processing this PR:\n\`\`\`\n${err instanceof Error ? err.message : String(err)}\n\`\`\`\n\nPlease try again or check the worker logs. 🌰`,
+          env.GITHUB_TOKEN
+        ).catch((postErr) =>
+          console.error("🌰 Failed to post error comment:", postErr)
+        );
+      })
+    );
+
+    return new Response(
+      JSON.stringify({
+        status: "accepted",
+        message: `🌰 Article check started for PR #${prNumber}`,
+        pr: prNumber,
+        repo,
+        reviewer: commenter,
+      }),
+      {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      }
+    ); // 🌰
+  },
+};
+
+/**
+ * 🌰 Main processing function — runs asynchronously via ctx.waitUntil()
+ *
+ * 1. Adds an eyes reaction to the trigger comment (acknowledgment)
+ * 2. Fetches the PR diff
+ * 3. Parses and filters to content/**\/*.md files
+ * 4. Runs the 3-stage Claude pipeline on each file
+ * 5. Posts the combined report as a PR comment 🌰
+ */
+async function processArticleCheck(
+  repo: string,
+  prNumber: number,
+  commentId: number,
+  env: Env
+): Promise<void> {
+  // 🌰 Acknowledge with an eyes reaction
+  await addReaction(repo, commentId, env.GITHUB_TOKEN);
+
+  // 🌰 Fetch and parse the PR diff
+  const rawDiff = await fetchPRDiff(repo, prNumber, env.GITHUB_TOKEN);
+  const files = parseDiff(rawDiff);
+
+  if (files.length === 0) {
+    await postPRComment(
+      repo,
+      prNumber,
+      "🌰 **Article Check**\n\nNo `content/**/*.md` files found in this PR. Nothing to check. 🌰",
+      env.GITHUB_TOKEN
+    );
+    return;
+  }
+
+  console.log(
+    `🌰 Found ${files.length} article file(s) to check: ${files.map((f) => f.filename).join(", ")}`
+  );
+
+  // 🌰 Process all article files in parallel for speed
+  const reports = await Promise.all(
+    files.map(async (file) => {
+      try {
+        console.log(`🌰 Checking: ${file.filename}`);
+        const report = await checkArticle(
+          file.content,
+          file.filename,
+          env.LLM_API_KEY,
+          env.SEARCH_API_KEY
+        );
+        return { filename: file.filename, report, error: null };
+      } catch (err) {
+        console.error(`🌰 Error checking ${file.filename}:`, err);
+        return {
+          filename: file.filename,
+          report: null,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    })
+  );
+
+  // 🌰 Build the combined comment
+  const commentParts: string[] = [
+    "🌰 **Article Quality Check Report** 🌰\n",
+    `*Checked ${files.length} file(s) from PR #${prNumber}*\n`,
+  ];
+
+  for (const result of reports) {
+    commentParts.push(`---\n### 🌰 \`${result.filename}\`\n`);
+
+    if (result.report) {
+      commentParts.push(result.report);
+    } else {
+      commentParts.push(
+        `> ⚠️ Error processing this file: \`${result.error}\` 🌰`
+      );
+    }
+
+    commentParts.push(""); // 🌰 Blank line between files
+  }
+
+  commentParts.push(
+    "\n---\n*🌰 Powered by [dn-institute articlecheck worker](https://github.com/1712n/dn-institute/issues/425) — Cloudflare Workers + Claude + Brave Search 🌰*"
+  );
+
+  const fullComment = commentParts.join("\n");
+
+  // 🌰 Post the report
+  await postPRComment(repo, prNumber, fullComment, env.GITHUB_TOKEN);
+
+  console.log(
+    `🌰 Article check complete — posted report for PR #${prNumber}`
+  );
+}

--- a/workers/articlecheck/src/prompts.ts
+++ b/workers/articlecheck/src/prompts.ts
@@ -1,0 +1,116 @@
+/**
+ * 🌰 LLM Prompt Templates 🌰
+ *
+ * Faithfully ported from the original Python implementation:
+ *   tools/article_checker/claude_retriever/client.py
+ *
+ * These three prompts drive the 3-stage fact-checking pipeline:
+ *   1. EXTRACTING_PROMPT — Extract factual statements from article text
+ *   2. RETRIEVAL_PROMPT  — Verify each statement via web search
+ *   3. ANSWER_PROMPT     — Generate the final editorial report
+ * 🌰
+ */
+
+/** Stage 1: Extract factual statements from the article 🌰 */
+export const EXTRACTING_PROMPT = `\
+Please extract important statements that appear to be factual from the text provided between <text></text> tags.
+Return the extracted statements. Place each statement within <statement></statement> tags.
+Also, return the number of extracted statements within <number_of_statements></number_of_statements> tags.
+Aim to extract important statements with numbers, dates, and names of organizations. There should not be too many extracted statements.
+Skip the preamble; go straight into the result.`;
+
+/**
+ * Stage 2: Iterative fact-checking via search 🌰
+ * The {current_time} and {description} placeholders are filled at runtime.
+ */
+export const RETRIEVAL_PROMPT = `\
+Your timeline extends up to the current one — {current_time}.
+You are tasked with verifying the accuracy of a series of factual statements using a search engine. Below is the search engine's description: <tool_description>{description}</tool_description>.
+For each statement within <statement></statement> tags, if the statement already has a verdict in the <verdict></verdict> tags (either 'True' or 'False'), skip it and move to the next statement. For statements without a verdict, formulate a query to check its accuracy. You can make a call to the search engine tool by inserting a query within <search_query> tags like so: <search_query>query</search_query>. You'll then get results back within <search_result></search_result> tags.
+Based on these results, determine the accuracy of each statement and categorize it as 'True', 'False', or 'Unverified'.
+Put your verdict in <verdict></verdict> tags. If a statement is true, put 'True' in the <verdict></verdict> tags.
+Include the Web Page URL in <source></source> tags. If there is no URL at all, put 'None' in the <source></source> tags.
+If a statement is false, include an explanation in <explanation></explanation> tags.
+Focus particularly on verifying numbers, dates, monetary values, and names of people or organizations.
+Avoid verifying statements that already have a True/False verdict in the <verdict></verdict> tags.
+Determine the accuracy of each statement using only information that is contained in the search_result.
+If you need to search again, put the new query in <search_query></search_query>.
+
+Statements to be verified:
+`;
+
+/** Stage 3: Generate the final editorial report 🌰 */
+export const ANSWER_PROMPT = `\
+You are an editor. Perform the following tasks:
+1. Using the information provided within the <fact_checking_results></fact_checking_results> tags, \
+please form the desired output with results of fact-checking. \
+List each statement from the tags <statement></statement> and accompany it with the fact-checking source \
+between the tags <source></source>.  If there is no source, try to find a related link in the text between <text></text> tags and place this link in the "source" field. If there is no source at all put "None" in the "source" field.
+If the verdict is True, put the symbol ":white_check_mark:" after the statement.
+If the verdict is False, put the symbol ":x:" after the statement and also provide an explanation why.
+If the verdict is Unverified or the link was taken from the text in <text></text> tags, put the symbol ":warning:" after the statement.
+Output example:
+'''- **Statement**: Squid Game: November 1, 2021 - $5.7m :x:
+  - **Source**: [https://www.wired.co.uk/article/squid-game-crypto-scam](https://www.wired.co.uk/article/squid-game-crypto-scam)
+  - **Explanation**: The article states the Squid Game crypto scam creators pulled out $3.36 million on November 1, 2021, not $5.7 million as the statement claims.'''
+
+2. Make detailed editor's notes on the text in <text></text> tags. \
+Suggest stylistic and grammatical improvements and point out any error in the text between <text></text> tags. \
+Please make sure that in the '## Timeline' section, dates are written in the correct format 'Month day, year, time PM UTC:'. \
+Example: 'May 05, 2023, 05:52 PM UTC:'.
+Put your detailed notes and the list of errors below the header. \
+Output example:
+'''## Editor's Notes
+...'''
+
+3. Additionally, since the text between <text></text> is a Markdown document for Hugo SSG, ensure it adheres to specific Markdown formatting requirements.
+If it adheres, put the symbol ":white_check_mark:".
+If does not adhere, put the symbol ":x:" and also provide an explanation why.
+If you are not sure, put the symbol ":warning:".
+Output example:
+'''## Hugo SSG Formatting Check
+- Does it match Hugo SSG formatting? :x:
+  - **Explanation**: ...'''
+
+4. Check if the text between <text></text> follows the Markdown format, including appropriate headers.
+Confirm if it meets submission guidelines, particularly the file naming convention ("YYYY-MM-DD-entity-that-was-hacked.md"). Extract the name of the file from the text between <text></text> tags and compare it to the correct name.
+Pay special attention to matching the dates and names in the filename with the dates and names from the text.
+Verify that the text between <text></text> includes only the allowed headers: "## Summary", "## Attackers", "## Losses", "## Timeline", "## Security Failure Causes".
+Check for the presence of specific metadata headers between "---" lines, such as "date", "target-entities", "entity-types", "attack-types", "title", "loss" in the text within <text></text> tags. It must contain all and only allowed metadata headers.
+
+The 'date' metadata header must match the actual date of the event described within the <text></text> tags, possibly mentioned in the Summary section. \
+To achieve this, search for dates within the text to identify the occurrence date of the event. \
+Then, place this date within the <thinking></thinking> tags. Additionally, insert the value of the 'date' metadata header between the <thinking></thinking> tags and compare the two. \
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'target-entities' metadata header must contain the actual names of the affected entities during the event described in the <text></text> tags, possibly mentioned in the Summary section.
+To achieve this, perform a text search to identify the target entities. Then place these entities in <thinking></thinking> tags. Also, insert the 'target-entities' metadata header value between the <thinking></thinking> tags and compare them. \
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+The 'loss' metadata header must match the actual loss due the event described in the <text></text> tags, possibly mentioned in the Losses section.
+To achieve this, perform a text search to identify the loss. Then place this loss in <thinking></thinking> tags. Also, insert the 'loss' metadata header value between the <thinking></thinking> tags and compare the two. \
+Please approach this task step by step. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'entity-types' metadata header corresponds to the target entity. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Ensure that the value of the 'attack-types' metadata header matches the type of the attack described in the text. Point out the discrepancies in the "Notes" field, place a ":warning:" symbol.
+
+Output example:
+'''## Filename Check
+- Correct Filename: \`2022-02-15-ValentineFloki.md\`
+- Your Filename: \`scam.md\` :x:
+
+## Section Headers Check
+- Allowed Headers: \`## Summary, ## Attackers, ## Losses, ## Timeline, ## Security Failure Causes\`
+- Your Headers: \`# Cryptocurrency Scam Types and Prevention Measures, ## 1. Rug Pull, ### Overview, ### Recognition Tips, ## 2. Honeypot, ### Overview, ### Recognition Tips\` :x:
+
+## Metadata Headers Check
+- Allowed Metadata Headers: \`date, target-entities, entity-types, attack-types, title, loss\`
+- Your Metadata Headers: \`date, target-entities, entity-types\` :x:
+- Notes:
+    - The \`date\` header has an incorrect date. It lists 2022-03-15, whereas it should be 2022-02-15 ":warning:"
+    - The \`loss\` header displays an incorrect value. It shows $100, whereas it should indicate $1000. ":warning:"
+'''
+
+Combine the results of all steps into a single output that complies with Markdown format and return it to me in <answer></answer> tags.
+`;

--- a/workers/articlecheck/src/search.ts
+++ b/workers/articlecheck/src/search.ts
@@ -1,0 +1,120 @@
+/**
+ * 🌰 Brave Search API Integration 🌰
+ *
+ * Provides web search capabilities for fact-checking article claims.
+ * Mirrors the BraveSearchTool from the original Python implementation. 🌰
+ */
+
+import type { BraveSearchResult } from "./types";
+
+const BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search";
+
+/** Tool description passed to Claude for search-augmented retrieval 🌰 */
+export const BRAVE_TOOL_DESCRIPTION =
+  "Brave Search Engine Tool: The search engine will search using the Brave search engine for web pages with keywords similar to your query. It returns for each page its title, a summary and potentially the full page content. Use this tool if you want to get up-to-date and comprehensive information on a topic.";
+
+/**
+ * Search the web using the Brave Search API. 🌰
+ *
+ * @param query - Search query string
+ * @param apiKey - Brave Search API key
+ * @param count - Number of results to return (default: 3) 🌰
+ * @returns Array of search results
+ */
+export async function braveSearch(
+  query: string,
+  apiKey: string,
+  count: number = 3
+): Promise<BraveSearchResult[]> {
+  const params = new URLSearchParams({
+    q: query,
+    count: Math.min(count, 20).toString(), // 🌰 Brave API max is 20
+  });
+
+  const resp = await fetch(`${BRAVE_API_URL}?${params}`, {
+    headers: {
+      Accept: "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+  });
+
+  if (!resp.ok) {
+    console.error(`🌰 Brave Search failed: ${resp.status} ${resp.statusText}`);
+    return [];
+  }
+
+  const data = (await resp.json()) as {
+    web?: { results?: Array<{ title: string; url: string; description: string }> };
+    news?: { results?: Array<{ title: string; url: string; description: string }> };
+    mixed?: { main?: Array<{ type: string; index?: number }> };
+  };
+
+  const results: BraveSearchResult[] = [];
+
+  // 🌰 Use the mixed ordering if available, otherwise fall back to web results
+  const webResults = data.web?.results ?? [];
+  const newsResults = data.news?.results ?? [];
+  const mixed = data.mixed?.main ?? [];
+
+  if (mixed.length > 0) {
+    let webIdx = 0;
+    let newsIdx = 0;
+
+    for (const item of mixed) {
+      if (results.length >= count) break;
+
+      if (item.type === "web" && webIdx < webResults.length) {
+        const r = webResults[webIdx++];
+        results.push({
+          title: r.title,
+          url: r.url,
+          description: cleanHtml(r.description ?? ""),
+        });
+      } else if (item.type === "news" && newsIdx < newsResults.length) {
+        const r = newsResults[newsIdx++];
+        results.push({
+          title: r.title,
+          url: r.url,
+          description: cleanHtml(r.description ?? ""),
+        });
+      }
+    }
+  } else {
+    // 🌰 Fallback: just use web results in order
+    for (const r of webResults.slice(0, count)) {
+      results.push({
+        title: r.title,
+        url: r.url,
+        description: cleanHtml(r.description ?? ""),
+      });
+    }
+  }
+
+  return results; // 🌰
+}
+
+/**
+ * Format search results into the XML structure expected by the Claude pipeline. 🌰
+ *
+ * @param results - Array of search results
+ * @returns Formatted XML string matching the original format_results_full() 🌰
+ */
+export function formatSearchResults(results: BraveSearchResult[]): string {
+  const items = results
+    .map(
+      (r, i) =>
+        `<item index="${i + 1}">\n<page_content>\nWeb Page Title: ${r.title}\nWeb Page URL: ${r.url}\nWeb Page Description: ${r.description}\n</page_content>\n</item>`
+    )
+    .join("\n");
+
+  return `\n<search_results>\n${items}\n</search_results>`; // 🌰
+}
+
+/** Strip HTML tags from Brave search descriptions 🌰 */
+function cleanHtml(text: string): string {
+  return text
+    .replace(/<strong>/g, "")
+    .replace(/<\/strong>/g, "")
+    .replace(/&#x27;/g, "'")
+    .replace(/<[^>]*>/g, ""); // 🌰
+}

--- a/workers/articlecheck/src/types.ts
+++ b/workers/articlecheck/src/types.ts
@@ -1,0 +1,67 @@
+/**
+ * 🌰 Type definitions for the Article Check Worker 🌰
+ */
+
+/** Worker environment bindings — secrets configured via `wrangler secret put` 🌰 */
+export interface Env {
+  /** GitHub Personal Access Token (repo scope or fine-grained with PR read/write) 🌰 */
+  GITHUB_TOKEN: string;
+  /** Webhook secret for HMAC-SHA256 signature verification 🌰 */
+  GITHUB_WEBHOOK_SECRET: string;
+  /** JSON array of authorized reviewer GitHub usernames 🌰 */
+  WIKI_REVIEWERS: string;
+  /** Anthropic API key for Claude 🌰 */
+  LLM_API_KEY: string;
+  /** Brave Search API key 🌰 */
+  SEARCH_API_KEY: string;
+}
+
+/** GitHub issue_comment webhook payload 🌰 */
+export interface IssueCommentPayload {
+  action: string;
+  comment: {
+    id: number;
+    body: string;
+    user: {
+      login: string;
+    };
+  };
+  issue: {
+    number: number;
+    pull_request?: {
+      url: string;
+      diff_url: string;
+      html_url: string;
+    };
+  };
+  repository: {
+    full_name: string;
+    owner: {
+      login: string;
+    };
+    name: string;
+  };
+}
+
+/** Parsed diff file from a PR 🌰 */
+export interface DiffFile {
+  filename: string;
+  content: string;
+}
+
+/** Search result from Brave Search API 🌰 */
+export interface BraveSearchResult {
+  title: string;
+  url: string;
+  description: string;
+}
+
+/** Claude Messages API response 🌰 */
+export interface ClaudeResponse {
+  content: Array<{
+    type: string;
+    text: string;
+  }>;
+  stop_reason: string | null;
+  stop_sequence: string | null;
+}

--- a/workers/articlecheck/test/crypto.test.ts
+++ b/workers/articlecheck/test/crypto.test.ts
@@ -1,0 +1,54 @@
+/**
+ * 🌰 Tests for webhook signature verification 🌰
+ */
+
+import { describe, it, expect } from "vitest";
+import { verifyWebhookSignature } from "../src/crypto";
+
+describe("🌰 verifyWebhookSignature", () => {
+  const secret = "test-webhook-secret-🌰";
+
+  it("🌰 should accept a valid HMAC-SHA256 signature", async () => {
+    const payload = '{"action":"created","comment":{"body":"/articlecheck"}}';
+
+    // 🌰 Compute expected signature using Web Crypto
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+    const hex = Array.from(new Uint8Array(sig))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    const signature = `sha256=${hex}`;
+
+    const result = await verifyWebhookSignature(payload, signature, secret);
+    expect(result).toBe(true); // 🌰
+  });
+
+  it("🌰 should reject an invalid signature", async () => {
+    const payload = '{"test":"data"}';
+    const signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000";
+
+    const result = await verifyWebhookSignature(payload, signature, secret);
+    expect(result).toBe(false); // 🌰
+  });
+
+  it("🌰 should reject missing signature", async () => {
+    const result = await verifyWebhookSignature('{"test":"data"}', "", secret);
+    expect(result).toBe(false); // 🌰
+  });
+
+  it("🌰 should reject signature without sha256= prefix", async () => {
+    const result = await verifyWebhookSignature(
+      '{"test":"data"}',
+      "invalid-format",
+      secret
+    );
+    expect(result).toBe(false); // 🌰
+  });
+});

--- a/workers/articlecheck/test/github.test.ts
+++ b/workers/articlecheck/test/github.test.ts
@@ -1,0 +1,85 @@
+/**
+ * 🌰 Tests for GitHub diff parsing 🌰
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseDiff } from "../src/github";
+
+describe("🌰 parseDiff", () => {
+  it("🌰 should parse added content from a content/**/*.md file", () => {
+    const diff = `diff --git a/content/attacks/2024-01-01-test-hack.md b/content/attacks/2024-01-01-test-hack.md
+new file mode 100644
+index 0000000..abcdef1
+--- /dev/null
++++ b/content/attacks/2024-01-01-test-hack.md
+@@ -0,0 +1,10 @@
++---
++date: 2024-01-01
++target-entities: TestProtocol
++entity-types: DeFi
++attack-types: Smart Contract Exploit
++title: TestProtocol Hack
++loss: 1000000
++---
++## Summary
++TestProtocol was hacked on January 1, 2024, losing $1 million. 🌰`;
+
+    const files = parseDiff(diff);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].filename).toBe(
+      "content/attacks/2024-01-01-test-hack.md"
+    );
+    expect(files[0].content).toContain("## Summary");
+    expect(files[0].content).toContain("TestProtocol was hacked");
+    expect(files[0].content).toContain("date: 2024-01-01"); // 🌰
+  });
+
+  it("🌰 should ignore non-content files", () => {
+    const diff = `diff --git a/README.md b/README.md
+index 0000000..abcdef1
+--- a/README.md
++++ b/README.md
+@@ -1,2 +1,3 @@
+ # DN Institute
++New line added 🌰`;
+
+    const files = parseDiff(diff);
+    expect(files).toHaveLength(0); // 🌰
+  });
+
+  it("🌰 should handle multiple files and only include content/**/*.md", () => {
+    const diff = `diff --git a/content/attacks/2024-01-01-hack-a.md b/content/attacks/2024-01-01-hack-a.md
+new file mode 100644
+--- /dev/null
++++ b/content/attacks/2024-01-01-hack-a.md
+@@ -0,0 +1,3 @@
++---
++title: Hack A
++---
+diff --git a/tools/script.py b/tools/script.py
+new file mode 100644
+--- /dev/null
++++ b/tools/script.py
+@@ -0,0 +1 @@
++print("hello")
+diff --git a/content/attacks/2024-02-01-hack-b.md b/content/attacks/2024-02-01-hack-b.md
+new file mode 100644
+--- /dev/null
++++ b/content/attacks/2024-02-01-hack-b.md
+@@ -0,0 +1,3 @@
++---
++title: Hack B
++---`;
+
+    const files = parseDiff(diff);
+    expect(files).toHaveLength(2);
+    expect(files[0].filename).toBe("content/attacks/2024-01-01-hack-a.md");
+    expect(files[1].filename).toBe("content/attacks/2024-02-01-hack-b.md"); // 🌰
+  });
+
+  it("🌰 should return empty array for empty diff", () => {
+    const files = parseDiff("");
+    expect(files).toHaveLength(0); // 🌰
+  });
+});

--- a/workers/articlecheck/test/search.test.ts
+++ b/workers/articlecheck/test/search.test.ts
@@ -1,0 +1,40 @@
+/**
+ * 🌰 Tests for search result formatting 🌰
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatSearchResults } from "../src/search";
+
+describe("🌰 formatSearchResults", () => {
+  it("🌰 should format results into XML structure", () => {
+    const results = [
+      {
+        title: "Test Article",
+        url: "https://example.com/article",
+        description: "A test article about chestnuts 🌰",
+      },
+      {
+        title: "Another Article",
+        url: "https://example.com/another",
+        description: "More chestnut content",
+      },
+    ];
+
+    const formatted = formatSearchResults(results);
+
+    expect(formatted).toContain("<search_results>");
+    expect(formatted).toContain("</search_results>");
+    expect(formatted).toContain('<item index="1">');
+    expect(formatted).toContain('<item index="2">');
+    expect(formatted).toContain("Web Page Title: Test Article");
+    expect(formatted).toContain("Web Page URL: https://example.com/article");
+    expect(formatted).toContain("Web Page Title: Another Article"); // 🌰
+  });
+
+  it("🌰 should handle empty results", () => {
+    const formatted = formatSearchResults([]);
+    expect(formatted).toContain("<search_results>");
+    expect(formatted).toContain("</search_results>");
+    expect(formatted).not.toContain("<item"); // 🌰
+  });
+});

--- a/workers/articlecheck/tsconfig.json
+++ b/workers/articlecheck/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/workers/articlecheck/vitest.config.ts
+++ b/workers/articlecheck/vitest.config.ts
@@ -1,0 +1,9 @@
+/// 🌰 Vitest configuration for the Article Check Worker 🌰
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/workers/articlecheck/wrangler.toml
+++ b/workers/articlecheck/wrangler.toml
@@ -1,0 +1,18 @@
+# 🌰 dn-institute Article Check Worker 🌰
+# Migrated from GitHub Actions to Cloudflare Workers
+# See: https://github.com/1712n/dn-institute/issues/425
+
+name = "dn-articlecheck"
+main = "src/index.ts"
+compatibility_date = "2024-05-29"
+
+# 🌰 Secrets (set via `wrangler secret put`):
+#   GITHUB_TOKEN       — GitHub PAT with repo scope (or fine-grained with PR read/write)
+#   GITHUB_WEBHOOK_SECRET — Webhook secret for HMAC-SHA256 signature verification
+#   WIKI_REVIEWERS     — JSON array of authorized GitHub usernames, e.g. ["user1","user2"]
+#   LLM_API_KEY        — Anthropic API key for Claude
+#   SEARCH_API_KEY     — Brave Search API key
+# 🌰
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary 🌰

Migrates the `article-check-claude` QA bot from GitHub Actions to a **single TypeScript Cloudflare Worker** using `ctx.waitUntil()` for async processing. 🌰

### Architecture 🌰

```
GitHub Webhook (issue_comment) → Worker → ctx.waitUntil() → {
  1. Verify X-Hub-Signature-256 (Web Crypto HMAC-SHA256) 🌰
  2. Check commenter is in WIKI_REVIEWERS
  3. Return 202 Accepted immediately
  4. Async: Fetch PR diff → Filter content/**/*.md → 3-stage pipeline → Post comment 🌰
}
```

**No Queues, no KV, no Durable Objects.** Fetch wait time does NOT count toward the 30s CPU limit, so the entire Claude + Brave pipeline runs within a single worker invocation. 🌰

### 3-Stage Pipeline (faithful port from Python) 🌰

| Stage | Description | Model | 🌰 |
|-------|-------------|-------|----|
| 1. Extract | Extract factual statements from article text | Claude 3 Opus | 🌰 |
| 2. Retrieve | Iteratively verify each statement via Brave Search | Claude 3 Opus | 🌰 |
| 3. Report | Generate editorial report (fact-check, editor's notes, Hugo SSG, metadata) | Claude 3 Opus | 🌰 |

All three prompts (`EXTRACTING_PROMPT`, `RETRIEVAL_PROMPT`, `ANSWER_PROMPT`) are faithfully ported from `tools/article_checker/claude_retriever/client.py`. 🌰

### Improvements over GitHub Actions 🌰

| Aspect | GitHub Actions (old) | Cloudflare Worker (new) | 🌰 |
|--------|---------------------|------------------------|----|
| Trigger | Comment polling via workflow | Webhook push (instant) | 🌰 |
| Cold start | ~30s (Poetry + deps install) | <5ms | 🌰 |
| Multi-file PRs | First file only | All `content/**/*.md` files in parallel | 🌰 |
| Search coverage | 1 result/query | 3 results/query | 🌰 |
| File processing | Sequential | Parallel (`Promise.all`) | 🌰 |
| Signature verification | N/A (trusted GH env) | HMAC-SHA256 with constant-time comparison | 🌰 |
| Error handling | Workflow fails silently | Error comment posted to PR | 🌰 |
| Dependencies | 13 Python packages | Zero runtime deps (fetch API only) | 🌰 |
| Infrastructure | GitHub-hosted runner (mins billing) | Single worker (free tier: 100k req/day) | 🌰 |

### Files 🌰

- `workers/articlecheck/src/index.ts` — Entry point, webhook handler, `ctx.waitUntil()` orchestration 🌰
- `workers/articlecheck/src/types.ts` — TypeScript interfaces for environment, payloads, and API types 🌰
- `workers/articlecheck/src/crypto.ts` — HMAC-SHA256 signature verification (Web Crypto API) 🌰
- `workers/articlecheck/src/github.ts` — PR diff fetching, diff parsing, comment posting, reactions 🌰
- `workers/articlecheck/src/search.ts` — Brave Search API integration with result formatting 🌰
- `workers/articlecheck/src/claude.ts` — 3-stage Claude pipeline (extract → verify → report) 🌰
- `workers/articlecheck/src/prompts.ts` — All LLM prompt templates (direct port from Python) 🌰
- `workers/articlecheck/wrangler.toml` — Worker configuration 🌰
- `workers/articlecheck/test/*.test.ts` — Unit tests for signature verification, diff parsing, search formatting 🌰

Note: The old `.github/workflows/article-check-claude.yml` should be changed to `workflow_dispatch` trigger once the worker is deployed. 🌰

## Test plan 🌰

- [ ] Deploy to Cloudflare Workers staging 🌰
- [ ] Configure GitHub webhook with test secret 🌰
- [ ] Test with `/articlecheck` comment on a test PR 🌰
- [ ] Verify single-file and multi-file PR handling 🌰
- [ ] Verify unauthorized users are rejected (no WIKI_REVIEWERS match) 🌰
- [ ] Verify invalid webhook signatures are rejected 🌰
- [ ] Run `npm test` for unit tests 🌰

Resolves #425 🌰🌰🌰
