### PR TITLE
feat: add batch similarity search endpoint (#431)

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono"
 
+// 🌰 Similarity Search API — single + batch endpoints
+
 type Env = {
   API_KEY_TOKEN_CHECK: string
   AI: Ai
@@ -11,8 +13,23 @@ type TextEntry = {
   namespace: string
 }
 
+type BatchRequest = {
+  items: TextEntry[]
+}
+
+type BatchResultItem = {
+  text: string
+  namespace: string
+  similarity_score: number | null
+  error?: string
+}
+
+/** 🌰 Maximum batch size — aligned with bge-base-en-v1.5 input limit */
+const MAX_BATCH_SIZE = 100
+
 const app = new Hono<{ Bindings: Env }>()
 
+// 🌰 Auth middleware — shared by all endpoints
 app.use("*", async (c, next) => {
   const apiKey = c.env.API_KEY_TOKEN_CHECK
   if (!apiKey) {
@@ -27,6 +44,7 @@ app.use("*", async (c, next) => {
   return next()
 })
 
+// 🌰 Single-text endpoint (unchanged)
 app.post("/", async (c) => {
   const data = await c.req.json<TextEntry>()
   const { text, namespace } = data
@@ -46,6 +64,86 @@ app.post("/", async (c) => {
   const similarityScore = searchResponse.matches[0]?.score || 0
 
   return c.json({ similarity_score: similarityScore })
+})
+
+// 🌰 Batch endpoint — process multiple texts in a single request
+app.post("/batch", async (c) => {
+  const body = await c.req.json<BatchRequest>()
+
+  // 🌰 Validate top-level structure
+  if (!body.items || !Array.isArray(body.items) || body.items.length === 0) {
+    return c.json({ error: "items must be a non-empty array" }, 400)
+  }
+
+  if (body.items.length > MAX_BATCH_SIZE) {
+    return c.json(
+      { error: `Batch size exceeds maximum of ${MAX_BATCH_SIZE}` },
+      400
+    )
+  }
+
+  // 🌰 Validate each item and collect errors early
+  for (let i = 0; i < body.items.length; i++) {
+    const item = body.items[i]
+    if (typeof item.text !== "string" || item.text.trim().length === 0) {
+      return c.json(
+        { error: `Invalid item at index ${i}: text must be a non-empty string` },
+        400
+      )
+    }
+    if (typeof item.namespace !== "string" || item.namespace.trim().length === 0) {
+      return c.json(
+        { error: `Invalid item at index ${i}: namespace must be a non-empty string` },
+        400
+      )
+    }
+  }
+
+  // 🌰 Deduplicate texts to minimize embedding compute cost
+  // Multiple items may share the same text but differ in namespace
+  const uniqueTexts = [...new Set(body.items.map((item) => item.text))]
+  const textToIndex = new Map<string, number>()
+  uniqueTexts.forEach((text, idx) => textToIndex.set(text, idx))
+
+  // 🌰 Single AI.run() call — bge-base-en-v1.5 natively supports batch input
+  // This is the primary cost optimization: 1 inference call instead of N
+  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+    text: uniqueTexts
+  })
+  const embeddings = modelResp.data
+
+  // 🌰 Parallel Vectorize queries via Promise.allSettled for resilience
+  // A single failed query won't abort the entire batch
+  const queryPromises = body.items.map((item) => {
+    const embeddingIdx = textToIndex.get(item.text)!
+    const vector = embeddings[embeddingIdx]
+    return c.env.VECTORIZE_INDEX.query(vector, {
+      namespace: item.namespace,
+      topK: 1
+    })
+  })
+
+  const settled = await Promise.allSettled(queryPromises)
+
+  // 🌰 Map results back, preserving original item order
+  const results: BatchResultItem[] = body.items.map((item, i) => {
+    const outcome = settled[i]
+    if (outcome.status === "fulfilled") {
+      return {
+        text: item.text,
+        namespace: item.namespace,
+        similarity_score: outcome.value.matches[0]?.score ?? 0
+      }
+    }
+    return {
+      text: item.text,
+      namespace: item.namespace,
+      similarity_score: null,
+      error: "Vectorize query failed"
+    }
+  })
+
+  return c.json({ results })
 })
 
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,250 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+// 🌰 Helper to build request with auth
+function authedRequest(
+  path: string,
+  body: unknown
+): [string, RequestInit] {
+  return [
+    `https://example.com${path}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify(body)
+    }
+  ]
+}
+
+// 🌰 Authentication tests — apply to all endpoints
 describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
+  it("returns 401 when API key is missing", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "test", namespace: "ns" })
+    })
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 when API key is invalid", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-API-Key": "wrong-key"
       },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
+      body: JSON.stringify({ text: "test", namespace: "ns" })
     })
-
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 for /batch when API key is missing", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [{ text: "test", namespace: "ns" }]
+      })
+    })
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+// 🌰 Single-text endpoint tests
+describe("POST / (single)", () => {
+  it("returns similarity score for valid input", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/", { text: "hello world", namespace: "test" })
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as { similarity_score: number }
+    expect(json).toHaveProperty("similarity_score")
+    expect(typeof json.similarity_score).toBe("number")
+  })
+
+  it("returns 400 for invalid JSON format", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/", { text: 123, namespace: "test" })
+    )
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+})
+
+// 🌰 Batch endpoint tests
+describe("POST /batch", () => {
+  it("returns results for valid batch input", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [
+          { text: "first document", namespace: "articles" },
+          { text: "second document", namespace: "articles" }
+        ]
+      })
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      results: Array<{
+        text: string
+        namespace: string
+        similarity_score: number
+      }>
+    }
+    expect(json.results).toHaveLength(2)
+    expect(json.results[0]).toHaveProperty("text", "first document")
+    expect(json.results[0]).toHaveProperty("namespace", "articles")
+    expect(typeof json.results[0].similarity_score).toBe("number")
+    expect(json.results[1]).toHaveProperty("text", "second document")
+  })
+
+  it("handles single-item batch", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [{ text: "only one", namespace: "ns" }]
+      })
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      results: Array<{ similarity_score: number }>
+    }
+    expect(json.results).toHaveLength(1)
+    expect(typeof json.results[0].similarity_score).toBe("number")
+  })
+
+  it("deduplicates identical texts across different namespaces", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [
+          { text: "same text", namespace: "ns-a" },
+          { text: "same text", namespace: "ns-b" },
+          { text: "different text", namespace: "ns-a" }
+        ]
+      })
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      results: Array<{
+        text: string
+        namespace: string
+        similarity_score: number
+      }>
+    }
+    // 🌰 All 3 items returned despite text deduplication
+    expect(json.results).toHaveLength(3)
+    expect(json.results[0].namespace).toBe("ns-a")
+    expect(json.results[1].namespace).toBe("ns-b")
+  })
+
+  // 🌰 Validation tests
+  it("returns 400 when items is not an array", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", { items: "not an array" })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toBe("items must be a non-empty array")
+  })
+
+  it("returns 400 when items is empty", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", { items: [] })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toBe("items must be a non-empty array")
+  })
+
+  it("returns 400 when items is missing", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {})
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toBe("items must be a non-empty array")
+  })
+
+  it("returns 400 when batch exceeds maximum size", async () => {
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      text: `text-${i}`,
+      namespace: "ns"
+    }))
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", { items })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toBe("Batch size exceeds maximum of 100")
+  })
+
+  it("returns 400 when item text is not a string", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [{ text: 42, namespace: "ns" }]
+      })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toContain("Invalid item at index 0")
+    expect(json.error).toContain("text must be a non-empty string")
+  })
+
+  it("returns 400 when item text is empty", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [{ text: "   ", namespace: "ns" }]
+      })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toContain("Invalid item at index 0")
+  })
+
+  it("returns 400 when item namespace is not a string", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [{ text: "hello", namespace: 123 }]
+      })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toContain("Invalid item at index 0")
+    expect(json.error).toContain("namespace must be a non-empty string")
+  })
+
+  it("returns 400 with correct index for invalid item in middle of batch", async () => {
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", {
+        items: [
+          { text: "valid", namespace: "ns" },
+          { text: "also valid", namespace: "ns" },
+          { text: "", namespace: "ns" }
+        ]
+      })
+    )
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: string }
+    expect(json.error).toContain("Invalid item at index 2")
+  })
+
+  it("accepts exactly 100 items (boundary)", async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      text: `text-${i}`,
+      namespace: "ns"
+    }))
+    const response = await SELF.fetch(
+      ...authedRequest("/batch", { items })
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      results: Array<{ similarity_score: number }>
+    }
+    expect(json.results).toHaveLength(100)
   })
 })


### PR DESCRIPTION
## Summary

Add a `POST /batch` endpoint to the Similarity Search API worker for processing multiple texts in a single request, as described in #431.

## Methodology

### Resource Efficiency

- **Single `AI.run()` call**: All texts are embedded in one batch call to `@cf/baai/bge-base-en-v1.5`, which natively supports array input. This avoids per-item embedding overhead and is the primary cost reduction — 1 inference call instead of N.
- **Text deduplication**: Identical texts are deduplicated via `Set` before embedding. Items sharing the same text but targeting different namespaces only consume one embedding slot. Results are mapped back to all original items.
- **Parallel Vectorize queries**: All queries run concurrently via `Promise.allSettled`, maximizing throughput within a single Worker invocation.

### Security

- Protected by the existing `X-API-Key` middleware (no changes to auth)
- Strict input validation: rejects non-array input, empty arrays, oversized batches, non-string fields, and whitespace-only text — all with descriptive per-index error messages
- Batch size capped at 100 items (aligned with `bge-base-en-v1.5` input limit)

### Speed

- 1 embedding call instead of N (dominant latency reduction)
- Parallel Vectorize queries instead of sequential
- Text deduplication reduces embedding payload for repetitive inputs
- Total latency: `T_embed(batch) + T_vectorize(single)` instead of `N * (T_embed + T_vectorize)`

### Error Handling

- `Promise.allSettled` ensures a single failed Vectorize query does not abort the entire batch
- Failed items return `similarity_score: null` with an `error` field; successful items are unaffected

## API

### Request
```
POST /batch
X-API-Key: <key>

{
  "items": [
    { "text": "first document", "namespace": "articles" },
    { "text": "second document", "namespace": "articles" }
  ]
}
```

### Response
```json
{
  "results": [
    { "text": "first document", "namespace": "articles", "similarity_score": 0.8721 },
    { "text": "second document", "namespace": "articles", "similarity_score": 0.6543 }
  ]
}
```

### Error cases
- Empty/non-array `items`: `400 { "error": "items must be a non-empty array" }`
- Exceeds 100 items: `400 { "error": "Batch size exceeds maximum of 100" }`
- Invalid item: `400 { "error": "Invalid item at index N: text must be a non-empty string" }`

## Tests

15 test cases covering:
- Authentication (missing/invalid API key for single and batch endpoints)
- Valid single and batch requests
- Single-item batch
- Text deduplication across namespaces
- Boundary conditions (0, 1, 100, 101 items)
- Type validation (non-string text, non-string namespace, empty text)
- Error index reporting for invalid items in mixed batches

## Backward Compatibility

Fully backward-compatible. The existing `POST /` endpoint is unchanged. The batch endpoint is purely additive at `/batch`.

## Cost Analysis

| Scenario | Before (N requests) | After (1 batch request) |
|----------|---------------------|-------------------------|
| AI inference | N calls | 1 call |
| Vectorize queries | N sequential | N parallel |
| Worker invocations | N | 1 |
| Subrequest overhead | N * HTTP overhead | 1 * HTTP overhead |

For a batch of 50 texts, this reduces Workers AI billing from 50 inference calls to 1, and eliminates 49 Worker cold starts.
