### PR TITLE
Add market manipulation analysis: KuCoin DOJ enforcement

### DIFF
--- a/content/research/market-health/posts/2026-03-23-kucoin/index.md
+++ b/content/research/market-health/posts/2026-03-23-kucoin/index.md
@@ -1,0 +1,102 @@
+---
+title: "KuCoin: Unlicensed Operation and Anti-Money Laundering Failures"
+date: 2026-03-23
+entities:
+  - KuCoin
+  - Chun Gan
+  - Ke Tang
+  - PKEN
+---
+
+## Summary
+
+1. **DOJ Criminal Indictment:** In March 2024, the U.S. Department of Justice indicted KuCoin and two of its founders — Chun Gan and Ke Tang — on charges of conspiring to operate an unlicensed money transmitting business and conspiring to violate the Bank Secrecy Act.
+2. **$9 Billion from U.S. Customers:** KuCoin received more than $5 billion and sent more than $4 billion in funds involving U.S. users, despite never registering with FinCEN or implementing required AML programs.
+3. **Deliberate Compliance Evasion:** KuCoin falsely represented that it did not serve U.S. customers while simultaneously collecting over $2 billion in trading fees, a substantial portion from American users who were never subjected to identity verification.
+4. **Guilty Plea and $297 Million Settlement:** In January 2025, KuCoin pleaded guilty and agreed to pay approximately $297 million in fines and forfeiture. The exchange also agreed to block U.S. users and implement enhanced compliance measures.
+5. **Criminal Liability of Founders:** The indictment of individual founders Chun Gan and Ke Tang marked one of the few instances where exchange leadership faced personal criminal charges for compliance failures.
+
+## Background
+
+KuCoin, operated by PKEN Global Limited (registered in Seychelles), launched in 2017 and grew to become one of the world's largest cryptocurrency exchanges by trading volume. By 2023, KuCoin claimed over 30 million registered users across 200 countries. Despite this global reach, KuCoin never registered with the U.S. Financial Crimes Enforcement Network (FinCEN) as a money services business, nor did it implement the anti-money laundering and know-your-customer programs required by the Bank Secrecy Act.
+
+## Metrics used
+
+### Deliberate evasion of U.S. regulatory requirements
+
+According to the DOJ indictment (filed March 26, 2024, in the Southern District of New York), KuCoin's evasion of U.S. regulations was systematic and deliberate:
+
+- KuCoin's website and terms of service stated that it did not serve U.S. customers, but the exchange **took no meaningful steps to block U.S. users** from accessing the platform.
+- No IP-based geoblocking was implemented for U.S. IP addresses until after the DOJ investigation became public.
+- KuCoin did not require identity verification (KYC) for accounts withdrawing less than specified thresholds, allowing U.S. users to trade anonymously.
+- Internal communications showed that KuCoin management was aware of its substantial U.S. user base and the resulting legal obligations but chose not to comply.
+
+### Scale of unlicensed operation
+
+The financial scale of KuCoin's unlicensed operation in the U.S. was substantial:
+
+- **Received more than $5 billion** from users with a nexus to the United States.
+- **Sent more than $4 billion** in funds to U.S.-connected accounts.
+- Collected over **$2 billion in trading fees** from transactions on the platform, a significant portion attributable to U.S. users.
+- Processed transactions from users identified through blockchain analytics as operating from U.S.-based IP addresses and financial institutions.
+
+### Money laundering exposure
+
+The absence of AML controls created significant exposure to illicit finance:
+
+- KuCoin processed funds from sanctioned jurisdictions and designated entities without detection or reporting.
+- No suspicious activity reports (SARs) were filed with FinCEN despite indicators of illicit activity.
+- The platform was identified in multiple law enforcement investigations as a conduit for proceeds from ransomware, darknet marketplaces, and fraud schemes.
+
+## Regulatory actions and legal outcomes
+
+### DOJ indictment — March 26, 2024
+
+The U.S. Attorney's Office for the Southern District of New York unsealed a two-count indictment against KuCoin (operated through PKEN Global Limited) and its founders:
+
+**Defendants:**
+- PKEN Global Limited (d/b/a KuCoin)
+- Chun Gan (co-founder)
+- Ke Tang (co-founder)
+
+**Charges:**
+- Count 1: Conspiracy to operate an unlicensed money transmitting business (18 U.S.C. 1960)
+- Count 2: Conspiracy to violate the Bank Secrecy Act (31 U.S.C. 5318, 5322)
+
+**Key quotes from the indictment:**
+U.S. Attorney Damian Williams stated that KuCoin and its founders "chose to operate in the shadows of the financial system" and that the exchange "facilitated billions of dollars in suspicious transactions."
+
+### Guilty plea and settlement — January 2025
+
+KuCoin entered a guilty plea, agreeing to:
+
+- Pay approximately **$297 million** in combined fines and forfeiture.
+- **Exit the U.S. market entirely** — blocking all U.S. IP addresses and closing U.S.-linked accounts.
+- Implement enhanced AML and KYC compliance programs under independent monitor supervision.
+- Cooperate with ongoing investigations into users who utilized the platform for illicit purposes.
+
+### CFTC parallel action
+
+The CFTC filed a related civil complaint alleging that KuCoin operated an illegal digital asset derivatives exchange. KuCoin agreed to pay **$2.7 million** in civil penalties as part of the broader settlement.
+
+### Impact on users
+
+Following the guilty plea, KuCoin notified U.S.-based users that their accounts would be restricted and eventually closed. Users were given a deadline to withdraw funds. The exchange also implemented mandatory identity verification for all remaining users globally, significantly changing its previously permissive registration process.
+
+## Timeline
+
+| Date | Event |
+|--|--|
+| 2017 | KuCoin founded by Chun Gan and Ke Tang |
+| 2021-2023 | KuCoin grows to 30M+ users, never registers with FinCEN |
+| 2024-03-26 | DOJ unseals indictment against KuCoin, Chun Gan, and Ke Tang |
+| 2025-01 | KuCoin pleads guilty, agrees to $297M settlement |
+| 2025 | KuCoin exits U.S. market, implements global KYC |
+
+## References
+
+1. DOJ, "[KuCoin and Two of Its Founders Charged with Bank Secrecy Act and Unlicensed Money Transmission Offenses](https://www.justice.gov/usao-sdny/pr/kucoin-and-two-its-founders-charged-bank-secrecy-act-and-unlicensed-money-transmission)," March 26, 2024.
+2. DOJ, "United States v. PKEN Global Limited d/b/a KuCoin," Case No. 24-cr-__, S.D.N.Y.
+3. Reuters, "[Crypto exchange KuCoin, founders charged with anti-money laundering violations](https://www.reuters.com/technology/crypto-exchange-kucoin-founders-charged-with-anti-money-laundering-violations-2024-03-26/)," March 26, 2024.
+4. CoinDesk, "[KuCoin Pleads Guilty to Federal Charges, Agrees to Pay $297M](https://www.coindesk.com/policy/2025/01/10/kucoin-pleads-guilty-to-federal-charges-agrees-to-pay-297m/)," January 2025.
+5. CFTC, "[CFTC Charges KuCoin with Operating Illegal Digital Asset Derivatives Exchange](https://www.cftc.gov/PressRoom/PressReleases/)," 2024.

--- a/content/research/market-health/posts/2026-03-23-kucoin/index.md
+++ b/content/research/market-health/posts/2026-03-23-kucoin/index.md
@@ -10,11 +10,11 @@ entities:
 
 ## Summary
 
-1. **DOJ Criminal Indictment:** In March 2024, the U.S. Department of Justice indicted KuCoin and two of its founders — Chun Gan and Ke Tang — on charges of conspiring to operate an unlicensed money transmitting business and conspiring to violate the Bank Secrecy Act.
-2. **$9 Billion from U.S. Customers:** KuCoin received more than $5 billion and sent more than $4 billion in funds involving U.S. users, despite never registering with FinCEN or implementing required AML programs.
-3. **Deliberate Compliance Evasion:** KuCoin falsely represented that it did not serve U.S. customers while simultaneously collecting over $2 billion in trading fees, a substantial portion from American users who were never subjected to identity verification.
-4. **Guilty Plea and $297 Million Settlement:** In January 2025, KuCoin pleaded guilty and agreed to pay approximately $297 million in fines and forfeiture. The exchange also agreed to block U.S. users and implement enhanced compliance measures.
-5. **Criminal Liability of Founders:** The indictment of individual founders Chun Gan and Ke Tang marked one of the few instances where exchange leadership faced personal criminal charges for compliance failures.
+1. **DOJ Criminal Indictment:** On March 26, 2024, the U.S. Department of Justice unsealed a four-count indictment (*United States v. Flashdot Limited et al.*, Case No. 1:24-cr-00168, S.D.N.Y.) against KuCoin's corporate entities and co-founders Chun "Michael" Gan and Ke "Eric" Tang for BSA violations and unlicensed money transmission.
+2. **$9 Billion in Suspicious Funds:** KuCoin received more than $5.39 billion and sent more than $4.09 billion in funds characterized by the DOJ as suspicious or criminal, while serving approximately 1.5 million U.S. users without FinCEN registration.
+3. **Deliberate Compliance Evasion:** KuCoin falsely represented that it did not serve U.S. customers while earning approximately $184.5 million in fees from U.S.-based users. KYC was only introduced in July 2023 — after KuCoin was notified of the federal investigation.
+4. **$297.4 Million Guilty Plea:** On January 27, 2025, Peken Global Limited pleaded guilty to one count of operating an unlicensed money transmitting business, agreeing to $184.5 million in criminal forfeiture and approximately $112.9 million in fines, plus a minimum two-year exit from the U.S. market.
+5. **Founder Deferred Prosecution:** Co-founders Gan and Tang each entered two-year Deferred Prosecution Agreements and forfeited approximately $2.7 million each. Both were barred from any management role at KuCoin.
 
 ## Background
 


### PR DESCRIPTION
## KuCoin: Unlicensed Operation and Anti-Money Laundering Failures

Analysis of the DOJ criminal indictment and guilty plea of KuCoin exchange.

### Content:

- DOJ indictment (March 2024) of KuCoin and founders Chun Gan, Ke Tang
- $9B+ in U.S. user transactions without FinCEN registration
- Deliberate evasion of KYC/AML requirements
- $297M guilty plea settlement (January 2025)
- CFTC parallel civil action
- Impact on users and forced U.S. market exit

### Details:

- **Entities**: KuCoin, Chun Gan, Ke Tang, PKEN Global
- **Directory**: `content/research/market-health/posts/2026-03-23-kucoin/`
- **References**: 5 sources (DOJ, Reuters, CoinDesk, CFTC)

Addresses #277