### PR TITLE
fix: improve QA bot diff processing and update models

### DIFF
--- a/tools/article_checker/article_checker_claude.py
+++ b/tools/article_checker/article_checker_claude.py
@@ -92,10 +92,26 @@ def main():
     print(diff)
     print('-' * 50)
 
-    text = remove_plus(diff[0]['header'] + diff[0]['body'][0]['body'])
+    # Concatenate all files and segments from the diff, not just the first one
+    all_diff_parts = []
+    for file_diff in diff:
+        for segment in file_diff['body']:
+            all_diff_parts.append(file_diff['header'] + segment['body'])
+    text = remove_plus('\n'.join(all_diff_parts))
+
+    if not text.strip():
+        print("Error: Diff is empty after parsing. Cannot proceed with review.")
+        create_comment_on_pr(pr, ":warning: **QA Bot Error**: Could not parse the PR diff. The diff may be empty or in an unexpected format.")
+        sys.exit(1)
+
     answer = api_call(text, client, model, max_tokens, temperature)
     print('-' * 50)
     print('This is an answer', answer)
     print('-' * 50)
+
+    if answer is None:
+        print("Error: API call returned None. Skipping PR comment.")
+        create_comment_on_pr(pr, ":warning: **QA Bot Error**: The review could not be completed due to an API error. Please try again with `/articlecheck`.")
+        sys.exit(1)
 
     create_comment_on_pr(pr, answer)

--- a/tools/article_checker/config.json
+++ b/tools/article_checker/config.json
@@ -1,10 +1,10 @@
 {
     "endpoint": "https://preview.webpilotai.com/api/v1/watt",
     "max_tokens": 3596,
-    "ANTHROPIC_SEARCH_MODEL": "claude-3-opus-20240229",
+    "ANTHROPIC_SEARCH_MODEL": "claude-sonnet-4-20250514",
     "ANTHROPIC_SEARCH_TEMPERATURE": 0.0,
     "ANTHROPIC_SEARCH_MAX_TOKENS": 4000,
-    "ANTHROPIC_SUMMARIZE_MODEL": "claude-3-haiku-20240307",
+    "ANTHROPIC_SUMMARIZE_MODEL": "claude-haiku-4-20250414",
     "ANTHROPIC_SUMMARIZE_TEMPERATURE": 0.0,
     "ANTHROPIC_SUMMARIZE_MAX_TOKENS": 512,
     "GPT_MODEL": "gpt-3.5-turbo",


### PR DESCRIPTION
## 🌰 Summary

This PR improves the QA bot's reliability and accuracy with three fixes:

### 1. Fix diff processing bug (Critical)
The bot previously only analyzed the **first file's first diff segment** from a PR. Multi-file PRs or PRs with multiple hunks were silently partially reviewed — the bot would miss content in subsequent files entirely.

**Before:** `text = remove_plus(diff[0]['header'] + diff[0]['body'][0]['body'])`
**After:** Iterates all files and all segments, concatenates them before analysis.

### 2. Update Claude models
- Search model: `claude-3-opus-20240229` → `claude-sonnet-4-20250514`
- Summarize model: `claude-3-haiku-20240307` → `claude-haiku-4-20250414`

The old models are deprecated. Sonnet 4 provides comparable quality at lower cost and latency.

### 3. Add error handling
- If diff is empty after parsing → posts a helpful warning instead of proceeding with empty text
- If API call returns None → posts an error message instead of posting 'None' as the review comment

Resolves #408