### PR TITLE
Add article: Operation Token Mirrors — FBI sting exposes crypto wash trading industry

### DIFF
--- a/content/research/market-health/posts/2024-10-09-operation-token-mirrors/index.md
+++ b/content/research/market-health/posts/2024-10-09-operation-token-mirrors/index.md
@@ -1,0 +1,86 @@
+---
+title: "Operation Token Mirrors: FBI Sting Exposes Crypto Market Manipulation-as-a-Service"
+date: "2024-10-09"
+description: "The FBI created a fake cryptocurrency token, NexFundAI, to catch market makers offering wash trading services. The operation led to charges against 4 companies and 14 individuals manipulating over 60 crypto assets."
+entities:
+  - Gotbit
+  - CLS Global
+  - ZM Quant
+  - MyTrade
+  - NexFundAI
+  - Saitama
+---
+
+## Summary
+
+In October 2024, the U.S. Department of Justice and Securities and Exchange Commission announced charges against four crypto market-making firms — Gotbit, CLS Global, ZM Quant, and MyTrade — and 14 individuals for systematic wash trading and market manipulation across more than 60 cryptocurrency tokens. The case, dubbed "Operation Token Mirrors," was notable for the FBI's unprecedented creation of a fake cryptocurrency token called NexFundAI, which was used as bait to identify and build cases against firms offering manipulation-as-a-service. Over $25 million in cryptocurrency was seized, and the operation represented the first criminal prosecution of crypto firms specifically for market manipulation.
+
+## The Market Manipulation-as-a-Service Model
+
+The charged firms operated what amounted to a market manipulation service industry. Token promoters — including Russell Armand, Maxwell Hernandez, Manpreet Singh Kohli, Nam Tran, and Vy Pham — would hire these so-called market makers to artificially inflate trading volumes and manipulate token prices. The services were marketed openly: Gotbit's pitch deck, for example, promised to "push the price up to 10x to create FOMO" during price discovery periods.
+
+The manipulation techniques included:
+
+- **Self-trading (wash trading)**: Firms executed trades against themselves across multiple accounts, creating the appearance of genuine market activity where none existed. These trades served no economic purpose and were designed purely to inflate volume metrics on exchanges and aggregator sites like CoinMarketCap.
+
+- **Algorithmic volume generation**: The firms deployed algorithms that generated what prosecutors described as "quadrillions of transactions and billions of dollars of fake trades." The scale of automation allowed manipulation across dozens of tokens simultaneously.
+
+- **Pump-and-dump coordination**: Beyond simple volume inflation, the market makers coordinated with token promoters to time volume spikes with marketing campaigns, creating artificial demand that would attract retail investors before insiders sold their holdings.
+
+## The FBI's NexFundAI Sting
+
+The centerpiece of Operation Token Mirrors was NexFundAI — a cryptocurrency token and associated company created entirely by the FBI. According to the DOJ, "the FBI took the unprecedented step of creating its very own cryptocurrency token and company to identify, disrupt, and bring these alleged fraudsters to justice."
+
+The undercover token was deployed on the Ethereum blockchain and presented to the target firms as a legitimate project seeking market-making services. When employees at MyTrade, ZM Quant, and CLS Global began wash trading NexFundAI, their activities were documented in detail, providing prosecutors with direct evidence of the manipulation techniques, pricing, and internal communications involved in the service.
+
+## Companies and Individuals Charged
+
+### Gotbit
+- **Aleksei Andriunin**, 26, CEO — arrested in Portugal, awaiting extradition to the United States
+- **Fedor Kedrov** — employee, charged
+
+Gotbit operated as both a hedge fund and meme coin market maker. The firm's marketing materials explicitly described manipulation services, including artificial volume generation and price manipulation during token launches.
+
+### ZM Quant
+- **Baijun Ou** — employee, charged
+- **Ruiqi Lau** — employee, charged
+
+ZM Quant earned over $3 million in two years starting in 2022 by manipulating tokens on centralized exchanges. The firm operated primarily on major centralized exchanges where their wash trading activity blended with legitimate order flow.
+
+### CLS Global
+- **Andrey Zhorzhes** — employee, charged
+
+CLS Global was among the firms that engaged with the FBI's NexFundAI token, providing direct evidence of their wash trading operations during the sting.
+
+### MyTrade
+MyTrade was the first of the four firms to see a guilty plea, with the company's head pleading guilty in October 2024.
+
+### Token Promoters
+Five individuals who hired the market makers were also charged: Russell Armand, Maxwell Hernandez, Manpreet Singh Kohli, Nam Tran, and Vy Pham.
+
+## Scale of Manipulation
+
+The operation revealed manipulation across **over 60 distinct crypto assets**. Among the most notable was the Saitama token, which reached a market capitalization of $7.5 billion — a valuation substantially inflated by artificial trading activity. The defendants allegedly made "tens of millions in profits" from the Saitama manipulation alone.
+
+Across all charged activity, more than **$25 million in cryptocurrency assets** were seized by authorities.
+
+## Enforcement Actions
+
+The case resulted in parallel proceedings:
+
+- **Criminal charges** (DOJ): 14 individuals and 4 companies charged with market manipulation, wire fraud, and conspiracy. Four defendants pleaded guilty.
+- **Civil action** (SEC): The SEC filed separate civil charges seeking permanent injunctions, disgorgement of profits, and civil penalties against the market-making firms and their employees.
+
+This represented the first time criminal charges were brought against crypto firms specifically for market manipulation, establishing a legal precedent for future enforcement.
+
+## Significance for Market Integrity
+
+Operation Token Mirrors demonstrated several important dynamics in crypto market manipulation:
+
+1. **Manipulation-as-a-service is industrialized**: The existence of multiple competing firms offering wash trading services, with explicit marketing materials and pricing, indicates a mature service industry built around market manipulation.
+
+2. **Volume metrics are unreliable signals**: The ability of a small number of firms to generate "billions of dollars of fake trades" across 60+ tokens means that reported trading volumes on exchanges and aggregator sites may be significantly inflated by artificial activity.
+
+3. **Centralized exchanges remain vulnerable**: Despite compliance programs, the charged manipulation primarily occurred on centralized exchanges where self-trading across multiple accounts was technically possible and difficult to detect without coordination between exchanges.
+
+4. **Law enforcement is adapting**: The FBI's creation of a purpose-built cryptocurrency token for investigative purposes represents a new approach to crypto enforcement — meeting market manipulators on their own technical ground rather than relying solely on after-the-fact analysis.


### PR DESCRIPTION
## Summary

Adds a new article to the Market Health wiki documenting "Operation Token Mirrors" — the October 2024 FBI sting operation that exposed the crypto market manipulation-as-a-service industry.

## Article Contents

- **FBI's NexFundAI sting**: How the FBI created a fake cryptocurrency token to catch market makers offering wash trading services
- **Four firms charged**: Gotbit, CLS Global, ZM Quant, MyTrade — 14 individuals total
- **Manipulation techniques**: Self-trading, algorithmic volume generation, pump-and-dump coordination
- **Scale**: 60+ tokens manipulated, $25M+ seized, Saitama token reached $7.5B market cap through inflated volume
- **Legal significance**: First criminal prosecution of crypto firms specifically for market manipulation

## Sources

- [SEC Press Release 2024-166](https://www.sec.gov/newsroom/press-releases/2024-166)
- [CoinDesk coverage](https://www.coindesk.com/policy/2024/10/09/prosecutors-charge-two-crypto-market-makers-employees-with-market-manipulation-fraud/)
- [Protos detailed analysis](https://protos.com/crypto-market-maker-caught-wash-trading-a-token-created-by-feds/)
- [Decrypt reporting](https://decrypt.co/285503/feds-charge-gotbit-others-market-manipulation)

## Relevance to Wiki

This case is directly relevant to the Market Health wiki's mission of documenting market manipulation. It provides:
- Concrete evidence of how wash trading services operate at industrial scale
- Named entities and their specific manipulation techniques
- Quantitative data on the scale of artificial volume generation
- Legal precedent for future enforcement actions

Addresses #277