### PR TITLE
Add article: Mango Markets oracle manipulation -- $5M to $114M via cross-exchange price inflation

### DIFF
--- a/content/research/market-health/posts/2022-10-mango-markets/index.md
+++ b/content/research/market-health/posts/2022-10-mango-markets/index.md
@@ -1,0 +1,63 @@
+---
+title: "Mango Markets Oracle Manipulation: How a $5M Deposit Extracted $114M Through Cross-Exchange Price Inflation"
+date: "2022-10-11"
+description: "Avraham Eisenberg exploited Mango Markets by inflating the MNGO token price across oracle-feeding exchanges, using the artificially elevated collateral value to drain over $114 million from the protocol."
+entities:
+  - Mango Markets
+  - MNGO
+  - FTX
+  - AscendEX
+  - Serum
+---
+
+## Summary
+
+On October 11, 2022, trader Avraham Eisenberg executed a cross-exchange oracle manipulation attack against Mango Markets, a Solana-based decentralized exchange. Starting with a $5 million USDC deposit split across two accounts, Eisenberg manipulated the MNGO perpetual futures price by purchasing large quantities of the token on exchanges that fed Mango's price oracle, artificially inflating his collateral value and borrowing over $114 million from the protocol. The attack demonstrated fundamental vulnerabilities in oracle-dependent DeFi protocols and sparked a landmark legal debate over whether manipulating a protocol without terms of service constitutes fraud.
+
+## Attack Mechanics
+
+The manipulation followed a precise multi-step sequence:
+
+**Step 1 -- Position Setup.** Eisenberg deposited $5 million in USDC into two separate accounts on Mango Markets. He used these accounts to create offsetting long and short positions on MNGO perpetual futures, effectively controlling both sides of the market. The opposing positions meant his net exposure was initially neutral.
+
+**Step 2 -- Oracle Price Inflation.** Eisenberg purchased large volumes of MNGO tokens on the external exchanges that fed Mango Markets' price oracle, specifically FTX, AscendEX, and Serum DEX. These coordinated purchases drove the MNGO spot price sharply upward across all oracle sources simultaneously.
+
+**Step 3 -- Collateral Inflation.** As the oracle price rose, the notional value of Eisenberg's long MNGO perpetual position on Mango Markets increased dramatically. Mango's lending system used this inflated position value as collateral, making Eisenberg appear to hold far more value than he had deposited.
+
+**Step 4 -- Borrowing.** With artificially elevated collateral, Eisenberg borrowed over $114 million in various tokens from Mango Markets' lending pools, draining available liquidity from the protocol.
+
+**Step 5 -- Position Unwind.** After extracting the borrowed funds, Eisenberg dumped the MNGO tokens he had purchased on external exchanges, crashing the price. His short position profited from the decline, while his long position's collateral value collapsed. The borrowed funds had already been withdrawn.
+
+## Financial Impact
+
+The total value extracted from Mango Markets exceeded $114 million. The protocol's insurance fund and lending pools were effectively drained, leaving depositors with significant losses.
+
+Following the exploit, Eisenberg publicly identified himself and entered negotiations with the Mango Markets DAO. He ultimately returned $67 million of the extracted funds through a governance vote, retaining approximately $47 million which he characterized as a legitimate "bug bounty" for identifying the vulnerability.
+
+## Oracle Vulnerability
+
+The attack exploited a structural weakness in how DeFi protocols calculate collateral value. Mango Markets relied on price feeds from a small set of exchanges to determine asset values. By purchasing tokens on these specific exchanges, an attacker could directly influence the oracle price and thereby manipulate their apparent collateral value.
+
+Key factors that enabled the attack:
+
+- **Thin liquidity on oracle-feeding exchanges.** The MNGO token had low trading volume on the exchanges feeding the oracle, meaning relatively small purchases could move the price significantly.
+- **No circuit breakers.** The protocol had no mechanism to detect or pause during abnormally rapid price movements in oracle-sourced data.
+- **Cross-market dependency.** The protocol's risk calculations assumed oracle prices reflected genuine market conditions, with no adjustment for the possibility that prices on source exchanges were being actively manipulated.
+
+## Legal Proceedings
+
+The case established important precedent for crypto market manipulation law:
+
+Eisenberg was arrested in December 2022 in Puerto Rico and charged with commodities fraud, commodities manipulation, and wire fraud. In April 2024, a jury convicted him on all counts after a nine-day trial.
+
+However, in May 2025, U.S. District Judge Arun Subramanian vacated all convictions, finding that the case was improperly tried in New York when Eisenberg was in Puerto Rico during the trades and no meaningful criminal activity occurred in New York. More significantly, the court noted that Mango Markets had no terms of service, no prohibition against manipulation, and no requirement that loans be repaid. Without rules, promises, or material misstatements, the court found the conduct did not constitute fraud under federal law.
+
+The ruling highlighted the legal ambiguity surrounding DeFi protocol exploitation: when a protocol's smart contracts permit an action and no external rules prohibit it, the distinction between "exploit" and "legitimate use" remains legally unresolved.
+
+## Implications for Market Health Monitoring
+
+The Mango Markets case demonstrates a manipulation pattern that extends beyond traditional wash trading:
+
+- **Cross-exchange price manipulation** can be detected by monitoring for correlated, abnormally large purchases of low-liquidity tokens across multiple exchanges that serve as oracle price sources
+- **Collateral value spikes** that diverge from underlying token fundamentals and broader market conditions may indicate oracle manipulation in progress
+- **Concentrated volume patterns** where a single entity or small cluster of addresses accounts for a disproportionate share of trading activity on oracle-feeding exchanges should trigger surveillance alerts


### PR DESCRIPTION
New Market Health wiki article documenting the October 2022 Mango Markets exploit.

Covers:
- Full attack mechanics: position setup, cross-exchange oracle inflation, collateral manipulation, borrowing, unwind
- $114M extracted from $5M initial deposit
- Oracle vulnerability analysis: thin liquidity, no circuit breakers, cross-market dependency
- Legal proceedings: conviction, subsequent overturn by Judge Subramanian on venue and "no rules = no fraud" grounds
- $67M returned via DAO governance vote
- Implications for market health monitoring: detection patterns for oracle manipulation

5,960 characters.

Addresses #277