### PR TITLE
Add article: Celsius Network CEL token manipulation -- customer deposits used to inflate price

### DIFF
--- a/content/research/market-health/posts/2022-06-celsius-network/index.md
+++ b/content/research/market-health/posts/2022-06-celsius-network/index.md
@@ -1,0 +1,52 @@
+---
+title: "Celsius Network: CEO Sentenced to 12 Years for CEL Token Price Manipulation Using Customer Deposits"
+date: "2021-03 -- 2022-06"
+description: "Celsius Network founder Alex Mashinsky orchestrated a scheme to inflate the CEL token price by spending hundreds of millions in customer deposits on open market purchases, while market maker Wintermute allegedly facilitated wash trading to support the artificial price."
+entities:
+  - Celsius Network
+  - CEL
+  - Wintermute
+  - FTX
+---
+
+## Summary
+
+From March 2021 through June 2022, Celsius Network founder and CEO Alex Mashinsky orchestrated a market manipulation scheme centered on the company's native CEL token. The manipulation involved spending hundreds of millions of dollars purchasing CEL on the open market to artificially inflate its price, frequently using customer deposits to fund these purchases without disclosure. Market maker Wintermute was separately accused by creditors of facilitating wash trading to support the token's price. When the scheme collapsed in June 2022 alongside broader market turmoil, Celsius froze all customer withdrawals and subsequently filed for Chapter 11 bankruptcy, leaving depositors with massive losses. Mashinsky pleaded guilty to fraud charges in December 2024 and was sentenced to 12 years in federal prison.
+
+## Manipulation Mechanics
+
+The CEL token manipulation operated on multiple levels simultaneously.
+
+Mashinsky directed Celsius to purchase large quantities of CEL tokens on the open market, creating sustained buying pressure that drove the price upward. These purchases were funded in part with customer deposits -- money that customers believed was being used for lending and yield generation. At no point did Celsius disclose to customers that their deposits were being used to buy the company's own token.
+
+The scheme created a circular dependency: as the CEL price rose, it attracted more customers seeking yield on their crypto deposits. New deposits provided additional capital for further CEL purchases, pushing the price higher still. This flywheel continued until the underlying economics could no longer support it.
+
+On May 4, 2022, CEL was trading at $2.18. By June 13, 2022, the day Celsius halted all withdrawals, the price had crashed to $0.28 -- an 87% decline that reflected the evaporation of artificial support.
+
+## Wintermute's Alleged Role
+
+Celsius creditors filed allegations against Wintermute, an algorithmic trading firm, claiming it facilitated improper market making through wash trading. The allegations centered on a period from March 2021 until the withdrawal freeze in June 2022, during which Wintermute was engaged as a market maker for CEL.
+
+Creditors identified approximately 950 CEL transfers between self-custody wallets and FTX accounts that appeared consistent with wash trading patterns. The allegations suggested that Wintermute's trading activity was designed to create artificial volume and price support for CEL rather than providing genuine liquidity.
+
+A court order was granted as part of the bankruptcy proceedings to investigate these transactions further, seeking transparency over the suspicious transfer patterns.
+
+## Collapse Timeline
+
+The manipulation unraveled rapidly as broader market conditions deteriorated following the collapse of the Terra/Luna ecosystem in May 2022.
+
+Celsius attempted to maintain the CEL price through continued purchases, but the scale of selling pressure from both market conditions and diminishing confidence in the platform overwhelmed the artificial support. On June 12, 2022, Celsius announced it was indefinitely pausing all transfers, swaps, and withdrawals, citing "extreme market conditions." On July 13, 2022, the company filed for Chapter 11 bankruptcy protection.
+
+## Legal Consequences
+
+The U.S. Department of Justice charged Mashinsky with seven counts of fraud, conspiracy, and market manipulation. In December 2024, he pleaded guilty to two counts of fraud and agreed to forfeit $48 million in gains associated with the CEL token manipulation. He was subsequently sentenced to 12 years in federal prison, one of the longest sentences issued in a cryptocurrency fraud case.
+
+The sentencing reflected not only the financial scale of the manipulation but the breach of trust involved in using customer deposits to artificially inflate a token that Mashinsky was simultaneously promoting to those same customers.
+
+## Detection Indicators
+
+The Celsius case illustrates several manipulation patterns detectable through market health metrics:
+
+- **Sustained price divergence from fundamentals.** The CEL token price showed persistent upward movement that did not correlate with genuine adoption metrics or protocol revenue growth, driven by concentrated buying from a single entity.
+- **Abnormal buy/sell ratio stability.** During the manipulation period, the buy side consistently dominated in patterns inconsistent with organic market activity, reflecting Celsius's systematic purchasing program.
+- **Circular volume patterns.** The transfer patterns identified between self-custody and exchange wallets suggested coordinated activity designed to generate artificial trading volume rather than genuine market participation.


### PR DESCRIPTION
New Market Health wiki article on the Celsius Network / CEL token manipulation scheme.

Covers:
- Mashinsky using hundreds of millions in customer deposits to buy CEL on open market
- Wintermute's alleged wash trading facilitation (950 suspicious transfers)
- Collapse from $2.18 to $0.28 in 6 weeks
- 12-year prison sentence (December 2024)
- Detection indicators for similar schemes

5,229 characters. Addresses #277