### PR TITLE
Add article: BitForex exit scam -- $56.5M drained after years of wash trading

### DIFF
--- a/content/research/market-health/posts/2024-02-bitforex/index.md
+++ b/content/research/market-health/posts/2024-02-bitforex/index.md
@@ -1,0 +1,43 @@
+---
+title: "BitForex Exit Scam: $56.5M Drained From Hot Wallets After Years of Suspected Wash Trading"
+date: "2024-02-23"
+description: "Hong Kong-based cryptocurrency exchange BitForex abruptly ceased operations after approximately $56.5 million was withdrawn from its hot wallets, following years of suspected wash trading and inflated volume reporting."
+entities:
+  - BitForex
+  - OMI
+---
+
+## Summary
+
+On February 23, 2024, Hong Kong-based cryptocurrency exchange BitForex executed what appears to be an exit scam, draining approximately $56.5 million from its hot wallets before ceasing all operations. The exchange stopped processing withdrawals, its social media accounts went silent, and customer support became unresponsive. The collapse followed years of suspected wash trading and inflated volume reporting that had previously attracted regulatory scrutiny in Japan. The exchange's CEO, Jason Luo, had departed in January 2024, one month before the shutdown.
+
+## Timeline of Collapse
+
+The BitForex exit followed a pattern common to exchange exit scams -- a period of deteriorating operations followed by a sudden fund extraction.
+
+In January 2024, CEO Jason Luo departed from BitForex without public explanation. At the time, the departure was not widely reported as a warning sign, though in retrospect it marked the beginning of the end.
+
+On February 21, 2024, BitForex's Telegram and social media accounts stopped posting. Community managers became inactive and changed their usernames, making them harder to identify. Reports emerged that the exchange was actively deleting user messages that raised concerns about platform issues.
+
+On February 23, 2024, approximately $56.5 million was moved out of the exchange's hot wallets. Withdrawal processing was simultaneously halted, trapping remaining customer funds on the platform. The exchange's website remained accessible but non-functional, displaying cached pages while backend systems were apparently shut down.
+
+## Prior Wash Trading Indicators
+
+BitForex had exhibited suspicious volume patterns well before the exit scam. The exchange was known for reporting trading volumes that appeared disproportionate to its actual user base and market position.
+
+Japanese financial regulators had previously flagged BitForex for operating without a license in their jurisdiction, and analysis of the exchange's reported trading data raised suspicions of systematic wash trading -- the practice of an entity trading with itself to create the appearance of market activity where none genuinely exists.
+
+Inflated volumes served multiple purposes for the exchange: higher reported volumes attracted new users who interpreted activity as a sign of liquidity and legitimacy, improved the exchange's ranking on aggregator sites like CoinMarketCap, and created an impression of a healthy trading platform that masked deteriorating fundamentals.
+
+## Impact on Token Markets
+
+The collapse had outsized impact on tokens that relied on BitForex as a primary trading venue. The OMI token crashed from $0.0069 to $0.00078, an 88% decline, as the loss of its primary exchange removed both genuine and artificial liquidity simultaneously. Tokens with concentrated exchange exposure are particularly vulnerable to this type of event, as the sudden removal of a trading venue eliminates both the platform's real order book and any artificial volume support that was masking thin genuine liquidity.
+
+## Detection Patterns
+
+The BitForex case illustrates several warning signs that precede exchange exit scams:
+
+- **Volume anomalies preceding collapse.** Sustained high reported volumes that don't correlate with on-chain deposit and withdrawal activity suggest artificial inflation. Exchanges preparing for exit may maintain or increase fake volume to attract last-minute deposits.
+- **Leadership departures.** The CEO's quiet exit one month before the collapse is a pattern seen in multiple exchange failures. Key personnel departing without clear succession plans or public explanation warrants heightened scrutiny.
+- **Communication decay.** The progressive shutdown of social media responsiveness, deletion of critical user messages, and community manager disappearance followed a predictable escalation pattern from reduced engagement to complete silence.
+- **Concentrated token exposure.** Tokens deriving a majority of their trading volume from a single exchange face existential risk from that exchange's failure, regardless of whether the failure is due to fraud, insolvency, or technical failure.


### PR DESCRIPTION
New Market Health wiki article on the February 2024 BitForex exit scam.

Covers:
- $56.5M drained from hot wallets before shutdown
- CEO departure one month prior
- Prior wash trading and volume inflation history
- Japanese regulatory scrutiny
- OMI token 88% crash from concentrated exchange exposure
- Detection patterns for exchange exit scams

4,543 characters. Addresses #277