### PR TITLE
Add article: JPEX Hong Kong fraud -- HK$1.6B losses, 66 arrests, influencer-driven scam

### DIFF
--- a/content/research/market-health/posts/2023-09-jpex/index.md
+++ b/content/research/market-health/posts/2023-09-jpex/index.md
@@ -1,0 +1,39 @@
+---
+title: "JPEX: HK$1.6 Billion Fraud Through Influencer Marketing, Withdrawal Restrictions, and Unlicensed Operations"
+date: "2023-09-13"
+description: "Hong Kong-based crypto exchange JPEX defrauded over 2,600 victims of approximately HK$1.6 billion through misleading licensing claims, influencer-driven marketing, and withdrawal restrictions that trapped customer funds."
+entities:
+  - JPEX
+---
+
+## Summary
+
+In September 2023, Hong Kong's Securities and Futures Commission issued a warning against JPEX, an unlicensed cryptocurrency exchange that had been actively soliciting customers through social media influencers and physical over-the-counter shops. The warning triggered a cascade of revelations about the platform's operations, ultimately exposing a fraud affecting more than 2,600 victims with losses totaling approximately HK$1.6 billion ($205 million USD). The case resulted in 66 arrests and became the largest fraud case in Hong Kong's history related to cryptocurrency, serving as a test case for the city's new virtual asset regulatory regime.
+
+## How the Fraud Operated
+
+JPEX combined several deceptive practices to attract and trap customer funds.
+
+The exchange made misleading claims about its licensing status, implying it was licensed to operate in Hong Kong when it was not. It marketed aggressively through social media influencers and celebrities, including high-profile figures like influencer Joseph Lam and Feng Shui expert Clement Chan, who promoted the platform to their audiences without disclosing the regulatory risks.
+
+Physical over-the-counter exchange shops were established in Hong Kong, giving the operation an appearance of legitimacy that purely online exchanges lack. These shops served as onboarding points where new customers could deposit fiat currency and begin trading.
+
+Once customer funds were deposited, JPEX progressively tightened withdrawal conditions. Withdrawal limits were reduced and handling fees were increased to levels that made retrieving funds prohibitively expensive. By the time the SFC warning was issued, many customers found themselves unable to access their assets at all.
+
+Behind the scenes, customer assets were being transferred out of the platform and laundered through multiple cryptocurrency wallets, making recovery difficult.
+
+## Regulatory Response
+
+The JPEX case became a defining moment for Hong Kong's approach to cryptocurrency regulation. The city had introduced a new licensing regime for virtual asset trading platforms in June 2023, requiring exchanges serving Hong Kong customers to obtain an SFC license.
+
+JPEX had not applied for such a license but continued operating and actively marketing to Hong Kong residents. The SFC's September 13 warning marked the first major enforcement action under the new regulatory framework.
+
+Hong Kong police launched a large-scale investigation that resulted in 66 arrests over the following months. In November 2025, 16 individuals were formally charged in connection with the fraud, more than two years after the initial arrests. Police also froze HK$229 million in assets linked to the exchange.
+
+## Market Manipulation Indicators
+
+While the JPEX case centered on fraud rather than traditional market manipulation, several patterns are relevant to market health monitoring:
+
+- **Artificial legitimacy through marketing spend.** Exchanges that invest heavily in influencer marketing relative to their regulatory compliance and infrastructure development may be compensating for fundamental deficiencies. Disproportionate marketing spend is a red flag.
+- **Withdrawal restriction patterns.** Progressive tightening of withdrawal conditions -- reducing limits, increasing fees, extending processing times -- is a classic pattern preceding exchange insolvency or exit scams. Monitoring on-chain outflow volumes relative to reported exchange reserves can detect this pattern before it becomes critical.
+- **Licensing misrepresentation.** Exchanges claiming or implying regulatory approval they do not hold can be identified through cross-referencing with public regulatory databases. The gap between marketing claims and actual licensing status is measurable.


### PR DESCRIPTION
New Market Health wiki article on the JPEX cryptocurrency exchange fraud in Hong Kong.

Covers:
- HK$1.6B ($205M USD) in losses across 2,600+ victims
- 66 arrests including influencers and celebrities
- Unlicensed operations with misleading regulatory claims
- Progressive withdrawal restriction pattern
- First major enforcement under HK's new virtual asset licensing regime
- Detection patterns: marketing spend vs compliance, withdrawal tightening, licensing misrepresentation

4,183 characters. Addresses #277