### PR TITLE
Add market manipulation analysis: JPEX Hong Kong fraud

### DIFF
--- a/content/research/market-health/posts/2026-03-27-jpex-hongkong/index.md
+++ b/content/research/market-health/posts/2026-03-27-jpex-hongkong/index.md
@@ -1,0 +1,94 @@
+---
+title: "JPEX: Hong Kong's Largest Crypto Fraud and the Catalyst for Regulatory Reform"
+date: 2026-03-27
+entities:
+  - JPEX
+  - Hong Kong SFC
+---
+
+## Summary
+
+1. **HK$1.6 Billion in Losses:** JPEX, an unlicensed cryptocurrency exchange operating in Hong Kong, collapsed in September 2023 after the Securities and Futures Commission (SFC) issued a public warning, leaving approximately 2,600 victims with combined losses of over HK$1.6 billion (approximately $205 million USD).
+2. **Unlicensed Operation with Aggressive Marketing:** JPEX was not licensed by Hong Kong's SFC but operated openly, using celebrity endorsements, social media influencers, and physical retail kiosks in shopping malls to attract retail investors — many of whom were first-time crypto users.
+3. **Ponzi-Like Structure:** JPEX offered yields of up to 21% APR on staking products. Investigations revealed that returns to early investors were funded by deposits from new users rather than legitimate trading or investment activity.
+4. **Mass Arrests:** Hong Kong police arrested over 60 individuals in connection with the JPEX fraud, including key operators, promoters, and social media influencers who had promoted the platform.
+5. **Regulatory Catalyst:** The JPEX scandal directly accelerated Hong Kong's implementation of a mandatory cryptocurrency exchange licensing regime, with the SFC fast-tracking enforcement of the new licensing framework that took effect on June 1, 2023.
+
+## Background
+
+JPEX (later rebranded from JP-EX) presented itself as a Dubai-headquartered cryptocurrency exchange serving the Asia-Pacific market. The platform targeted Hong Kong retail investors through an aggressive marketing campaign that included physical over-the-counter (OTC) shops in shopping centers, partnerships with popular social media influencers, and sponsorship of public events. Despite operating extensively in Hong Kong, JPEX never applied for or obtained a license from the SFC.
+
+## Metrics used
+
+### Unlicensed operation with retail targeting
+
+JPEX's approach to customer acquisition was unusual for an unlicensed exchange:
+
+- **Physical OTC locations** in Hong Kong shopping malls where staff helped customers open accounts and deposit funds.
+- **Influencer partnerships** with popular Hong Kong social media personalities, several of whom promoted JPEX to audiences of hundreds of thousands of followers.
+- **Celebrity endorsements** that lent credibility to the unlicensed platform.
+- Promises of **up to 21% annual returns** on crypto staking products, far exceeding sustainable yields.
+
+### The SFC warning and collapse
+
+The collapse unfolded rapidly:
+
+- **September 13, 2023:** The Hong Kong SFC issued a public warning that JPEX was operating without a license and had been promoting its products to Hong Kong investors through "suspicious features."
+- **Immediately after the warning:** JPEX raised withdrawal fees to an effective 999 USDT per transaction, making it economically impossible for most users to withdraw their funds.
+- **Within days:** The platform became effectively inaccessible for withdrawals, trapping customer funds.
+- Over **2,600 complaints** were filed with Hong Kong police, with reported losses exceeding HK$1.6 billion.
+
+### Ponzi indicators
+
+Analysis of JPEX's operations revealed classic Ponzi characteristics:
+
+- Promised returns far exceeded what could be generated through legitimate market-making or trading.
+- New customer deposits were used to fund withdrawals and returns for existing users.
+- When the flow of new deposits slowed (triggered by the SFC warning), the system collapsed immediately — consistent with a liquidity structure dependent on continuous inflows.
+
+## Regulatory actions and legal outcomes
+
+### Hong Kong Police — Mass arrests
+
+Hong Kong police launched one of the largest fraud investigations in the city's history:
+
+- Over **60 individuals arrested** in connection with the JPEX fraud.
+- Arrestees included JPEX operators, promoters, and social media influencers.
+- Several prominent Hong Kong influencers were arrested for their role in promoting the unlicensed platform.
+- Investigations extended to mainland China and Southeast Asia.
+
+### SFC enforcement
+
+The SFC's warning on September 13, 2023 was the trigger for the collapse. The SFC subsequently:
+
+- Added JPEX to its public alert list of unlicensed virtual asset trading platforms.
+- Accelerated enforcement of the new licensing regime requiring all crypto exchanges operating in or targeting Hong Kong to obtain SFC licenses.
+- Used the JPEX case as justification for stricter licensing requirements and enhanced investor protection measures.
+
+### Regulatory impact — New licensing regime
+
+The JPEX scandal had a direct impact on Hong Kong's crypto regulatory framework:
+
+- Hong Kong's **Virtual Asset Service Provider (VASP) licensing regime** took effect on June 1, 2023, requiring all crypto exchanges operating in Hong Kong to obtain SFC licenses.
+- After the JPEX collapse, the SFC accelerated enforcement against unlicensed platforms.
+- The SFC published updated guidelines with stricter requirements for customer asset segregation, proof of reserves, and marketing practices.
+- The case became a cautionary example cited in regulatory proceedings across Asia.
+
+## Timeline
+
+| Date | Event |
+|--|--|
+| 2022-2023 | JPEX operates in Hong Kong without SFC license |
+| 2023-06-01 | Hong Kong VASP licensing regime takes effect |
+| 2023-09-13 | SFC issues public warning about JPEX |
+| 2023-09-13 | JPEX raises withdrawal fees to 999 USDT |
+| 2023-09 | 2,600+ complaints filed, HK$1.6B in reported losses |
+| 2023-09 to 2024 | Over 60 arrests including operators and influencers |
+
+## References
+
+1. Hong Kong SFC, "[Warning: JPEX](https://www.sfc.hk/en/alert-list)," September 13, 2023.
+2. South China Morning Post, "[JPEX scandal: Hong Kong police arrest more than 60](https://www.scmp.com/news/hong-kong/law-and-crime/article/3236187/)," 2023.
+3. Reuters, "[Hong Kong police investigate JPEX crypto exchange over $166 mln fraud claims](https://www.reuters.com/technology/hong-kong-police-investigate-crypto-exchange-jpex-over-fraud-claims-2023-09-18/)," September 18, 2023.
+4. Bloomberg, "[JPEX Crypto Scandal Deepens With More Arrests in Hong Kong](https://www.bloomberg.com/news/articles/2023-09-25/jpex-crypto-scandal-deepens-with-more-arrests-in-hong-kong)," September 2023.
+5. Hong Kong SFC, "[Virtual Asset Trading Platform Licensing](https://www.sfc.hk/en/Welcome-to-the-Fintech-Contact-Point/Virtual-assets)," 2023.


### PR DESCRIPTION
JPEX unlicensed exchange collapse, HK$1.6B losses, 60+ arrests, influencer marketing fraud, catalyst for Hong Kong VASP licensing regime. Addresses #277