### PR TITLE
[BOUNTY] Refactor Market Health Reporter Prompts

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -62,21 +62,29 @@ Concurrent Irregularities in First-Digit Distribution and K-S Test: Significant 
 Inconsistencies in VWAP and Buy/Sell Ratio: A substantial difference between VWAP and market prices, along with abnormal Buy/Sell Ratios, could signify price manipulation. Traders might be attempting to influence the perceived average price through strategic buying or selling.
 Correlation between Time-of-Trade and Buy/Sell Ratio Anomalies: If the Time-of-Trade metric shows high frequency or evenly distributed trades, and the Buy/Sell Ratio deviates significantly from the 0.4-0.6 range, this might suggest automated trading systems are in play. This could be an attempt to influence market prices or create false market sentiment.
 
-Create an article with the results of your analysis. The article should include:
-- Fields between --- and ---:
-    - 'date'
-        The content of this field must match the format YYYY-MM-DD — YYYY-MM-DD, where the first date is the start of the analysis period, and the second date is the end of the analysis period.
-        Example: '2023-10-02 — 2023-10-08'
-    - 'entities'
-        The content of this field should include entities implicated in wash trading. Example: 'Huobi, HT, TRX, DOGE'
-    - 'title'
-        The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
+Create an article analyzing the results of your analysis. You MUST output the article starting with valid YAML Front Matter enclosed in `---` blocks. 
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
+Your output MUST be enclosed within `<article> </article>` tags.
+The article MUST strictly follow this Markdown structure:
+
+```yaml
+---
+title: "[Dynamic Title Example: Uncovering Wash Trading and Market Manipulation on Huobi]"
+date: [YYYY-MM-DD - YYYY-MM-DD format indicating analysis period]
+entities: [Comma separated list of implicated entities, e.g. Huobi, HT, TRX]
+---
+```
+
+After the Front Matter, write the main body of the article in Markdown.
+Follow the qualitative style of the provided `<example>` closely. Only include information supported by the data provided.
+
+You can create placeholders for illustrations where relevant, formatted like this:
+`{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`
+
 Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
-Place the article into the <article> </article> tags.
+- `volume_hist.png`
+- `crypto_metrics.png`
+- `benford_law.png`
+- `vv_correlation.png`
+
+CRITICAL: Output ONLY the requested article inside the `<article>` tags and nothing else outside of them!


### PR DESCRIPTION
Closes #427. 

Improves the robustness and compatibility of the Market Health Reporter's generated articles:
- Converts the ambiguous 'Fields between --- and ---' instructional block into a strict YAML Front Matter template.
- Ensures identical structuring aligning with the stated example article guidelines.
- Prevents LLMs from producing invalid markdown configurations when submitting dynamic metric spikes.