### PR TITLE
tools/similarity_search: add Vitest integration tests

### DIFF
--- a/tools/similarity_search/test/integration.spec.ts
+++ b/tools/similarity_search/test/integration.spec.ts
@@ -1,0 +1,83 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, expect, it, vi } from 'vitest';
+
+const post = (body: unknown, key?: string) =>
+  new Request('https://example.com/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { 'X-API-Key': key } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+describe('Similarity Search worker - auth', () => {
+  it('rejects requests with no X-API-Key (401)', async () => {
+    const res = await SELF.fetch(post({ text: 'hello', namespace: 'docs' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects requests with wrong X-API-Key (401)', async () => {
+    const res = await SELF.fetch(post({ text: 'hello', namespace: 'docs' }, 'bad'));
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts requests with correct X-API-Key', async () => {
+    vi.spyOn(env.AI, 'run').mockResolvedValue({ data: [[0.1, 0.2, 0.3]] } as any);
+    vi.spyOn(env.VECTORIZE, 'query').mockResolvedValue({
+      matches: [{ id: 'doc-1', score: 0.92 }],
+    } as any);
+    const res = await SELF.fetch(post({ text: 'hello', namespace: 'docs' }, 'test-key'));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { score: number };
+    expect(body.score).toBe(0.92);
+  });
+});
+
+describe('Similarity Search worker - input validation', () => {
+  it('returns 400 when text is missing', async () => {
+    const res = await SELF.fetch(post({ namespace: 'docs' }, 'test-key'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when namespace is missing', async () => {
+    const res = await SELF.fetch(post({ text: 'hello' }, 'test-key'));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('Similarity Search worker - namespace isolation', () => {
+  it('queries the requested namespace with topK 1', async () => {
+    const querySpy = vi.spyOn(env.VECTORIZE, 'query').mockResolvedValue({
+      matches: [{ id: 'doc-7', score: 0.71 }],
+    } as any);
+    vi.spyOn(env.AI, 'run').mockResolvedValue({ data: [[0.5, 0.5, 0.5]] } as any);
+    await SELF.fetch(post({ text: 'topic A', namespace: 'tickets' }, 'test-key'));
+    expect(querySpy).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ namespace: 'tickets', topK: 1 }),
+    );
+  });
+});
+
+describe('Similarity Search worker - failure modes', () => {
+  it('handles AI binding throwing', async () => {
+    vi.spyOn(env.AI, 'run').mockRejectedValue(new Error('AI down'));
+    const res = await SELF.fetch(post({ text: 'foo', namespace: 'docs' }, 'test-key'));
+    expect([500, 502]).toContain(res.status);
+  });
+});
+
+describe('Similarity Search worker - concurrency', () => {
+  it('handles 10 concurrent requests', async () => {
+    vi.spyOn(env.AI, 'run').mockResolvedValue({ data: [[0.1, 0.2]] } as any);
+    vi.spyOn(env.VECTORIZE, 'query').mockResolvedValue({
+      matches: [{ id: 'doc-1', score: 0.5 }],
+    } as any);
+    const reqs = Array.from({ length: 10 }, () =>
+      SELF.fetch(post({ text: 'hello', namespace: 'docs' }, 'test-key')),
+    );
+    const results = await Promise.all(reqs);
+    for (const r of results) expect(r.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Re: Issue #430 — Similarity Search API Integration Testing

Opening as **draft** to solicit feedback on coverage approach before final polish. Happy to iterate on whatever convention deviations or assumptions you flag.

## Methodology

I treated the issue's three eval axes (resource efficiency, security, speed) as concrete coverage requirements:

- **Security:** auth gates (401 with no key, 401 with wrong key, 200 with correct key), namespace isolation (each request only queries the namespace it requested).
- **Resource efficiency:** stubbed AI + Vectorize bindings via `vi.spyOn` so tests do not call real Cloudflare endpoints. CI is free to run.
- **Speed:** concurrency check with 10 parallel requests, no shared-state regressions.
- **Higher-level over per-function:** every test exercises the full request → AI embedding → Vectorize query → response shape pipeline using `SELF.fetch()` from `cloudflare:test`. No internal helper functions are tested directly.

## Coverage

| Test | Behavior covered |
|---|---|
| `rejects requests with no X-API-Key (401)` | Auth header required |
| `rejects requests with wrong X-API-Key (401)` | Auth value validated |
| `accepts requests with correct X-API-Key` | Happy path, response shape |
| `returns 400 when text is missing` | Input validation |
| `returns 400 when namespace is missing` | Input validation |
| `queries the requested namespace with topK 1` | Namespace propagation, vector params |
| `handles AI binding throwing` | Failure mode (5xx not crash) |
| `handles 10 concurrent requests` | Concurrency / no shared-state bugs |

Status-code asserts use ranges (e.g. `[400, 500]`) where I was uncertain of the worker's exact convention. Happy to tighten to single statuses based on your preference.

## Open questions for the maintainer

1. **Binding names**: tests assume the AI binding is `env.AI` and the Vectorize binding is `env.VECTORIZE`. If your `wrangler.toml` uses different names, point me at the right ones and I'll update.
2. **Response shape**: tests assert `{ score: number }` for the success response. Confirm or correct.
3. **Error conventions**: which status code do you prefer for missing AI/Vectorize results: `404`, `502`, or `200 with score: null`? I'll align all asserts.
4. **`@cloudflare/vitest-pool-workers` version**: I pinned at `^0.5.0` in the skeleton. Want me to bump to the exact current minor at merge time?

## How to run locally

```bash
cd tools/similarity_search
npm install
npm test
```

## CI

I added a scoped GitHub Actions workflow at `.github/workflows/similarity-search-test.yml` (separate commit) that only triggers on changes under `tools/similarity_search/**`. Skip if you'd rather not add CI yet.

## Payout

If accepted, payout to: Base address ending `3CD5D` (full address sent via email to `challenge.bounties@dn.institute` upon merge, per your README).

---

This is M&M's first PR. Feedback is welcomed. Strict reviews appreciated, not deflected.

Co-Authored-By: Machine&Machine <machineandmachine@gmail.com>
