### PR TITLE
Add Market Health article on wash-trading liquidity traps

### DIFF
--- a/content/research/market-health/posts/2026-05-01-wash-trading-liquidity-traps/index.md
+++ b/content/research/market-health/posts/2026-05-01-wash-trading-liquidity-traps/index.md
@@ -1,0 +1,104 @@
+---
+title: "Wash-Trading Liquidity Traps: When Reported Volume Hides Execution Risk"
+date: 2026-05-01
+entities:
+  - Market Health
+  - Wash Trading
+  - Crypto Exchanges
+---
+
+## Summary
+
+Reported exchange volume is often treated as a proxy for liquidity. In crypto markets that assumption can be dangerous: a venue may show large turnover while still offering poor real execution conditions. This article describes the "wash-trading liquidity trap": a market that looks liquid because reported volume is high, but where the underlying trade-size, timing, and buy/sell patterns suggest manufactured activity rather than organic demand.
+
+A safer analyst workflow is to compare reported volume against market-health signals such as transaction-size distribution, buy/sell balance, time-of-trade clustering, VWAP behavior, and Benford-style distribution tests. No single metric proves manipulation on its own. The risk signal becomes stronger when several independent metrics point in the same direction.
+
+## Why high reported volume can be misleading
+
+Liquidity is the ability to trade a meaningful size without moving the market too much. Volume is only a historical count of turnover. Wash trading can inflate turnover without improving real executable depth. For users, this creates three practical risks:
+
+1. **Slippage risk:** A trader expects tight execution because the pair appears active, then discovers shallow real depth.
+2. **Exit risk:** A token appears easy to sell until the artificial flow disappears.
+3. **Signal risk:** Volume-based rankings, screeners, and token dashboards overstate market interest.
+
+The trap is most dangerous when an exchange, market maker, or issuer benefits from making a pair look more active than it is.
+
+## Observable red flags
+
+### 1. Transaction-size patterns look too regular
+
+Organic markets usually contain a mix of retail-sized trades, larger informed flows, arbitrage, and liquidity-provider rebalancing. A suspicious venue may show repeated trade sizes, narrow size bands, or sudden shifts in average transaction size that are not mirrored on healthier venues.
+
+Analyst check:
+
+- Compare average and median trade size across venues for the same pair.
+- Look for abrupt changes in transaction-size distribution after listing events, incentive campaigns, or market stress.
+- Treat repeated round-number sizing as a weak signal that needs confirmation from timing and buy/sell metrics.
+
+### 2. Time-of-trade clustering is mechanical
+
+Real markets cluster around news, funding cycles, macro releases, and regional trading hours. Artificial flow often has a more mechanical cadence: trades appear at highly regular intervals or maintain activity during periods when comparable venues are quiet.
+
+Analyst check:
+
+- Plot trade counts per second or minute.
+- Compare active/inactive windows against benchmark venues.
+- Flag pairs where reported activity is smooth even when external interest is low.
+
+### 3. Buy/sell balance does not match price behavior
+
+In a healthy market, persistent buy pressure should usually correspond to upward price pressure, and persistent sell pressure to downward pressure, after allowing for liquidity and arbitrage. Wash trading can create apparent buy/sell activity that does not map cleanly to price discovery.
+
+Analyst check:
+
+- Compare buy/sell volume imbalance with price and VWAP movement.
+- Look for high turnover with little directional information.
+- Watch for native or exchange-linked tokens where incentives to support price perception are strongest.
+
+### 4. Volume distribution diverges from comparable venues
+
+The same asset trading across multiple venues gives analysts a useful control group. If one venue's distribution is materially different from peers, the difference may be explained by user base, fee structure, market-maker behavior, or manipulation. The point is not to assume wrongdoing; the point is to investigate the outlier.
+
+Analyst check:
+
+- Compare distribution shape for the same pair across venues.
+- Use Benford-style and trade-size-distribution checks as anomaly screens, not final verdicts.
+- Prioritize cases where multiple unrelated assets show similar abnormal patterns on the same venue.
+
+## A practical triage checklist
+
+Before trusting a high-volume crypto market, ask:
+
+1. Does order-book depth support the reported turnover?
+2. Are trade sizes naturally varied or unusually repetitive?
+3. Is trading activity clustered around plausible market events, or is it mechanically smooth?
+4. Does buy/sell pressure explain price and VWAP behavior?
+5. Do comparable venues show similar distributions for the same asset?
+6. Are anomalies concentrated in exchange-linked, founder-linked, or incentive-heavy tokens?
+7. Do several metrics agree, or is there only one weak signal?
+
+A market with high reported volume but weak answers to these questions should be treated as a liquidity-risk candidate.
+
+## How different users can respond
+
+### Retail users
+
+Do not treat volume ranking as proof of liquidity. Check spread, depth, venue reputation, and whether abnormal market-health metrics have been reported for the asset or exchange.
+
+### Market makers
+
+Use anomaly screens before committing inventory. Artificial turnover can create toxic flow, poor hedging assumptions, and unreliable volume-based fee projections.
+
+### Token teams
+
+Avoid using inflated exchange volume as a KPI. It may create short-term marketing optics while damaging long-term credibility and exposing holders to exit-risk.
+
+### Researchers
+
+Publish reproducible methods and avoid overclaiming. The strongest work separates "anomaly detected" from "manipulation proven" and explains which alternative hypotheses were considered.
+
+## Conclusion
+
+The wash-trading liquidity trap is a measurement problem: reported volume is easy to inflate, while real liquidity is harder to fake. Market Health metrics help close that gap by looking at the structure of trades rather than the headline number alone. The safest approach is multi-signal: transaction-size distribution, timing, buy/sell behavior, VWAP, and cross-venue comparisons should be read together.
+
+High volume should start the analysis, not end it.


### PR DESCRIPTION
## Summary

Adds a Market Health article draft for the bounty in 1712n/dn-institute#277:

**Wash-Trading Liquidity Traps: When Reported Volume Hides Execution Risk**

The article is educational and evidence-oriented. It explains why reported exchange volume can be a poor proxy for executable liquidity and proposes a multi-signal review checklist using Market Health-style metrics.

## Coverage

- transaction-size distribution red flags
- time-of-trade clustering
- buy/sell balance vs price/VWAP behavior
- cross-venue volume distribution divergence
- practical triage checklist for users, market makers, token teams, and researchers

## Safety / scope

The article avoids trading advice and avoids operational instructions for manipulation. It frames metrics as anomaly screens rather than proof of wrongdoing.

Related issue: #277
