### PR TITLE
feat: replace static matplotlib charts with interactive Chart.js

### DIFF
--- a/layouts/shortcodes/market_chart.html
+++ b/layouts/shortcodes/market_chart.html
@@ -1,0 +1,76 @@
+{{/*
+  market_chart: Renders an interactive Chart.js chart from inline JSON data.
+
+  Usage in markdown:
+    {{< market_chart id="volume-hist" type="bar" title="Transaction Volume Distribution" >}}
+    {"labels":["0-10","10-20",...],"datasets":[{"data":[5,12,...]}]}
+    {{< /market_chart >}}
+
+  Parameters:
+    id     - Unique canvas element ID (required)
+    type   - Chart.js chart type: bar, line, scatter (default: "line")
+    title  - Chart title (optional)
+    height - Canvas height in px (default: 400)
+    xLabel - X-axis label (optional)
+    yLabel - Y-axis label (optional)
+    y2Label - Secondary Y-axis label (optional, enables dual-axis)
+*/}}
+
+{{ $id := .Get "id" }}
+{{ $chartType := .Get "type" | default "line" }}
+{{ $title := .Get "title" | default "" }}
+{{ $height := .Get "height" | default "400" }}
+{{ $xLabel := .Get "xLabel" | default "" }}
+{{ $yLabel := .Get "yLabel" | default "" }}
+{{ $y2Label := .Get "y2Label" | default "" }}
+
+{{ $chart := resources.Get "/js/chart.js" }}
+<script src="{{ $chart.Permalink }}"></script>
+
+<div style="position:relative;width:100%;max-width:900px;margin:1.5em auto;">
+  <canvas id="{{ $id }}" height="{{ $height }}"></canvas>
+</div>
+
+<script>
+(function() {
+  var ctx = document.getElementById('{{ $id }}').getContext('2d');
+  var chartData = {{ .Inner | safeJS }};
+
+  var scales = { x: {}, y: {} };
+
+  {{ with $xLabel }}
+  scales.x.title = { display: true, text: '{{ . }}' };
+  {{ end }}
+
+  {{ with $yLabel }}
+  scales.y.title = { display: true, text: '{{ . }}' };
+  {{ end }}
+
+  {{ with $y2Label }}
+  scales.y2 = {
+    position: 'right',
+    title: { display: true, text: '{{ . }}' },
+    grid: { drawOnChartArea: false }
+  };
+  {{ end }}
+
+  new Chart(ctx, {
+    type: '{{ $chartType }}',
+    data: chartData,
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        title: {
+          display: {{ if $title }}true{{ else }}false{{ end }},
+          text: '{{ $title }}'
+        },
+        tooltip: { enabled: true },
+        legend: { display: true, position: 'top' }
+      },
+      scales: scales
+    }
+  });
+})();
+</script>

--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -181,10 +181,15 @@ def main():
             output = extract_between_tags("article", output)
 
             print("This is an answer: ", output)
-            save_output(output, OUTPUT_DIR, marketvenueid, pairid, start, end)
+            # Generate interactive Chart.js shortcodes instead of static PNGs
             vis = Visualization()
-            output_subdir = os.path.join(OUTPUT_DIR, f"{start}-{end}-{marketvenueid}-{pairid}") 
-            vis.generate_report(data, output_subdir)  
+            output_subdir = os.path.join(OUTPUT_DIR, f"{start}-{end}-{marketvenueid}-{pairid}")
+            chart_shortcodes = vis.generate_report(data, output_subdir)
+
+            # Append interactive charts to the LLM-generated article
+            output_with_charts = output + "\n\n## Interactive Charts\n\n" + chart_shortcodes
+
+            save_output(output_with_charts, OUTPUT_DIR, marketvenueid, pairid, start, end)
 
             post_comment_to_issue(args.github_token, int(args.issue), REPO_NAME, output)
 

--- a/tools/python_modules/report_graphics_tool.py
+++ b/tools/python_modules/report_graphics_tool.py
@@ -1,92 +1,182 @@
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-import matplotlib.dates as mdates
+import json
 import os
+
+import numpy as np
+import pandas as pd
 
 
 class Visualization:
+    """Generate interactive Chart.js charts via Hugo shortcodes.
+
+    Instead of saving static matplotlib PNGs, each chart method returns a Hugo
+    shortcode string that embeds the chart data as inline JSON. The shortcode
+    ``market_chart`` (layouts/shortcodes/market_chart.html) renders these as
+    interactive, responsive Chart.js charts in the browser.
+    """
+
     def __init__(self):
         pass
 
+    @staticmethod
+    def _ts_labels(index):
+        """Convert a DatetimeIndex to ISO-formatted string labels."""
+        return [t.strftime("%Y-%m-%d %H:%M") for t in index]
 
-    def _make_volume_hist(self, data, directory):
-        plt.figure(figsize=(10, 6))
-        plt.hist(data['volume'], bins=30, color='skyblue', edgecolor='black')
-        plt.xlabel('Transaction Volume')
-        plt.ylabel('Frequency')
-        plt.title('Transaction Volume Distribution')
-        plt.grid(True, which='both', linestyle='--', linewidth=0.5)
-        plt.savefig(os.path.join(directory, 'volume_hist.png'))
-        plt.close()
+    def _make_volume_hist(self, data):
+        """Return a Hugo shortcode for an interactive volume histogram."""
+        volumes = data["volume"].dropna().values
+        counts, bin_edges = np.histogram(volumes, bins=30)
+        labels = [f"{bin_edges[i]:.2f}-{bin_edges[i+1]:.2f}" for i in range(len(counts))]
+        chart_data = {
+            "labels": labels,
+            "datasets": [
+                {
+                    "label": "Frequency",
+                    "data": counts.tolist(),
+                    "backgroundColor": "rgba(135,206,235,0.7)",
+                    "borderColor": "rgba(0,0,0,0.8)",
+                    "borderWidth": 1,
+                }
+            ],
+        }
+        inner = json.dumps(chart_data)
+        return (
+            '{{< market_chart id="volume-hist" type="bar" '
+            'title="Transaction Volume Distribution" '
+            'xLabel="Transaction Volume" yLabel="Frequency" >}}\n'
+            f"{inner}\n"
+            "{{< /market_chart >}}"
+        )
 
+    def _make_crypto_metrics(self, data):
+        """Return Hugo shortcodes for each crypto metric as separate line charts."""
+        labels = self._ts_labels(data.index)
+        metrics = [
+            ("volume", "Volume", "rgba(54,162,235,1)"),
+            ("tradecount", "Trade Count", "rgba(75,192,75,1)"),
+            ("avgtransactionsize", "Avg Transaction Size", "rgba(255,159,64,1)"),
+            ("buysellratio", "Buy/Sell Ratio", "rgba(255,99,132,1)"),
+        ]
+        shortcodes = []
+        for col, label, color in metrics:
+            if col not in data.columns:
+                continue
+            chart_data = {
+                "labels": labels,
+                "datasets": [
+                    {
+                        "label": label,
+                        "data": data[col].tolist(),
+                        "borderColor": color,
+                        "backgroundColor": color.replace("1)", "0.1)"),
+                        "fill": True,
+                        "tension": 0.2,
+                        "pointRadius": 0,
+                    }
+                ],
+            }
+            inner = json.dumps(chart_data)
+            slug = col.replace(" ", "-").lower()
+            shortcodes.append(
+                f'{{{{< market_chart id="metric-{slug}" type="line" '
+                f'title="{label} Over Time" '
+                f'xLabel="Timestamp" yLabel="{label}" >}}}}\n'
+                f"{inner}\n"
+                "{{< /market_chart >}}"
+            )
+        return "\n\n".join(shortcodes)
 
-    def _make_crypto_metrics(self, data, directory):
-        fig, axs = plt.subplots(4, 1, figsize=(15, 10), sharex=True)
+    def _make_benfordlaw(self, data):
+        """Return a Hugo shortcode for a dual-axis Benford law chart."""
+        labels = self._ts_labels(data.index)
+        benford_vals = data["benfordlawtest"].tolist()
+        threshold = (1.36 / np.sqrt(data["tradecount"])).tolist()
+        chart_data = {
+            "labels": labels,
+            "datasets": [
+                {
+                    "label": "Benford Law Test Score",
+                    "data": benford_vals,
+                    "borderColor": "rgba(54,162,235,1)",
+                    "backgroundColor": "rgba(54,162,235,0.1)",
+                    "fill": False,
+                    "tension": 0.2,
+                    "pointRadius": 0,
+                    "yAxisID": "y",
+                },
+                {
+                    "label": "Critical Value (1.36/sqrt(n))",
+                    "data": threshold,
+                    "borderColor": "rgba(75,192,75,1)",
+                    "backgroundColor": "rgba(75,192,75,0.1)",
+                    "fill": False,
+                    "tension": 0.2,
+                    "pointRadius": 0,
+                    "yAxisID": "y2",
+                },
+            ],
+        }
+        inner = json.dumps(chart_data)
+        return (
+            '{{< market_chart id="benford-law" type="line" '
+            'title="Benford Law Test Score and Trade Count Over Time" '
+            'xLabel="Timestamp" yLabel="Benford Law Test Score" '
+            'y2Label="Critical Value" >}}\n'
+            f"{inner}\n"
+            "{{< /market_chart >}}"
+        )
 
-        axs[0].plot(data.index, data['volume'], label='Volume', color='blue')
-        axs[0].set_ylabel('Volume')
-
-        axs[1].plot(data.index, data['tradecount'], label='Trade Count', color='green')
-        axs[1].set_ylabel('Trade Count')
-
-        axs[2].plot(data.index, data['avgtransactionsize'], label='Avg Transaction Size', color='orange')
-        axs[2].set_ylabel('Avg Transaction Size')
-
-        axs[3].plot(data.index, data['buysellratio'], label='Buy/Sell Ratio', color='red')
-        axs[3].set_ylabel('Buy/Sell Ratio')
-
-        axs[3].set_xlabel('Timestamp')
-
-        fig.suptitle('Cryptocurrency Metrics Over Time')
-
-        for ax in axs:
-            plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
-
-        plt.tight_layout()
-        plt.savefig(os.path.join(directory, 'crypto_metrics.png'))
-        plt.close()
-        
-
-    def _make_benfordlaw(self, data, directory):
-        fig, ax1 = plt.subplots(figsize=(15, 10), layout='constrained')
-        ax1.plot(data.index, data['benfordlawtest'], color='blue', linestyle='-', label='Benford Law Test Score')
-        ax1.set_xlabel('Timestamp')
-        ax1.set_ylabel('Benford Law Test Score', color='blue')
-        ax1.xaxis.set_major_locator(mdates.HourLocator(interval=24))
-        ax1.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-        ax2 = ax1.twinx()
-        ax2.plot(data.index, 1.36 / np.sqrt(data['tradecount']), color='green', linestyle='-', label='Trade Count')
-        ax2.set_ylabel('Trade Count', color='green')
-        ax1.set_title('Benford Law Test Score and Trade Count Over Time')
-        lines = ax1.get_lines() + ax2.get_lines()
-        labels = [line.get_label() for line in lines]
-        ax1.legend(lines, labels, loc='upper left')
-        plt.savefig(os.path.join(directory, 'benford_law.png'))
-        plt.close()
-
-
-    def _make_vvcorrelation(self, data, directory):
-        fig, ax = plt.subplots(figsize=(15, 10), layout='constrained')
-        ax.plot(data.index, data['vvcorrelation'], color='purple', linestyle='-', marker='o', label='VV Correlation')
-        ax.xaxis.set_major_locator(mdates.HourLocator(interval=24))
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-        ax.set_xlabel('Timestamp')
-        ax.set_ylabel('VV Correlation')
-        ax.set_title('VV Correlation Over Time')
-        ax.legend()
-        plt.xticks(rotation=45)
-        plt.savefig(os.path.join(directory, 'vv_correlation.png'))
-        plt.close()
+    def _make_vvcorrelation(self, data):
+        """Return a Hugo shortcode for a VV correlation line chart."""
+        labels = self._ts_labels(data.index)
+        chart_data = {
+            "labels": labels,
+            "datasets": [
+                {
+                    "label": "VV Correlation",
+                    "data": data["vvcorrelation"].tolist(),
+                    "borderColor": "rgba(128,0,128,1)",
+                    "backgroundColor": "rgba(128,0,128,0.1)",
+                    "fill": True,
+                    "tension": 0.2,
+                    "pointRadius": 2,
+                }
+            ],
+        }
+        inner = json.dumps(chart_data)
+        return (
+            '{{< market_chart id="vv-correlation" type="line" '
+            'title="VV Correlation Over Time" '
+            'xLabel="Timestamp" yLabel="VV Correlation" >}}\n'
+            f"{inner}\n"
+            "{{< /market_chart >}}"
+        )
 
     def generate_report(self, data, directory):
+        """Generate interactive Chart.js shortcodes from market data.
+
+        Returns a string of Hugo shortcodes. Also writes them to
+        ``charts.md`` in *directory* for easy inclusion in reports.
+        """
         if not os.path.exists(directory):
             os.makedirs(directory)
-        data = pd.DataFrame(data)
-        data['timestamp'] = pd.to_datetime(data['timestamp'])
-        data.set_index('timestamp', inplace=True)
 
-        self._make_volume_hist(data, directory)
-        self._make_crypto_metrics(data, directory)
-        self._make_benfordlaw(data, directory)
-        self._make_vvcorrelation(data, directory)
+        df = pd.DataFrame(data)
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df.set_index("timestamp", inplace=True)
+
+        sections = []
+        sections.append(self._make_volume_hist(df))
+        sections.append(self._make_crypto_metrics(df))
+        if "benfordlawtest" in df.columns and "tradecount" in df.columns:
+            sections.append(self._make_benfordlaw(df))
+        if "vvcorrelation" in df.columns:
+            sections.append(self._make_vvcorrelation(df))
+
+        shortcodes = "\n\n".join(sections)
+
+        charts_path = os.path.join(directory, "charts.md")
+        with open(charts_path, "w", encoding="utf-8") as f:
+            f.write(shortcodes)
+
+        return shortcodes


### PR DESCRIPTION
## Summary

Replaces the static matplotlib PNG chart generation in the Market Health Reporter with interactive, responsive [Chart.js](https://www.chartjs.org/) charts rendered via Hugo shortcodes.

### Changes

1. **New Hugo shortcode** `market_chart` (`layouts/shortcodes/market_chart.html`)
   - Accepts inline JSON chart data and renders interactive Chart.js charts
   - Supports bar, line, and scatter chart types
   - Optional dual-axis support (used for Benford Law chart)
   - Responsive design that adapts to screen size
   - Tooltips and legends enabled by default

2. **Rewritten `report_graphics_tool.py`**
   - `Visualization.generate_report()` now returns Hugo shortcode markdown strings instead of saving PNGs
   - Each chart method returns a self-contained shortcode with embedded JSON data
   - Removes matplotlib dependency entirely
   - All 4 original chart types preserved:
     - Volume histogram (bar chart)
     - Crypto metrics: Volume, Trade Count, Avg Transaction Size, Buy/Sell Ratio (separate line charts)
     - Benford Law test score with critical value threshold (dual-axis line chart)
     - VV Correlation over time (line chart with fill)

3. **Updated `market_health_reporter.py`**
   - Chart shortcodes are appended to the LLM-generated article under an "Interactive Charts" section
   - No more separate PNG files saved alongside the markdown

### Methodology

The approach leverages the existing Chart.js 4.4.1 library already present in the repo (`assets/js/chart.js`) and the Hugo shortcode pattern already used by `market_widget.html`. The chart data is serialized as JSON directly into the markdown content, so:
- No external API calls needed at render time
- Charts load instantly (no async data fetching)
- Each report is self-contained
- Charts are interactive: hover for tooltips, click legend to toggle datasets

### Testing

Smoke-tested the `Visualization` class with sample market data:
```
SUCCESS - shortcodes generated
Length: 4098 chars
Contains market_chart: True
Charts count: 7 (1 histogram + 4 metrics + benford + vvcorrelation)
```

Resolves #415