### PR TITLE
feat: add batch processing endpoint to Similarity Search API

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -48,4 +48,81 @@ app.post("/", async (c) => {
   return c.json({ similarity_score: similarityScore })
 })
 
+// Maximum items per batch request. Workers AI embeds one text at a time via
+// bge-base-en-v1.5, so we cap the batch to avoid hitting the 30-second CPU
+// time limit on Workers. 50 items × ~200ms each ≈ 10s, leaving headroom.
+const MAX_BATCH_SIZE = 50
+
+type BatchEntry = TextEntry & { id?: string }
+type BatchResult = {
+  id?: string
+  similarity_score: number
+}
+type BatchErrorResult = {
+  id?: string
+  error: string
+}
+
+app.post("/batch", async (c) => {
+  const body = await c.req.json<{ items: BatchEntry[] }>()
+  const { items } = body
+
+  if (!Array.isArray(items) || items.length === 0) {
+    return c.text("Invalid JSON format: 'items' must be a non-empty array", 400)
+  }
+
+  if (items.length > MAX_BATCH_SIZE) {
+    return c.text(
+      `Batch too large: maximum ${MAX_BATCH_SIZE} items per request, got ${items.length}`,
+      400
+    )
+  }
+
+  // Validate every entry upfront before doing any AI work
+  for (let i = 0; i < items.length; i++) {
+    const entry = items[i]
+    if (typeof entry.text !== "string" || typeof entry.namespace !== "string") {
+      return c.text(
+        `Invalid item at index ${i}: 'text' and 'namespace' must be strings`,
+        400
+      )
+    }
+  }
+
+  // Process items concurrently with allSettled so one failure doesn't abort
+  // the entire batch. Each item embeds independently because the bge model
+  // accepts a text array but Vectorize queries are per-namespace.
+  const results = await Promise.allSettled(
+    items.map(async (entry): Promise<BatchResult> => {
+      const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+        text: [entry.text],
+      })
+      const vector = modelResp.data[0]
+      const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
+        namespace: entry.namespace,
+        topK: 1,
+      })
+      const similarityScore = searchResponse.matches[0]?.score || 0
+      return {
+        ...(entry.id !== undefined && { id: entry.id }),
+        similarity_score: similarityScore,
+      }
+    })
+  )
+
+  const response: { results: (BatchResult | BatchErrorResult)[] } = {
+    results: results.map((r, i) => {
+      if (r.status === "fulfilled") {
+        return r.value
+      }
+      return {
+        ...(items[i].id !== undefined && { id: items[i].id }),
+        error: r.reason instanceof Error ? r.reason.message : String(r.reason),
+      }
+    }),
+  }
+
+  return c.json(response)
+})
+
 export default app

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,240 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const AUTH_HEADERS = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key",
+}
+
+// ─── Existing single-item auth test ──────────────────────────────────
+
 describe("Authentication", () => {
   it("returns 401 Unauthorized when API key is missing or invalid", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         text: "Sample text",
-        namespace: "test-namespace"
-      })
+        namespace: "test-namespace",
+      }),
     })
-
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+// ─── Batch endpoint tests ────────────────────────────────────────────
+
+describe("Batch Processing - /batch", () => {
+  // --- Authentication ---
+
+  it("returns 401 when API key is missing on /batch", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [{ text: "test", namespace: "ns" }],
+      }),
+    })
+    expect(response.status).toBe(401)
+  })
+
+  // --- Input validation ---
+
+  it("returns 400 when items is not an array", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items: "not-an-array" }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("non-empty array")
+  })
+
+  it("returns 400 when items is empty", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items: [] }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("non-empty array")
+  })
+
+  it("returns 400 when batch exceeds maximum size", async () => {
+    const items = Array.from({ length: 51 }, (_, i) => ({
+      text: `item ${i}`,
+      namespace: "ns",
+    }))
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("Batch too large")
+  })
+
+  it("returns 400 when an item has invalid text type", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({
+        items: [
+          { text: "valid", namespace: "ns" },
+          { text: 123, namespace: "ns" },
+        ],
+      }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("index 1")
+  })
+
+  it("returns 400 when an item has missing namespace", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({
+        items: [{ text: "hello" }],
+      }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("index 0")
+  })
+
+  // --- Successful batch processing ---
+
+  it("processes a single item batch successfully", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({
+        items: [{ text: "Bitcoin exchange hack", namespace: "attacks" }],
+      }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]).toHaveProperty("similarity_score")
+    expect(typeof body.results[0].similarity_score).toBe("number")
+  })
+
+  it("processes multiple items concurrently", async () => {
+    const items = [
+      { text: "Flash loan attack on DeFi protocol", namespace: "attacks" },
+      { text: "Rug pull on a memecoin project", namespace: "scams" },
+      { text: "Oracle manipulation vulnerability", namespace: "defi" },
+    ]
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results).toHaveLength(3)
+    for (const result of body.results) {
+      expect(result).toHaveProperty("similarity_score")
+      expect(typeof result.similarity_score).toBe("number")
+    }
+  })
+
+  it("preserves optional id field in results", async () => {
+    const items = [
+      { id: "msg-001", text: "Test message one", namespace: "test" },
+      { id: "msg-002", text: "Test message two", namespace: "test" },
+    ]
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results[0].id).toBe("msg-001")
+    expect(body.results[1].id).toBe("msg-002")
+  })
+
+  it("omits id field when not provided in input", async () => {
+    const items = [{ text: "No ID provided", namespace: "test" }]
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results[0]).not.toHaveProperty("id")
+    expect(body.results[0]).toHaveProperty("similarity_score")
+  })
+
+  // --- Response format ---
+
+  it("returns application/json content type for batch", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({
+        items: [{ text: "test", namespace: "ns" }],
+      }),
+    })
+    expect(response.headers.get("content-type")).toContain("application/json")
+  })
+
+  it("returns results in the same order as input items", async () => {
+    const items = Array.from({ length: 5 }, (_, i) => ({
+      id: `order-${i}`,
+      text: `Message number ${i}`,
+      namespace: "ordering-test",
+    }))
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results).toHaveLength(5)
+    for (let i = 0; i < 5; i++) {
+      expect(body.results[i].id).toBe(`order-${i}`)
+    }
+  })
+
+  // --- Mixed namespaces ---
+
+  it("handles items with different namespaces in one batch", async () => {
+    const items = [
+      { text: "Exchange security breach", namespace: "attacks" },
+      { text: "New token launch", namespace: "general" },
+      { text: "DeFi yield farming", namespace: "defi" },
+    ]
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results).toHaveLength(3)
+    for (const result of body.results) {
+      expect(typeof result.similarity_score).toBe("number")
+    }
+  })
+
+  // --- Edge cases ---
+
+  it("handles batch at maximum allowed size", async () => {
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      text: `Max batch item ${i}`,
+      namespace: "stress",
+    }))
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ items }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json<{ results: any[] }>()
+    expect(body.results).toHaveLength(50)
   })
 })


### PR DESCRIPTION
## Summary

Adds a `POST /batch` endpoint to the Similarity Search Cloudflare Worker that accepts multiple text+namespace pairs in a single request and processes them concurrently. This resolves #431.

### Implementation

**New endpoint:** `POST /batch`

**Request format:**
```json
{
  "items": [
    { "id": "msg-001", "text": "Flash loan attack on DeFi", "namespace": "attacks" },
    { "text": "Rug pull on memecoin", "namespace": "scams" }
  ]
}
```

**Response format:**
```json
{
  "results": [
    { "id": "msg-001", "similarity_score": 0.87 },
    { "similarity_score": 0.65 }
  ]
}
```

### Design Decisions

| Decision | Rationale |
|---|---|
| **50-item batch cap** | Workers AI `bge-base-en-v1.5` embeds one text at a time (~200ms). 50 items x 200ms = ~10s, leaving headroom within the 30s CPU limit |
| **`Promise.allSettled`** | One failed embedding does not abort the entire batch. Errors are returned per-item with descriptive messages |
| **Upfront validation** | All items are type-checked before any AI inference starts, preventing wasted compute on partial-valid batches |
| **Optional `id` field** | Clients can pass correlation IDs to match results to inputs without relying on array order |
| **Same auth middleware** | The `*` middleware applies to `/batch` too, so no new auth surface |
| **Preserved ordering** | Results array matches input items array index-for-index |

### Resource Efficiency

- No new external dependencies
- No new bindings required
- Concurrent processing via `Promise.allSettled` maximizes throughput within a single Worker invocation
- Batch cap prevents CPU timeout and excessive Vectorize/AI quota consumption
- Early validation avoids wasting AI inference on malformed requests

### Tests

15 Vitest integration tests for the batch endpoint:

| Category | Tests |
|---|---|
| Auth on /batch | 1 |
| Input validation | 5 (not array, empty, too large, bad type, missing field) |
| Successful processing | 4 (single, multiple, with IDs, without IDs) |
| Response format | 2 (content-type, ordering) |
| Mixed namespaces | 1 |
| Edge: max size | 1 |
| Existing auth test | 1 |

All 15 tests pass locally with `npx vitest run`.

Resolves #431