### PR TITLE
add: Africrypt alleged Bitcoin disappearance and regulatory gap (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-africrypt/index.md
+++ b/content/research/market-health/posts/2026-05-05-africrypt/index.md
@@ -10,11 +10,11 @@ entities:
 
 ## Summary
 
-1. **In April 2021, the South African cryptocurrency investment platform Africrypt ceased operations**, with its founders — brothers Ameer and Raees Cajee — informing investors that the platform had been hacked and that funds could not be recovered. The claimed losses were initially reported at approximately 69,000 BTC, valued at roughly $3.6 billion at Bitcoin's price at the time.
-2. **The actual amount of Bitcoin held by Africrypt and the true scale of losses remain disputed**. While early media reports cited the $3.6 billion figure based on investor claims and attorney statements, subsequent investigations and reporting suggested that the platform may have held significantly less than 69,000 BTC. The South African Financial Sector Conduct Authority (FSCA) noted that cryptocurrency assets were not regulated under its mandate at the time, complicating the investigation.
-3. **The Cajee brothers disappeared after announcing the alleged hack**, and their whereabouts were unknown for a period. They reportedly moved to the United Arab Emirates and other locations. South African law enforcement, including the Directorate for Priority Crime Investigation (Hawks), launched an investigation. The brothers have denied wrongdoing and claimed that a genuine hack occurred.
-4. **Africrypt's operational model exhibited characteristics commonly associated with fraudulent investment schemes**: promises of consistently high returns (reportedly 10% or more per month in some cases), limited transparency about trading strategies, encouragement of large deposits, and ultimately, a sudden cessation of operations with claims of external theft.
-5. **The case highlighted significant regulatory gaps in South Africa's cryptocurrency framework**. At the time of Africrypt's collapse, South Africa had no specific legislation governing cryptocurrency exchanges or investment platforms. The FSCA stated that it lacked jurisdiction to investigate or regulate Africrypt's cryptocurrency activities. This regulatory vacuum allowed the platform to operate without the licensing, auditing, and capital requirements that applied to traditional financial services.
+1. **In April 2021, the South African cryptocurrency investment platform Africrypt ceased operations**, with its founders — brothers Ameer and Raees Cajee — informing investors that the platform had been hacked and that funds could not be recovered. Early reports claimed approximately 69,000 BTC, valued around $3.6 billion, had vanished.
+2. **The actual amount of Bitcoin held by Africrypt and the true scale of losses remain disputed**. While early media reports cited the $3.6 billion figure based on investor and attorney statements, later reporting and official commentary suggested that the platform may have held far less than 69,000 BTC. Some later estimates range from tens of millions of dollars to a few hundred million dollars, but no comprehensive public proof-of-reserves or forensic accounting record has settled the number.
+3. **The Cajee brothers became unreachable after announcing the alleged hack**, and their whereabouts were unclear for a period. They were later reported in other jurisdictions, including the United Arab Emirates and Switzerland. South African law enforcement, including the Directorate for Priority Crime Investigation (Hawks), investigated the matter. The brothers have denied wrongdoing and claimed that a genuine hack occurred.
+4. **Africrypt's operational model exhibited characteristics commonly associated with fraudulent investment schemes**: promises of consistently high returns (reportedly 10-13% per month in some accounts), limited transparency about trading strategies, encouragement of large deposits, and ultimately a sudden cessation of operations with claims of external theft.
+5. **The case highlighted significant regulatory gaps in South Africa's cryptocurrency framework**. At the time of Africrypt's collapse, crypto assets were not yet declared financial products under South Africa's FAIS Act. The FSCA stated that this limited its jurisdiction over Africrypt's cryptocurrency activities. That gap meant customers had fewer regulatory protections than they would have had with licensed financial-service providers.
 
 ## Background
 
@@ -38,9 +38,9 @@ Key operational characteristics:
 | FSCA jurisdiction over crypto | Limited; crypto assets outside the Financial Advisory and Intermediary Services Act |
 | Exchange licensing requirements | None specific to cryptocurrency |
 | Investor protection | Traditional financial protections did not extend to cryptocurrency investments |
-| Reserve Bank position | Recognized cryptocurrency as a "cyber-token" but not legal tender |
+| Reserve Bank position | Crypto assets were not legal tender |
 
-South Africa had become one of Africa's largest cryptocurrency markets by 2021, with significant retail adoption. However, the regulatory framework had not kept pace with market growth, creating gaps that operators like Africrypt could exploit.
+South Africa had significant cryptocurrency adoption by 2021. However, the regulatory framework had not kept pace with market growth, creating gaps that high-risk operators could exploit.
 
 ## Timeline of Events
 
@@ -55,14 +55,14 @@ South Africa had become one of Africa's largest cryptocurrency markets by 2021, 
 | June 2021 | FSCA states it lacks jurisdiction over cryptocurrency losses |
 | June 2021 | Hawks (DPCI) opens investigation |
 | June-July 2021 | Cajee brothers reportedly leave South Africa |
-| 2021-2022 | Investigation continues; brothers' location reportedly tracked to UAE and other jurisdictions |
-| 2022-2023 | Legal proceedings continue; exact fund recovery and location of Bitcoin remains unclear |
+| 2021-2022 | Investigation continues; brothers' location reportedly tracked to UAE, Switzerland, and other jurisdictions |
+| 2022-2026 | Legal proceedings and reporting continue; exact fund recovery and location of Bitcoin remains unclear |
 
 ### The "Hack" Claim
 
 When Africrypt ceased operations, the Cajee brothers communicated to investors that:
 - The platform had been the victim of a sophisticated hack
-- All funds, including investor Bitcoin, had been stolen
+- Investor funds had been taken in a hack or were otherwise unrecoverable
 - Investors should not report the incident to authorities, as this would complicate and slow the recovery process
 - The team was working on recovery
 
@@ -72,26 +72,26 @@ The request that investors not contact authorities was widely viewed as a red fl
 
 ### Red Flags Consistent with Fraudulent Schemes
 
-Africrypt's operations exhibited multiple characteristics commonly associated with Ponzi schemes and investment fraud:
+Africrypt's operations exhibited multiple characteristics commonly associated with Ponzi-like schemes and investment fraud:
 
 1. **Unsustainable return promises**: Monthly returns of 10% compound to approximately 214% annually — far exceeding any sustainable trading strategy and exceeding even the most volatile cryptocurrency market returns on a consistent basis.
 
-2. **Opaque trading strategy**: The platform attributed returns to AI-driven trading and arbitrage but did not provide verifiable evidence of trading activity, audited performance records, or detailed strategy descriptions.
+2. **Opaque trading strategy**: The platform attributed returns to AI-driven trading and arbitrage but did not provide public proof of trading activity, audited performance records, or detailed strategy descriptions.
 
 3. **Age and experience of founders**: The founders were notably young and had limited documented experience in financial services or institutional trading. While age alone is not disqualifying, the combination of youth, extraordinary return claims, and large sums under management was unusual.
 
 4. **Discouragement of regulatory reporting**: The explicit request that investors not contact authorities after the claimed hack is inconsistent with legitimate platform behavior and is a recognized pattern in exit scams.
 
-5. **Sudden cessation**: The abrupt shutdown with claims of external theft follows the classic pattern of investment frauds that collapse when new investor inflows become insufficient to pay promised returns to existing investors.
+5. **Sudden cessation**: The abrupt shutdown with claims of external theft resembles a common pattern in investment frauds that fail when new investor inflows cannot cover promised returns to existing investors.
 
-6. **Withdrawal difficulties before collapse**: Some investors reportedly experienced increasing delays in processing withdrawals in the weeks before the platform ceased operations — a pattern often observed in the terminal phase of Ponzi schemes.
+6. **Withdrawal difficulties before collapse**: Some investors reportedly experienced increasing delays in processing withdrawals in the weeks before the platform ceased operations — a pattern often observed in the terminal phase of Ponzi-like schemes.
 
 ### Ponzi Scheme Economics
 
-If Africrypt operated as a Ponzi scheme (paying existing investors with new investor deposits rather than actual trading profits), the math of its collapse was predictable:
+If Africrypt operated as a Ponzi-like scheme (paying existing investors with new investor deposits rather than actual trading profits), the economics would have been fragile:
 
 - **At 10% monthly returns**: The platform needed to grow its deposit base by at least 10% per month just to meet return obligations, before accounting for any operational costs or founder withdrawals
-- **Sustainability threshold**: Ponzi schemes collapse when new inflows cannot cover outflow obligations. The larger the fund grows, the larger the absolute dollar amount of new deposits required each month
+- **Sustainability threshold**: Ponzi-like schemes fail when new inflows cannot cover outflow obligations. The larger a fund grows, the larger the absolute dollar amount of new deposits required each month
 - **Bitcoin price appreciation**: Rising Bitcoin prices in 2020-2021 may have temporarily masked the scheme's insolvency, as investors measuring returns in BTC terms could see their investment appreciate through Bitcoin price gains rather than actual trading profits
 
 ## Disputed Loss Figures
@@ -103,31 +103,32 @@ The headline figure of approximately 69,000 BTC (~$3.6 billion) was widely repor
 | Source | Claimed Amount |
 |--------|---------------|
 | Initial media reports | ~69,000 BTC (~$3.6B) |
-| Hanekom Attorneys (investor law firm) | Approximately 69,000 BTC |
-| Cajee brothers (disputed) | Significantly less than reported |
-| Independent verification | Not publicly available |
+| Hanekom Attorneys / investor-side statements | Approximately 69,000 BTC reported in early coverage |
+| Later FSCA / complaint-based floor cited in reporting | Far lower, around tens of millions of dollars |
+| Later liquidator / ledger-based upper estimates cited in reporting | Up to a few hundred million dollars |
+| Independent public verification | Not publicly available |
 
 **Reasons for uncertainty**:
 
-1. **No audited records**: Africrypt did not publish audited financial statements or proof-of-reserves. The 69,000 BTC figure appears to have originated from investor estimates and attorney statements rather than independently verified records.
+1. **No audited records**: Africrypt did not publish audited financial statements or proof-of-reserves. The 69,000 BTC figure appears to have originated from investor estimates and attorney statements rather than independently verified public records.
 
-2. **Inflated by paper returns**: If Africrypt was a Ponzi scheme, investor "balances" shown on the platform included fictitious returns that were never backed by actual Bitcoin. The real Bitcoin holdings may have been substantially less than the sum of investor account balances.
+2. **Inflated by paper returns**: If Africrypt was a Ponzi-like scheme, investor "balances" shown on the platform may have included fictitious returns that were not backed by actual Bitcoin. The real Bitcoin holdings may have been substantially less than the sum of investor account balances.
 
 3. **Bitcoin price variability**: The $3.6 billion valuation depended on Bitcoin's price at a specific date. At different points, the same BTC amount would be valued very differently.
 
-4. **Difficulty of on-chain verification**: While Bitcoin blockchain analysis could potentially identify Africrypt's wallet addresses and trace fund flows, no comprehensive public analysis has definitively established how much Bitcoin the platform actually held.
+4. **Difficulty of on-chain verification**: While Bitcoin blockchain analysis can trace known wallet addresses, no comprehensive public analysis has established how much Bitcoin Africrypt actually controlled.
 
 ### Comparison to Other Alleged Crypto Ponzi Schemes
 
 | Scheme | Date | Claimed Loss | Verified Loss | Jurisdiction |
 |--------|------|-------------|---------------|-------------|
-| Africrypt | 2021 | ~$3.6B (disputed) | Unverified | South Africa |
+| Africrypt | 2021 | ~$3.6B (disputed) | Not publicly settled | South Africa |
 | BitConnect | 2016-2018 | ~$2.4B | SEC: ~$2.4B | Global (India-linked) |
 | OneCoin | 2014-2019 | ~$4B+ | DOJ: €4B+ | Global (Bulgaria-linked) |
 | PlusToken | 2018-2019 | ~$3B | Chinese courts: ~$5.7B | China |
-| Mirror Trading International | 2019-2020 | ~$588M | Liquidators investigating | South Africa |
+| Mirror Trading International | 2019-2020 | Hundreds of millions to $1B+ reported | Liquidation / enforcement proceedings | South Africa |
 
-South Africa experienced two major alleged cryptocurrency Ponzi schemes in close succession (Mirror Trading International in 2020 and Africrypt in 2021), highlighting the country's particular vulnerability to cryptocurrency fraud during this period.
+South Africa experienced two major alleged cryptocurrency investment-scheme collapses in close succession (Mirror Trading International in 2020 and Africrypt in 2021), highlighting the importance of crypto-specific conduct supervision during this period.
 
 ## Fund Tracing Challenges
 
@@ -136,42 +137,42 @@ South Africa experienced two major alleged cryptocurrency Ponzi schemes in close
 Tracing Africrypt's Bitcoin presented several challenges:
 
 1. **Potential mixing**: Reports suggest that Bitcoin from Africrypt may have been moved through mixing services or numerous intermediate wallets to obscure the trail
-2. **Cross-jurisdictional movement**: Funds may have been moved to exchanges in jurisdictions with limited cooperation with South African authorities
+2. **Cross-jurisdictional movement**: Funds may have been moved to exchanges or custody locations outside South Africa, complicating recovery
 3. **Bitcoin's pseudonymity**: While Bitcoin transactions are publicly visible, linking addresses to real-world identities requires cooperation from exchanges and service providers
-4. **Time elapsed**: The longer funds remain in motion, the more dispersed they become, making recovery increasingly difficult
+4. **Time elapsed**: The longer funds remain in motion, the more dispersed they can become, making recovery increasingly difficult
 
 ### Legal and Jurisdictional Challenges
 
-- **Regulatory gap**: The FSCA's lack of jurisdiction over cryptocurrency meant that the primary financial regulator could not compel Africrypt to disclose records or freeze assets
+- **Regulatory gap**: The FSCA's limited jurisdiction over crypto assets at the time reduced the primary conduct regulator's ability to use ordinary financial-sector tools against Africrypt
 - **Cross-border complexity**: The Cajee brothers' reported movement to the UAE and potentially other jurisdictions introduced cross-border legal complexities
 - **Mutual legal assistance**: International cooperation in cryptocurrency fraud cases, while improving, remained slow and procedurally complex in 2021-2022
-- **South African crypto regulation (post-Africrypt)**: In 2022, South Africa moved to classify cryptocurrency assets as financial products under FSCA oversight, directly influenced by the Africrypt and Mirror Trading International incidents
+- **South African crypto regulation (post-Africrypt)**: In October 2022, the FSCA declared crypto assets to be financial products under the FAIS Act, bringing crypto-asset service providers into a clearer licensing and conduct framework
 
 ## Regulatory Response
 
 ### South African Regulatory Evolution
 
-The Africrypt collapse directly contributed to South Africa's regulatory response to cryptocurrency:
+Africrypt and Mirror Trading International became high-profile examples cited in South Africa's broader regulatory response to cryptocurrency:
 
-1. **Intergovernmental Fintech Working Group (IFWG)**: Published position papers on crypto asset regulation, accelerated by the Africrypt and MTI cases
+1. **Intergovernmental Fintech Working Group (IFWG)**: Published position papers on crypto asset regulation amid growing concern about crypto fraud and consumer protection
 2. **FSCA Declaration (October 2022)**: Crypto assets declared as financial products, bringing them under FSCA regulation
-3. **Licensing requirements**: Cryptocurrency service providers required to apply for Financial Service Provider (FSP) licenses
-4. **Consumer protection**: Regulated crypto service providers subject to conduct standards, capital requirements, and record-keeping obligations
+3. **Licensing requirements**: Crypto asset service providers brought into licensing expectations under the FAIS framework
+4. **Consumer protection**: Regulated crypto service providers became subject to conduct and record-keeping obligations, with broader AML/CFT obligations developing through related frameworks
 
 ### Impact on African Cryptocurrency Regulation
 
-The Africrypt case influenced cryptocurrency regulation discussions across the African continent:
-- **Nigeria**: Central Bank of Nigeria's approach to cryptocurrency regulation was shaped partly by awareness of fraud cases in neighboring jurisdictions
-- **Kenya**: Kenya's Capital Markets Authority referenced regional fraud cases in its cryptocurrency regulation development
-- **Pan-African**: The African Union's engagement with cryptocurrency policy acknowledged the need for cross-border regulatory coordination to prevent fraudsters from exploiting jurisdictional gaps
+The Africrypt case also became a regional cautionary example:
+- **Investor-protection framing**: It demonstrated how retail and high-net-worth investors can be exposed when deposit-taking crypto platforms operate outside licensing regimes
+- **Cross-border enforcement**: Reported movement of founders and assets across jurisdictions showed why fraud investigations require international cooperation
+- **Regulatory perimeter design**: The case illustrated the risk of platforms presenting investment products while claiming to sit outside traditional financial regulation
 
 ## Lessons for Market Surveillance
 
-1. **Return sustainability analysis**: Any cryptocurrency investment platform promising consistent monthly returns above normal market rates (e.g., >5% per month sustained) should be flagged for enhanced scrutiny. The mathematical unsustainability of such returns is the strongest predictor of Ponzi scheme collapse.
+1. **Return sustainability analysis**: Any cryptocurrency investment platform promising consistent monthly returns above normal market rates (e.g., >5% per month sustained) should be flagged for enhanced scrutiny. The mathematical pressure created by such returns is a strong warning sign for Ponzi-like schemes.
 
 2. **Proof-of-reserves verification**: Platforms that accept significant customer deposits but do not provide verifiable proof of reserves (on-chain attestation, third-party audits) present elevated risk. Surveillance systems should track which platforms provide proof-of-reserves and flag those that do not.
 
-3. **Withdrawal pattern monitoring**: Increasing withdrawal delays before a platform collapse are a leading indicator. If a platform's on-chain transaction patterns show declining outflows relative to inflows, this may signal liquidity problems consistent with a Ponzi scheme approaching insolvency.
+3. **Withdrawal pattern monitoring**: Increasing withdrawal delays before a platform collapse are a leading indicator. If a platform's on-chain transaction patterns show declining outflows relative to inflows, this may signal liquidity problems consistent with a Ponzi-like scheme approaching insolvency.
 
 4. **Regulatory status tracking**: Platforms operating in jurisdictions without cryptocurrency regulation — or in regulated jurisdictions without the required licenses — present higher risk. Surveillance should maintain a database of platform regulatory status across jurisdictions.
 

--- a/content/research/market-health/posts/2026-05-05-africrypt/index.md
+++ b/content/research/market-health/posts/2026-05-05-africrypt/index.md
@@ -1,0 +1,189 @@
+---
+title: "🌰 Africrypt — Alleged $3.6B Bitcoin Disappearance and South African Exchange Collapse"
+date: 2026-05-05
+entities:
+  - Africrypt
+  - Bitcoin
+  - South Africa
+  - Hawks (DPCI)
+---
+
+## Summary
+
+1. **In April 2021, the South African cryptocurrency investment platform Africrypt ceased operations**, with its founders — brothers Ameer and Raees Cajee — informing investors that the platform had been hacked and that funds could not be recovered. The claimed losses were initially reported at approximately 69,000 BTC, valued at roughly $3.6 billion at Bitcoin's price at the time.
+2. **The actual amount of Bitcoin held by Africrypt and the true scale of losses remain disputed**. While early media reports cited the $3.6 billion figure based on investor claims and attorney statements, subsequent investigations and reporting suggested that the platform may have held significantly less than 69,000 BTC. The South African Financial Sector Conduct Authority (FSCA) noted that cryptocurrency assets were not regulated under its mandate at the time, complicating the investigation.
+3. **The Cajee brothers disappeared after announcing the alleged hack**, and their whereabouts were unknown for a period. They reportedly moved to the United Arab Emirates and other locations. South African law enforcement, including the Directorate for Priority Crime Investigation (Hawks), launched an investigation. The brothers have denied wrongdoing and claimed that a genuine hack occurred.
+4. **Africrypt's operational model exhibited characteristics commonly associated with fraudulent investment schemes**: promises of consistently high returns (reportedly 10% or more per month in some cases), limited transparency about trading strategies, encouragement of large deposits, and ultimately, a sudden cessation of operations with claims of external theft.
+5. **The case highlighted significant regulatory gaps in South Africa's cryptocurrency framework**. At the time of Africrypt's collapse, South Africa had no specific legislation governing cryptocurrency exchanges or investment platforms. The FSCA stated that it lacked jurisdiction to investigate or regulate Africrypt's cryptocurrency activities. This regulatory vacuum allowed the platform to operate without the licensing, auditing, and capital requirements that applied to traditional financial services.
+
+## Background
+
+### Africrypt's Operations
+
+Africrypt was founded in 2019 by Ameer Cajee (reportedly 17 years old at the time of founding) and his brother Raees Cajee (reportedly in his early 20s). The platform was based in Durban, South Africa, and presented itself as a cryptocurrency investment and trading platform.
+
+Key operational characteristics:
+
+- **Investment model**: Investors deposited Bitcoin or South African Rand (converted to Bitcoin) with the platform
+- **Promised returns**: Reports indicate that Africrypt promised high monthly returns, with some accounts citing 10% per month or higher
+- **Trading strategy claims**: The platform attributed its returns to AI-driven trading algorithms and cryptocurrency arbitrage
+- **Client base**: Investors included high-net-worth individuals, family offices, and retail investors in South Africa
+- **Minimum investment**: Reports suggest minimum investments of 1 million ZAR (approximately $70,000 USD at the time) for some tiers
+
+### South African Cryptocurrency Context (2021)
+
+| Aspect | Status |
+|--------|--------|
+| Cryptocurrency regulation | No specific legislation; crypto not classified as financial product |
+| FSCA jurisdiction over crypto | Limited; crypto assets outside the Financial Advisory and Intermediary Services Act |
+| Exchange licensing requirements | None specific to cryptocurrency |
+| Investor protection | Traditional financial protections did not extend to cryptocurrency investments |
+| Reserve Bank position | Recognized cryptocurrency as a "cyber-token" but not legal tender |
+
+South Africa had become one of Africa's largest cryptocurrency markets by 2021, with significant retail adoption. However, the regulatory framework had not kept pace with market growth, creating gaps that operators like Africrypt could exploit.
+
+## Timeline of Events
+
+| Date | Event |
+|------|-------|
+| 2019 | Africrypt founded by Ameer and Raees Cajee in Durban |
+| 2019-2021 | Platform operates, reportedly generating high returns for early investors |
+| April 13, 2021 | Africrypt informs investors of a security breach; requests that investors not report to authorities (claiming it would slow recovery) |
+| April 2021 | Investors unable to access funds or contact Africrypt |
+| Late April 2021 | Investors engage law firm Hanekom Attorneys to investigate |
+| June 2021 | Media reports emerge citing approximately 69,000 BTC (~$3.6B) in losses |
+| June 2021 | FSCA states it lacks jurisdiction over cryptocurrency losses |
+| June 2021 | Hawks (DPCI) opens investigation |
+| June-July 2021 | Cajee brothers reportedly leave South Africa |
+| 2021-2022 | Investigation continues; brothers' location reportedly tracked to UAE and other jurisdictions |
+| 2022-2023 | Legal proceedings continue; exact fund recovery and location of Bitcoin remains unclear |
+
+### The "Hack" Claim
+
+When Africrypt ceased operations, the Cajee brothers communicated to investors that:
+- The platform had been the victim of a sophisticated hack
+- All funds, including investor Bitcoin, had been stolen
+- Investors should not report the incident to authorities, as this would complicate and slow the recovery process
+- The team was working on recovery
+
+The request that investors not contact authorities was widely viewed as a red flag. In legitimate security incidents, victims and platforms typically cooperate with law enforcement and are transparent about the situation.
+
+## Analysis of Africrypt's Operating Model
+
+### Red Flags Consistent with Fraudulent Schemes
+
+Africrypt's operations exhibited multiple characteristics commonly associated with Ponzi schemes and investment fraud:
+
+1. **Unsustainable return promises**: Monthly returns of 10% compound to approximately 214% annually — far exceeding any sustainable trading strategy and exceeding even the most volatile cryptocurrency market returns on a consistent basis.
+
+2. **Opaque trading strategy**: The platform attributed returns to AI-driven trading and arbitrage but did not provide verifiable evidence of trading activity, audited performance records, or detailed strategy descriptions.
+
+3. **Age and experience of founders**: The founders were notably young and had limited documented experience in financial services or institutional trading. While age alone is not disqualifying, the combination of youth, extraordinary return claims, and large sums under management was unusual.
+
+4. **Discouragement of regulatory reporting**: The explicit request that investors not contact authorities after the claimed hack is inconsistent with legitimate platform behavior and is a recognized pattern in exit scams.
+
+5. **Sudden cessation**: The abrupt shutdown with claims of external theft follows the classic pattern of investment frauds that collapse when new investor inflows become insufficient to pay promised returns to existing investors.
+
+6. **Withdrawal difficulties before collapse**: Some investors reportedly experienced increasing delays in processing withdrawals in the weeks before the platform ceased operations — a pattern often observed in the terminal phase of Ponzi schemes.
+
+### Ponzi Scheme Economics
+
+If Africrypt operated as a Ponzi scheme (paying existing investors with new investor deposits rather than actual trading profits), the math of its collapse was predictable:
+
+- **At 10% monthly returns**: The platform needed to grow its deposit base by at least 10% per month just to meet return obligations, before accounting for any operational costs or founder withdrawals
+- **Sustainability threshold**: Ponzi schemes collapse when new inflows cannot cover outflow obligations. The larger the fund grows, the larger the absolute dollar amount of new deposits required each month
+- **Bitcoin price appreciation**: Rising Bitcoin prices in 2020-2021 may have temporarily masked the scheme's insolvency, as investors measuring returns in BTC terms could see their investment appreciate through Bitcoin price gains rather than actual trading profits
+
+## Disputed Loss Figures
+
+### The $3.6 Billion Question
+
+The headline figure of approximately 69,000 BTC (~$3.6 billion) was widely reported in media but has been subject to significant uncertainty:
+
+| Source | Claimed Amount |
+|--------|---------------|
+| Initial media reports | ~69,000 BTC (~$3.6B) |
+| Hanekom Attorneys (investor law firm) | Approximately 69,000 BTC |
+| Cajee brothers (disputed) | Significantly less than reported |
+| Independent verification | Not publicly available |
+
+**Reasons for uncertainty**:
+
+1. **No audited records**: Africrypt did not publish audited financial statements or proof-of-reserves. The 69,000 BTC figure appears to have originated from investor estimates and attorney statements rather than independently verified records.
+
+2. **Inflated by paper returns**: If Africrypt was a Ponzi scheme, investor "balances" shown on the platform included fictitious returns that were never backed by actual Bitcoin. The real Bitcoin holdings may have been substantially less than the sum of investor account balances.
+
+3. **Bitcoin price variability**: The $3.6 billion valuation depended on Bitcoin's price at a specific date. At different points, the same BTC amount would be valued very differently.
+
+4. **Difficulty of on-chain verification**: While Bitcoin blockchain analysis could potentially identify Africrypt's wallet addresses and trace fund flows, no comprehensive public analysis has definitively established how much Bitcoin the platform actually held.
+
+### Comparison to Other Alleged Crypto Ponzi Schemes
+
+| Scheme | Date | Claimed Loss | Verified Loss | Jurisdiction |
+|--------|------|-------------|---------------|-------------|
+| Africrypt | 2021 | ~$3.6B (disputed) | Unverified | South Africa |
+| BitConnect | 2016-2018 | ~$2.4B | SEC: ~$2.4B | Global (India-linked) |
+| OneCoin | 2014-2019 | ~$4B+ | DOJ: €4B+ | Global (Bulgaria-linked) |
+| PlusToken | 2018-2019 | ~$3B | Chinese courts: ~$5.7B | China |
+| Mirror Trading International | 2019-2020 | ~$588M | Liquidators investigating | South Africa |
+
+South Africa experienced two major alleged cryptocurrency Ponzi schemes in close succession (Mirror Trading International in 2020 and Africrypt in 2021), highlighting the country's particular vulnerability to cryptocurrency fraud during this period.
+
+## Fund Tracing Challenges
+
+### On-Chain Investigation Difficulties
+
+Tracing Africrypt's Bitcoin presented several challenges:
+
+1. **Potential mixing**: Reports suggest that Bitcoin from Africrypt may have been moved through mixing services or numerous intermediate wallets to obscure the trail
+2. **Cross-jurisdictional movement**: Funds may have been moved to exchanges in jurisdictions with limited cooperation with South African authorities
+3. **Bitcoin's pseudonymity**: While Bitcoin transactions are publicly visible, linking addresses to real-world identities requires cooperation from exchanges and service providers
+4. **Time elapsed**: The longer funds remain in motion, the more dispersed they become, making recovery increasingly difficult
+
+### Legal and Jurisdictional Challenges
+
+- **Regulatory gap**: The FSCA's lack of jurisdiction over cryptocurrency meant that the primary financial regulator could not compel Africrypt to disclose records or freeze assets
+- **Cross-border complexity**: The Cajee brothers' reported movement to the UAE and potentially other jurisdictions introduced cross-border legal complexities
+- **Mutual legal assistance**: International cooperation in cryptocurrency fraud cases, while improving, remained slow and procedurally complex in 2021-2022
+- **South African crypto regulation (post-Africrypt)**: In 2022, South Africa moved to classify cryptocurrency assets as financial products under FSCA oversight, directly influenced by the Africrypt and Mirror Trading International incidents
+
+## Regulatory Response
+
+### South African Regulatory Evolution
+
+The Africrypt collapse directly contributed to South Africa's regulatory response to cryptocurrency:
+
+1. **Intergovernmental Fintech Working Group (IFWG)**: Published position papers on crypto asset regulation, accelerated by the Africrypt and MTI cases
+2. **FSCA Declaration (October 2022)**: Crypto assets declared as financial products, bringing them under FSCA regulation
+3. **Licensing requirements**: Cryptocurrency service providers required to apply for Financial Service Provider (FSP) licenses
+4. **Consumer protection**: Regulated crypto service providers subject to conduct standards, capital requirements, and record-keeping obligations
+
+### Impact on African Cryptocurrency Regulation
+
+The Africrypt case influenced cryptocurrency regulation discussions across the African continent:
+- **Nigeria**: Central Bank of Nigeria's approach to cryptocurrency regulation was shaped partly by awareness of fraud cases in neighboring jurisdictions
+- **Kenya**: Kenya's Capital Markets Authority referenced regional fraud cases in its cryptocurrency regulation development
+- **Pan-African**: The African Union's engagement with cryptocurrency policy acknowledged the need for cross-border regulatory coordination to prevent fraudsters from exploiting jurisdictional gaps
+
+## Lessons for Market Surveillance
+
+1. **Return sustainability analysis**: Any cryptocurrency investment platform promising consistent monthly returns above normal market rates (e.g., >5% per month sustained) should be flagged for enhanced scrutiny. The mathematical unsustainability of such returns is the strongest predictor of Ponzi scheme collapse.
+
+2. **Proof-of-reserves verification**: Platforms that accept significant customer deposits but do not provide verifiable proof of reserves (on-chain attestation, third-party audits) present elevated risk. Surveillance systems should track which platforms provide proof-of-reserves and flag those that do not.
+
+3. **Withdrawal pattern monitoring**: Increasing withdrawal delays before a platform collapse are a leading indicator. If a platform's on-chain transaction patterns show declining outflows relative to inflows, this may signal liquidity problems consistent with a Ponzi scheme approaching insolvency.
+
+4. **Regulatory status tracking**: Platforms operating in jurisdictions without cryptocurrency regulation — or in regulated jurisdictions without the required licenses — present higher risk. Surveillance should maintain a database of platform regulatory status across jurisdictions.
+
+5. **Founder and operator due diligence**: Cryptocurrency investment platforms operated by individuals with limited verifiable professional history, operating without institutional backing, and making extraordinary return claims represent the highest-risk category.
+
+6. **Cross-scheme pattern matching**: South Africa experienced two major alleged crypto Ponzi collapses (MTI and Africrypt) within 12 months. Surveillance systems should monitor for clustering of similar scheme types within a jurisdiction, as this may indicate a regulatory environment that is particularly vulnerable to a specific type of fraud.
+
+## References
+
+1. Bloomberg. "Africrypt Bitcoin Worth Billions Vanishes, Brothers Nowhere to Be Found." Bloomberg, June 23, 2021.
+2. Financial Sector Conduct Authority (FSCA). "FSCA Statement on Africrypt." FSCA Media Release, June 2021.
+3. Hanekom Attorneys. "Africrypt Investor Legal Proceedings." Public statements, June 2021.
+4. Reuters. "South Africa to Regulate Crypto Assets as Financial Products." Reuters, October 2022.
+5. CoinDesk. "The Africrypt Saga: Inside South Africa's Biggest Alleged Crypto Fraud." CoinDesk, 2021.
+6. Chainalysis. "The 2022 Crypto Crime Report." Chapter: Scams. Chainalysis Inc., February 2022.


### PR DESCRIPTION
Contribution to #277.

Adds a market-health incident writeup on the Africrypt platform collapse:

- Incident type: alleged exit scam / platform collapse with disputed Bitcoin loss figures.
- Claimed loss: early reports cited 69,000 BTC / roughly $3.6B, but later reporting disputes that headline number and suggests much lower verified or documented ranges.
- Operators: Ameer and Raees Cajee; they denied wrongdoing and claimed Africrypt was hacked.
- Risk signals: high monthly return claims, AI-trading narrative, no public proof-of-reserves, withdrawal/reporting friction, and limited transparency.
- Regulatory angle: South Africa's FSCA said crypto assets were outside its ordinary jurisdiction in 2021; the case highlighted the gap before the 2022 crypto-as-financial-product declaration.

Payout can be BTC, Lightning, or stablecoin if accepted.