### PR TITLE
add: Warp Finance LP-token oracle manipulation (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-warp-finance/index.md
+++ b/content/research/market-health/posts/2026-05-05-warp-finance/index.md
@@ -13,7 +13,7 @@ entities:
   - id: maker
     name: MakerDAO
     type: defi
-title: "Warp Finance flash-loan LP-token oracle manipulation and $7.7 M lending-protocol drain"
+title: "Warp Finance flash-loan LP-token oracle manipulation and $7.7M lending-protocol drain"
 ---
 
 ## 1. Introduction and incident overview
@@ -34,7 +34,7 @@ Warp Finance's value proposition was that LP tokens represent productive capital
 
 A Uniswap V2 LP token represents a pro-rata claim on the two assets held in a trading pair's pool. The value of an LP token is a function of the pool's total reserves and the prices of both constituent assets. For a pool with reserves (R_x, R_y) and total LP supply S, each LP token represents a claim on (R_x / S) of asset X and (R_y / S) of asset Y.
 
-The key vulnerability arises from how these reserves change during large trades. Uniswap V2 uses a constant-product AMM (x * y = k), so a large trade that buys asset X from the pool increases R_y and decreases R_x. If the LP-token valuation uses the pool's current reserve ratio as a price input — reading the reserves at the moment of the collateral evaluation — then a large trade immediately before the evaluation can artificially inflate the apparent value of the LP token.
+The key vulnerability arises from how these reserves change during large trades. Uniswap V2 uses a constant-product AMM (x * y = k), so a large trade can sharply distort the reserve mix and implied spot prices. If the LP-token valuation uses the pool's current reserves or reserve-implied spot prices at the moment of collateral evaluation, then a large trade immediately before the evaluation can artificially inflate the apparent value of the LP token.
 
 ### 2.3 Warp Finance's oracle design
 
@@ -54,23 +54,23 @@ The attack was executed in a single Ethereum transaction. The sequence of operat
 
 **Step 1 — Flash-loan acquisition**: The attacker borrowed a large quantity of WETH (wrapped Ether) via a flash loan from dYdX. The borrowed amount was sufficient to significantly move the reserves in the targeted Uniswap V2 pool.
 
-**Step 2 — LP-token acquisition**: The attacker used a portion of the flash-loaned WETH to provide liquidity to the Uniswap V2 WETH/DAI pool, receiving LP tokens in return.
+**Step 2 — LP-token acquisition**: The attacker used a portion of the flash-loaned assets to provide liquidity to the Uniswap V2 WETH/DAI pool, receiving LP tokens in return.
 
-**Step 3 — Reserve manipulation**: The attacker executed a large swap on the same Uniswap V2 WETH/DAI pool, selling a substantial amount of WETH for DAI. This swap dramatically shifted the pool's reserve ratio, increasing the DAI reserves and decreasing the WETH reserves. Because the constant-product formula requires the product of reserves to remain constant, the trade moved the pool to a state where each LP token (which represents a fixed fraction of the total reserves) appeared to hold significantly more DAI than before the swap.
+**Step 3 — Reserve manipulation**: The attacker executed large swaps around the same Uniswap V2 WETH/DAI pool. These swaps dramatically shifted the pool's reserve ratio and the reserve-implied spot price. Because Warp read manipulable pool state during the same transaction, the LP tokens appeared to support a much larger borrowing capacity than their fair value would justify after the manipulation unwound.
 
 **Step 4 — Inflated collateral deposit**: The attacker deposited the LP tokens obtained in Step 2 into Warp Finance as collateral. Warp Finance's oracle queried the Uniswap pool's reserves at this moment — after the manipulative swap in Step 3 — and valued the LP tokens at their inflated, post-manipulation price.
 
 **Step 5 — Maximum borrowing**: Based on the inflated collateral valuation, the attacker borrowed the maximum available DAI and USDC from Warp Finance's lending pools — approximately $7.7 million in stablecoins.
 
-**Step 6 — Unwinding and flash-loan repayment**: The attacker reversed the reserve-manipulation swap (buying back WETH with DAI) to recover most of the flash-loaned capital, repaid the dYdX flash loan, and retained the approximately $7.7 million in borrowed stablecoins. The LP tokens deposited as collateral were abandoned — their value, once the pool reserves returned to normal, was far less than the borrowed amount.
+**Step 6 — Unwinding and flash-loan repayment**: The attacker unwound the price manipulation enough to repay the flash loans and retained the borrowed stablecoins. The LP tokens deposited as collateral remained in Warp, but their recoverable value after the pool state normalized was far below the stablecoins borrowed against them.
 
 ### 3.2 Net extraction
 
-The net profit was the difference between the borrowed stablecoins ($7.7M) and the cost of the abandoned LP tokens plus flash-loan fees and gas costs. Because the LP tokens were acquired with a portion of the flash-loaned capital and their value after the manipulation reversal was minimal, the attacker's net extraction was approximately the full $7.7 million minus gas and fees — effectively the vast majority of the borrowed amount.
+The net extraction was the difference between the borrowed stablecoins and the recoverable value of the LP-token collateral plus flash-loan fees, trading costs, and gas. Public reporting commonly described the stablecoin drain at roughly $7.7-$7.8 million before later recovery of a substantial portion of the attacker's collateral.
 
 ### 3.3 Post-exploit fund movement
 
-The attacker moved the stolen stablecoins through several Ethereum addresses. A portion was later returned: Warp Finance reported that approximately $5.85 million in WETH collateral was recovered, either through negotiation or because the attacker's unwinding transactions left recoverable value. The net loss to Warp Finance depositors, after recovery, was approximately $1.85 million.
+The attacker moved the borrowed stablecoins through several Ethereum addresses. Warp Finance later reported that it recovered approximately $5.85 million of value from the collateral left in the protocol after the attack, using its liquidation path after the relevant timelock expired. The reported net unrecovered loss was therefore roughly $1.8-$2.0 million, depending on asset prices and accounting treatment.
 
 ## 4. Why the attack succeeded
 
@@ -98,15 +98,15 @@ Research published after the Warp Finance attack (and several similar incidents)
 
 ### 5.1 Immediate actions
 
-Warp Finance paused all protocol operations immediately after detecting the exploit. The team published a post-mortem within 48 hours, identifying the spot-reserve oracle as the root cause and acknowledging that the LP-token pricing mechanism was insufficient to resist flash-loan manipulation.
+Warp Finance paused protocol operations after detecting the exploit. Public post-incident communications and independent analyses identified flash-loan-manipulable LP-token pricing as the core weakness and showed that the collateral valuation mechanism was insufficient to resist within-transaction reserve manipulation.
 
 ### 5.2 Fund recovery
 
-The team reported recovering approximately $5.85 million of the $7.7 million extracted, representing WETH that remained in the protocol's collateral pool after the attacker's unwinding transactions. The recovery reduced the net loss to approximately $1.85 million, which was borne by stablecoin depositors whose DAI and USDC could not be fully repaid.
+The team reported recovering approximately $5.85 million of value from collateral left in the protocol, often described as about 75% of the original stablecoin drain. The recovery reduced the net unrecovered loss to roughly $1.85 million, with affected users receiving recovered funds and remaining claims handled through the project's recovery plan.
 
 ### 5.3 Protocol redesign
 
-Warp Finance announced plans to redesign its oracle system using Chainlink price feeds and secure LP-token pricing formulas. The protocol eventually relaunched in 2021 with improved oracle architecture, though it did not regain significant market share.
+Warp Finance announced plans to redesign its oracle system around more robust price feeds and secure LP-token pricing formulas. The incident nevertheless damaged confidence in the protocol and became a reference case for LP-collateral oracle risk.
 
 ## 6. Broader market-health implications
 

--- a/content/research/market-health/posts/2026-05-05-warp-finance/index.md
+++ b/content/research/market-health/posts/2026-05-05-warp-finance/index.md
@@ -1,0 +1,196 @@
+---
+date: 2026-05-05
+entities:
+  - id: warp-finance
+    name: Warp Finance
+    type: defi
+  - id: uniswap
+    name: Uniswap
+    type: defi
+  - id: dydx
+    name: dYdX
+    type: defi
+  - id: maker
+    name: MakerDAO
+    type: defi
+title: "Warp Finance flash-loan LP-token oracle manipulation and $7.7 M lending-protocol drain"
+---
+
+## 1. Introduction and incident overview
+
+On 17 December 2020, the Ethereum-based lending protocol Warp Finance was exploited through a flash-loan attack that manipulated the price of Uniswap V2 liquidity-provider (LP) tokens used as collateral. The attacker borrowed approximately $7.7 million in stablecoins (DAI and USDC) from Warp Finance's lending pools by inflating the apparent value of LP-token collateral through a series of large flash-loan-funded swaps on Uniswap. The entire attack was executed within a single Ethereum transaction, and the borrowed stablecoins were never returned.
+
+The Warp Finance exploit was one of several flash-loan oracle-manipulation attacks during the 2020–2021 DeFi expansion period. It is notable for targeting LP tokens specifically — a collateral type whose pricing depends on the reserves of both assets in the underlying Uniswap pool, making it particularly susceptible to manipulation through large trades that temporarily shift pool reserves.
+
+## 2. Technical background
+
+### 2.1 Warp Finance's lending model
+
+Warp Finance launched in late 2020 as a lending protocol that differentiated itself by accepting Uniswap V2 LP tokens as collateral. Standard lending protocols like Aave and Compound accepted individual ERC-20 tokens (ETH, WBTC, stablecoins), but LP tokens — which represent a proportional share of a Uniswap trading pair's pooled reserves — were generally not accepted because their pricing is more complex and more susceptible to manipulation.
+
+Warp Finance's value proposition was that LP tokens represent productive capital (earning trading fees in Uniswap pools) and should be usable as collateral to borrow stablecoins, enabling LP holders to leverage their positions without withdrawing liquidity from Uniswap.
+
+### 2.2 Uniswap V2 LP-token pricing
+
+A Uniswap V2 LP token represents a pro-rata claim on the two assets held in a trading pair's pool. The value of an LP token is a function of the pool's total reserves and the prices of both constituent assets. For a pool with reserves (R_x, R_y) and total LP supply S, each LP token represents a claim on (R_x / S) of asset X and (R_y / S) of asset Y.
+
+The key vulnerability arises from how these reserves change during large trades. Uniswap V2 uses a constant-product AMM (x * y = k), so a large trade that buys asset X from the pool increases R_y and decreases R_x. If the LP-token valuation uses the pool's current reserve ratio as a price input — reading the reserves at the moment of the collateral evaluation — then a large trade immediately before the evaluation can artificially inflate the apparent value of the LP token.
+
+### 2.3 Warp Finance's oracle design
+
+Warp Finance priced LP-token collateral by querying the Uniswap V2 pool's current reserves at the time of the borrowing transaction. This spot-reserve-based pricing meant that the collateral valuation reflected the pool's state at the instant of the borrow call, including any temporary distortions caused by large trades in the same block or transaction.
+
+This design did not incorporate time-weighted average prices (TWAPs), external oracle feeds (such as Chainlink), or any mechanism to smooth out short-term reserve fluctuations. It was therefore directly vulnerable to within-transaction manipulation via flash loans.
+
+### 2.4 Flash loans as an attack enabler
+
+Flash loans, available from protocols like dYdX, Aave, and later Uniswap V3, allow users to borrow arbitrary amounts of capital within a single transaction, provided the loan is repaid by the end of that transaction. For an attacker, flash loans eliminate the capital requirement for price-manipulation attacks: instead of needing millions of dollars to move a market, the attacker can borrow the necessary capital, execute the manipulation, extract the profit, repay the flash loan, and keep the difference — all atomically within one transaction.
+
+## 3. Attack execution
+
+### 3.1 Transaction anatomy
+
+The attack was executed in a single Ethereum transaction. The sequence of operations within that transaction was:
+
+**Step 1 — Flash-loan acquisition**: The attacker borrowed a large quantity of WETH (wrapped Ether) via a flash loan from dYdX. The borrowed amount was sufficient to significantly move the reserves in the targeted Uniswap V2 pool.
+
+**Step 2 — LP-token acquisition**: The attacker used a portion of the flash-loaned WETH to provide liquidity to the Uniswap V2 WETH/DAI pool, receiving LP tokens in return.
+
+**Step 3 — Reserve manipulation**: The attacker executed a large swap on the same Uniswap V2 WETH/DAI pool, selling a substantial amount of WETH for DAI. This swap dramatically shifted the pool's reserve ratio, increasing the DAI reserves and decreasing the WETH reserves. Because the constant-product formula requires the product of reserves to remain constant, the trade moved the pool to a state where each LP token (which represents a fixed fraction of the total reserves) appeared to hold significantly more DAI than before the swap.
+
+**Step 4 — Inflated collateral deposit**: The attacker deposited the LP tokens obtained in Step 2 into Warp Finance as collateral. Warp Finance's oracle queried the Uniswap pool's reserves at this moment — after the manipulative swap in Step 3 — and valued the LP tokens at their inflated, post-manipulation price.
+
+**Step 5 — Maximum borrowing**: Based on the inflated collateral valuation, the attacker borrowed the maximum available DAI and USDC from Warp Finance's lending pools — approximately $7.7 million in stablecoins.
+
+**Step 6 — Unwinding and flash-loan repayment**: The attacker reversed the reserve-manipulation swap (buying back WETH with DAI) to recover most of the flash-loaned capital, repaid the dYdX flash loan, and retained the approximately $7.7 million in borrowed stablecoins. The LP tokens deposited as collateral were abandoned — their value, once the pool reserves returned to normal, was far less than the borrowed amount.
+
+### 3.2 Net extraction
+
+The net profit was the difference between the borrowed stablecoins ($7.7M) and the cost of the abandoned LP tokens plus flash-loan fees and gas costs. Because the LP tokens were acquired with a portion of the flash-loaned capital and their value after the manipulation reversal was minimal, the attacker's net extraction was approximately the full $7.7 million minus gas and fees — effectively the vast majority of the borrowed amount.
+
+### 3.3 Post-exploit fund movement
+
+The attacker moved the stolen stablecoins through several Ethereum addresses. A portion was later returned: Warp Finance reported that approximately $5.85 million in WETH collateral was recovered, either through negotiation or because the attacker's unwinding transactions left recoverable value. The net loss to Warp Finance depositors, after recovery, was approximately $1.85 million.
+
+## 4. Why the attack succeeded
+
+### 4.1 Spot-price oracle vulnerability
+
+The fundamental vulnerability was Warp Finance's use of spot-reserve-based LP-token pricing. By reading Uniswap pool reserves at the moment of the borrow transaction, the oracle could not distinguish between legitimate market conditions and temporary, attacker-induced reserve distortions.
+
+This is a well-documented class of oracle vulnerability in DeFi. The Uniswap V2 documentation itself warns against using instantaneous reserve values as price inputs and recommends time-weighted average prices (TWAPs) for oracle use cases. The Warp Finance team's decision to use spot reserves — presumably for simplicity or to avoid the latency inherent in TWAPs — directly enabled the attack.
+
+### 4.2 Absence of borrowing limits or circuit breakers
+
+Warp Finance did not implement borrowing caps or circuit breakers that would have limited the damage even if the oracle was manipulated. For example:
+
+- A maximum borrow amount per transaction would have capped the extraction regardless of collateral valuation.
+- A utilization-rate trigger that paused borrowing when pool utilization exceeded a threshold would have prevented the attacker from draining the pools.
+- A collateral-value change threshold that flagged or blocked borrowing when LP-token valuation deviated significantly from recent averages could have caught the manipulation.
+
+### 4.3 LP-token complexity
+
+LP tokens are inherently more complex to price securely than individual tokens. An individual token's price can be sourced from external oracles (Chainlink, Band, etc.) that aggregate prices across multiple exchanges and use median or TWAP aggregation to resist manipulation. LP tokens, by contrast, derive their value from the internal state of a specific Uniswap pool, making them dependent on that pool's instantaneous reserves unless the pricing mechanism explicitly compensates for this.
+
+Research published after the Warp Finance attack (and several similar incidents) formalized secure LP-token pricing approaches that calculate the fair value of LP tokens using the invariant formula and external token prices rather than reading pool reserves directly. These approaches — sometimes called "fair LP pricing" — became standard practice for DeFi protocols accepting LP-token collateral, but were not widely adopted at the time of the Warp Finance exploit.
+
+## 5. Warp Finance's response
+
+### 5.1 Immediate actions
+
+Warp Finance paused all protocol operations immediately after detecting the exploit. The team published a post-mortem within 48 hours, identifying the spot-reserve oracle as the root cause and acknowledging that the LP-token pricing mechanism was insufficient to resist flash-loan manipulation.
+
+### 5.2 Fund recovery
+
+The team reported recovering approximately $5.85 million of the $7.7 million extracted, representing WETH that remained in the protocol's collateral pool after the attacker's unwinding transactions. The recovery reduced the net loss to approximately $1.85 million, which was borne by stablecoin depositors whose DAI and USDC could not be fully repaid.
+
+### 5.3 Protocol redesign
+
+Warp Finance announced plans to redesign its oracle system using Chainlink price feeds and secure LP-token pricing formulas. The protocol eventually relaunched in 2021 with improved oracle architecture, though it did not regain significant market share.
+
+## 6. Broader market-health implications
+
+### 6.1 Flash-loan oracle manipulation as a systematic DeFi risk
+
+The Warp Finance exploit is part of a broader pattern of flash-loan oracle-manipulation attacks that peaked during the 2020–2021 DeFi expansion. Other notable incidents in this category include:
+
+| Protocol | Date | Loss | Oracle vector |
+|---|---|---|---|
+| bZx (first attack) | Feb 2020 | $350K | Uniswap spot price |
+| bZx (second attack) | Feb 2020 | $600K | Uniswap/Kyber spot price |
+| Harvest Finance | Oct 2020 | $34M | Curve Y pool spot price |
+| Warp Finance | Dec 2020 | $7.7M | Uniswap LP-token spot reserves |
+| Cream Finance (v1) | Feb 2021 | $37M | Yearn vault token spot price |
+| PancakeBunny | May 2021 | $45M | PancakeSwap spot price |
+
+The common pattern is: a protocol uses spot (instantaneous) pricing from an AMM as its oracle, and an attacker uses a flash loan to temporarily distort the AMM's state, borrow against the inflated collateral, and repay the flash loan — all within a single transaction.
+
+### 6.2 LP-token collateral risk
+
+The Warp Finance incident highlighted the specific risks of accepting LP tokens as collateral in lending protocols:
+
+1. **Pricing complexity**: LP tokens' value depends on the reserves of both underlying assets, the total LP supply, and the fee accumulation — all of which can change within a single transaction.
+
+2. **Manipulation surface**: Unlike individual token prices, which can be sourced from multiple independent exchanges, LP-token reserves are entirely determined by the state of one specific AMM pool, creating a single point of manipulation.
+
+3. **Impermanent loss interaction**: LP tokens are already subject to impermanent loss during volatile market conditions. Using them as collateral adds liquidation risk on top of impermanent loss, creating compounding risk for users.
+
+4. **Fair-value pricing as a solution**: Research and tooling for secure LP-token pricing (e.g., Alpha Homora's fair-value approach, Uniswap V3's concentrated liquidity considerations) have improved since 2020, but the underlying complexity means that LP-token collateral requires more sophisticated oracle design than single-asset collateral.
+
+### 6.3 DeFi protocol launch security standards
+
+The Warp Finance exploit occurred shortly after the protocol's launch, during a period when DeFi protocols were deploying rapidly with minimal auditing or security review. The incident contributed to a broader industry shift toward:
+
+- **Pre-launch audits**: Security audits by firms like Trail of Bits, OpenZeppelin, and Consensys Diligence became expected (though not universal) before mainnet deployment.
+
+- **Bug bounties**: Protocols began offering bug bounties through platforms like Immunefi to incentivize responsible disclosure of vulnerabilities before they could be exploited.
+
+- **Gradual deployment**: Launching with low caps on total value locked (TVL), borrowing limits, and supported collateral types, then expanding as the protocol's security was validated in production.
+
+- **Oracle best practices**: The DeFi community developed and documented oracle security guidelines, including the recommendation to use TWAPs or external oracle networks rather than spot AMM prices for critical pricing functions.
+
+### 6.4 Market surveillance implications
+
+For market-health surveillance, the Warp Finance exploit pattern produces specific on-chain signatures:
+
+1. **Flash-loan borrowing**: Large flash-loan originations from dYdX, Aave, or other providers in the same block or transaction as abnormal protocol interactions.
+
+2. **AMM reserve distortion**: Uniswap or other AMM pool reserves moving dramatically within a single block, then reverting in the same or next block.
+
+3. **Abnormal borrowing**: A single address borrowing an outsized proportion of a lending protocol's available liquidity in one transaction.
+
+4. **Immediate post-borrow fund movement**: Borrowed funds being transferred to external addresses or mixer contracts immediately after borrowing.
+
+Monitoring for these signatures can enable early detection of flash-loan attacks in progress, though the atomic nature of these attacks (all steps within one transaction) means that detection is often post-facto rather than preventive.
+
+## 7. Lessons learned and recommendations
+
+### 7.1 For DeFi lending protocols
+
+1. **Never use spot AMM reserves for collateral pricing**: Use time-weighted average prices (TWAPs), external oracle networks (Chainlink, Band), or fair-value pricing formulas that derive LP-token value from the AMM invariant and external token prices.
+
+2. **Implement borrowing circuit breakers**: Cap per-transaction and per-block borrowing amounts. Pause lending when utilization rates spike abnormally. Flag transactions where collateral valuation deviates significantly from recent averages.
+
+3. **Conduct flash-loan attack simulations**: Before launch, model the economic attack surface by simulating flash-loan-funded manipulation of all accepted collateral types. If a profitable attack path exists with available flash-loan liquidity, the oracle design is insufficient.
+
+4. **Start with conservative collateral parameters**: Launch with low loan-to-value ratios, low borrowing caps, and a limited set of well-understood collateral types. Expand gradually as the protocol's security posture is validated.
+
+### 7.2 For LP-token holders
+
+1. **Understand collateral risks**: Using LP tokens as collateral in lending protocols adds liquidation risk on top of impermanent loss. The protocol's oracle design determines whether the collateral valuation is manipulation-resistant.
+
+2. **Evaluate protocol security**: Before depositing LP tokens as collateral, check whether the lending protocol has been audited, uses secure LP-token pricing, and has borrowing limits or circuit breakers.
+
+### 7.3 For market surveillance and regulators
+
+1. **Monitor flash-loan patterns**: Flag large flash-loan originations coinciding with abnormal lending-protocol interactions, particularly on newly launched protocols.
+
+2. **Track AMM reserve anomalies**: Detect and alert on within-block reserve distortions that deviate from normal trading patterns.
+
+3. **Assess new protocol launch risk**: Protocols that launch without audits, accept complex collateral types (LP tokens, vault tokens, rebasing tokens), and use spot-price oracles represent elevated risk for users and the broader market.
+
+## 8. Conclusion
+
+The Warp Finance exploit of December 2020 demonstrated the specific risks of using spot AMM-reserve readings to price LP-token collateral in DeFi lending protocols. By executing a flash-loan-funded swap to temporarily distort a Uniswap V2 pool's reserves, the attacker inflated the apparent value of LP-token collateral and borrowed $7.7 million in stablecoins that were never repaid. Approximately $5.85 million was subsequently recovered from residual collateral, leaving a net loss of approximately $1.85 million to stablecoin depositors.
+
+The incident contributed to the DeFi industry's shift toward secure oracle practices — including TWAPs, external oracle networks, and fair-value LP-token pricing — and toward more conservative protocol launch parameters. For market-health surveillance, the Warp Finance attack pattern produces identifiable on-chain signatures (flash-loan origination, within-transaction reserve distortion, abnormal borrowing spikes) that can inform monitoring systems, though the atomic nature of flash-loan attacks limits the window for preventive intervention.


### PR DESCRIPTION
Contribution to #277.

Adds a market-health incident writeup on the December 2020 Warp Finance exploit:

- Incident type: flash-loan-funded Uniswap V2 LP-token collateral/oracle manipulation.
- Loss framing: roughly $7.7-$7.8M DAI/USDC drain, with about $5.85M later recovered from residual collateral and roughly $1.8-$2.0M net unrecovered loss.
- Technical focus: spot-reserve LP-token pricing, within-transaction AMM reserve distortion, dYdX/Uniswap flash-loan capital, missing TWAP/external oracle controls, and missing borrow/circuit caps.
- Market-health lesson: LP tokens are complex collateral; lending protocols need fair-value LP pricing, external price inputs, conservative launch caps, and flash-loan attack simulations.

Payout can be BTC, Lightning, or stablecoin if accepted.