### PR TITLE
add: Genesis Global Gemini Earn lending failure (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-genesis-global/index.md
+++ b/content/research/market-health/posts/2026-05-05-genesis-global/index.md
@@ -1,0 +1,202 @@
+---
+date: 2026-05-05
+entities:
+  - id: genesis-global-capital
+    name: Genesis Global Capital
+    type: cefi
+  - id: gemini
+    name: Gemini
+    type: exchange
+  - id: digital-currency-group
+    name: Digital Currency Group
+    type: holding-company
+  - id: sec
+    name: Securities and Exchange Commission
+    type: regulatory
+  - id: new-york-attorney-general
+    name: New York Attorney General
+    type: regulatory
+title: "Genesis Global Capital bankruptcy and the Gemini Earn lending-contagion failure"
+---
+
+## 1. Introduction and incident overview
+
+Genesis Global Capital was one of the central institutional lenders in the 2020-2022 crypto credit cycle. As part of Digital Currency Group's crypto-finance network, Genesis provided lending, borrowing, and trading services to institutions and also served as the lending counterparty behind Gemini Earn, a retail-facing yield program offered through the Gemini exchange. In November 2022, after FTX collapsed and crypto credit markets froze, Genesis suspended withdrawals and new loan originations. In January 2023, Genesis Global Holdco and lending affiliates filed for Chapter 11 bankruptcy protection.
+
+The bankruptcy stranded a large number of Gemini Earn users. According to the SEC's 2024 settlement announcement, Genesis held approximately $900 million in crypto assets from about 340,000 Gemini Earn investors when it stopped allowing withdrawals. The case also pulled in Digital Currency Group (DCG), Gemini, the New York Attorney General, the SEC, and bankruptcy courts, making Genesis one of the most legally complex credit failures of the cycle.
+
+Genesis is a market-health case study because it shows how retail yield, institutional lending, parent-company support, and intercompany claims can combine into a risk structure that users cannot easily see. The product presented to a Gemini Earn user looked simple: lend crypto and earn interest. The risk chain behind that product included Genesis borrower defaults, Three Arrows Capital exposure, FTX-era liquidity stress, DCG promissory notes, regulatory disputes, and bankruptcy recovery mechanics.
+
+## 2. Genesis's role in crypto credit markets
+
+### 2.1 Institutional lending hub
+
+Genesis was not primarily a consumer app. Its importance came from institutional credit. Crypto funds, trading firms, market makers, and other counterparties borrowed and lent through Genesis. In bull markets, that role made Genesis a key liquidity provider. It connected asset holders seeking yield with borrowers seeking leverage, inventory, or trading capital.
+
+This position also made Genesis a transmission node. If major borrowers failed, Genesis would absorb losses. If Genesis stopped withdrawals, counterparties and retail programs connected to Genesis would experience stress. The firm sat in the middle of a private credit graph that was far less transparent than on-chain DeFi markets.
+
+### 2.2 Gemini Earn structure
+
+Gemini Earn allowed Gemini customers to lend crypto assets and receive interest. Gemini acted as the customer-facing platform, while Genesis was the borrower and yield-generating counterparty. The SEC later described the program as a purported investment opportunity in which Gemini customers loaned crypto assets to Genesis in exchange for Genesis's promise to pay interest from its use of those assets.
+
+The key market-health issue is that many users encountered the risk through Gemini's familiar exchange interface, but the economic exposure was to Genesis's creditworthiness. Gemini Earn was not the same as holding assets in a fully reserved exchange wallet. Users were participating in a lending product, and their ability to withdraw depended on Genesis having enough liquid assets to satisfy requests.
+
+### 2.3 Parent-company context
+
+Genesis was part of Digital Currency Group, a major crypto holding company with interests across trading, media, asset management, mining, and venture investments. DCG's reputation and ecosystem position mattered because counterparties often interpreted parent-company affiliation as a source of support. After Genesis suffered losses connected to Three Arrows Capital, DCG issued a long-dated promissory note to Genesis, a step that became central to later disputes over the true state of Genesis's balance sheet.
+
+Parent support can be valuable, but it can also obscure risk if the support is illiquid, long-dated, or difficult for creditors to value. A promissory note is not the same as immediately available cash or crypto liquidity.
+
+## 3. The 3AC and FTX shocks
+
+### 3.1 Three Arrows Capital exposure
+
+The collapse of Three Arrows Capital in mid-2022 inflicted severe losses across crypto lenders. Genesis was one of the major affected creditors. Public reporting and later litigation described very large Genesis exposure to 3AC, with disputed claims and settlements later handled through bankruptcy processes.
+
+The 3AC default mattered because it impaired Genesis before FTX collapsed. Like other lenders, Genesis had to manage losses from a borrower whose assets were highly correlated with the broader crypto downturn. In a market where collateral values and borrower solvency fell together, loan books that looked profitable during a bull market became fragile.
+
+### 3.2 DCG promissory note
+
+After the 3AC event, DCG assumed or backstopped part of Genesis's loss exposure through a promissory note reported around $1.1 billion. Supporters could frame this as parent-company support for a subsidiary. Critics and later litigants argued that it did not provide the same liquidity as cash and that public communications around Genesis's condition were misleading.
+
+The New York Attorney General's October 2023 lawsuit alleged that Genesis, Gemini, and DCG misled investors by concealing losses and misrepresenting the risks of the Earn program. Those claims are legal allegations, not merely market analysis, but they identify the central disclosure problem: users and counterparties needed to know whether Genesis had liquid assets or a long-dated related-party receivable.
+
+### 3.3 FTX and Alameda market shock
+
+In November 2022, FTX and Alameda Research collapsed. The failure triggered a broad liquidity crisis across crypto credit markets. Genesis announced that abnormal withdrawal requests had exceeded its available liquidity and suspended redemptions and new loan originations. Gemini Earn withdrawals stopped because Genesis could not return the loaned assets.
+
+This was the point where hidden credit exposure became visible to retail users. Gemini Earn customers had not necessarily followed Genesis's institutional loan book, but they experienced the result directly: assets that had been lent through Earn were no longer withdrawable on demand.
+
+## 4. Bankruptcy and creditor process
+
+### 4.1 Chapter 11 filing
+
+Genesis Global Holdco and lending affiliates filed Chapter 11 petitions in the Southern District of New York on 19 January 2023. Chapter 11 was intended to preserve value, resolve creditor claims, and create a distribution plan. The filing placed Earn users, institutional lenders, parent-company entities, and other creditors into a court-supervised process.
+
+The bankruptcy illustrated a recurring CeFi risk: once withdrawals stop, customers no longer have a simple app balance. They have claims whose treatment depends on account terms, intercompany arrangements, asset prices, litigation outcomes, and court-approved plans.
+
+### 4.2 Gemini Earn customer claims
+
+Gemini Earn users became a major creditor constituency. The SEC stated that Genesis held approximately $900 million from about 340,000 Gemini Earn investors when withdrawals were halted. Gemini publicly fought with Genesis and DCG over responsibility for returning Earn assets, while customers waited through bankruptcy, regulatory actions, and settlement negotiations.
+
+The Earn structure created an accountability triangle. Users had a relationship with Gemini. Genesis had the borrowed assets. DCG owned Genesis. When the system broke, each layer mattered. For market-health monitoring, this is a warning against products where the consumer brand and the actual risk-taking entity are different.
+
+### 4.3 Settlements and distributions
+
+Genesis's restructuring eventually included settlements with major counterparties and regulators, and the estate began distributions after plan confirmation. Public summaries described billions of dollars in cash and crypto distributions, with Gemini Earn recoveries receiving special attention because of the retail impact and subsequent settlement arrangements.
+
+Recovery outcomes in crypto bankruptcies are complicated by valuation dates and asset appreciation. A customer can receive a high percentage of petition-date claim value while still feeling harmed if crypto prices rose during the bankruptcy period. For this reason, market-health analysis should distinguish between legal recovery percentage, in-kind recovery, dollar value at petition date, and user's expected self-custody outcome.
+
+## 5. Regulatory actions
+
+### 5.1 SEC action
+
+In January 2023, the SEC charged Genesis and Gemini with the unregistered offer and sale of securities through Gemini Earn. In March 2024, Genesis agreed to a final judgment ordering a $21 million civil penalty and a permanent injunction to settle the SEC charges. The settlement provided that the SEC would not receive any part of the penalty until after payment of other allowed bankruptcy claims, including retail Earn investor claims. Genesis settled without admitting or denying the allegations.
+
+The SEC's framing was straightforward: crypto lending products offered to the public need registration or an exemption so investors receive required disclosures. From a market-health perspective, the key question is not only legal classification. It is whether users had enough information to understand that they were lending to Genesis and taking Genesis credit risk.
+
+### 5.2 New York Attorney General lawsuit
+
+In October 2023, the New York Attorney General filed a lawsuit against Gemini, Genesis, DCG, and related executives. The NYAG alleged that the companies defrauded more than 230,000 investors and concealed or misrepresented risks and losses connected to Genesis and the Earn program. The complaint focused on alleged misstatements around safety, risk, and Genesis's financial condition after the 3AC collapse.
+
+Those allegations should be treated as legal claims, not independent proof of every fact. However, they highlight the disclosure standards that matter for market health: if a lending product depends on the solvency of an institutional borrower, users need timely information about that borrower's losses, liquidity, and related-party support.
+
+### 5.3 DCG and related-party risk
+
+DCG's role made Genesis different from a standalone lender. Parent-company relationships can create support, conflicts, and opacity. If a subsidiary relies on a parent promissory note or intercompany obligation, creditors need to know the maturity, enforceability, collateral, and liquidity of that obligation. Otherwise, a balance sheet can appear stronger than its cash position.
+
+The Genesis case showed that related-party claims are not just accounting details. They can determine whether retail users can withdraw.
+
+## 6. Mechanics of the failure
+
+### 6.1 Liquidity mismatch
+
+Genesis faced a liquidity mismatch between obligations to lenders and the availability of liquid assets. Borrowers such as 3AC had defaulted or become impaired. Market stress after FTX increased redemption demand. Genesis could not meet all withdrawal requests, so it froze redemptions.
+
+This is similar to bank-run mechanics but without the same regulatory backstops. Crypto lenders that offer withdrawable lending products need liquidity reserves, stress tests, and transparent asset-liability management. Without those, a market shock turns into a withdrawal freeze.
+
+### 6.2 Counterparty concentration and hidden leverage
+
+Genesis's credit risk depended on institutional counterparties. Users of Gemini Earn could not see the full list of borrowers, collateral, loan terms, or concentration. They therefore could not independently estimate how a 3AC or FTX shock would affect their assets.
+
+Private credit can be efficient, but it becomes dangerous when retail users supply capital without loan-book transparency. A retail yield product that depends on a small number of large borrowers is not diversified from the user's point of view.
+
+### 6.3 Related-party liquidity opacity
+
+The DCG promissory-note dispute illustrates the difference between solvency and liquidity. A lender may have a claim on a parent company, but if that claim is long-dated or contested, it cannot satisfy immediate withdrawal requests. Users need to know not only whether assets exist on paper but whether they are liquid and enforceable.
+
+### 6.4 Platform-brand mismatch
+
+Gemini Earn users interacted with Gemini, a regulated New York trust company and well-known exchange brand. The credit exposure sat with Genesis. This mismatch can create false comfort: users may transfer trust in the platform brand to the lending counterparty even though the legal and economic risk is different.
+
+Market-health disclosures should therefore identify the actual borrower and legal obligor in large type, not only in terms of service.
+
+## 7. Market-health warning signals
+
+### 7.1 Yield product depends on a third-party borrower
+
+If a consumer-facing platform offers yield through an external lending partner, users need to evaluate the partner, not just the platform. A brand-name exchange interface does not eliminate borrower risk.
+
+### 7.2 Large borrower losses replaced by parent notes
+
+A parent-company note can be a legitimate restructuring tool, but it should be treated as a risk signal if it replaces immediately liquid assets after a borrower default. Analysts should ask whether the note is secured, callable, short-dated, and collectible under stress.
+
+### 7.3 Withdrawal freeze after market shock
+
+Genesis froze withdrawals after FTX-era market stress. The timing showed that liquidity was insufficient for a system-wide redemption wave. Similar products should be monitored for language about "abnormal withdrawal requests," "temporary suspension," or "liquidity preservation."
+
+### 7.4 Regulatory charges around unregistered lending products
+
+Registration allegations do not automatically prove insolvency, but they often point to inadequate disclosure. If a lending product is being challenged by regulators for missing investor disclosures, users should revisit whether they understand the risk being taken.
+
+### 7.5 Public disputes between distribution partners
+
+The public dispute between Gemini, Genesis, and DCG was itself a market-health signal. When a consumer platform, lending counterparty, and parent company publicly disagree over responsibility for customer funds, users should assume recovery will be slow and legally complex.
+
+## 8. Comparison with related failures
+
+### 8.1 Voyager Digital
+
+Voyager transmitted 3AC credit risk directly to retail customers through a brokerage/yield platform. Genesis transmitted institutional credit risk through Gemini Earn. Both show that retail users can be exposed to hedge-fund defaults without ever negotiating with the hedge fund.
+
+### 8.2 BlockFi
+
+BlockFi survived part of the 3AC shock by relying on FTX support and then failed after FTX collapsed. Genesis also faced 3AC impairment before FTX-era liquidity stress. The common lesson is that one contagion wave can weaken a lender, while the next wave exposes whether support arrangements were truly liquid.
+
+### 8.3 Celsius
+
+Celsius marketed yield directly to retail users and froze withdrawals in June 2022. Genesis was more institutional, but Gemini Earn made its lending book retail-relevant. Both cases demonstrate the risk of yield products where customers cannot observe asset deployment and liquidity.
+
+### 8.4 FTX/Alameda
+
+FTX's collapse was the immediate market shock that pushed Genesis to suspend withdrawals. It also impaired many counterparties and destroyed confidence in centralized crypto credit. Genesis shows how an exchange failure can become a lender failure even when the lender is not an exchange itself.
+
+## 9. Lessons for product and risk design
+
+### 9.1 Disclose the real borrower
+
+If a platform offers yield through a third-party lending desk, the app should prominently disclose who borrows the assets, what legal claim the user has, and what happens if the borrower freezes withdrawals or files for bankruptcy.
+
+### 9.2 Separate exchange custody from lending
+
+Users should be able to distinguish exchange custody balances from lent Earn balances. The interface should not allow a customer to confuse a wallet account with a credit product.
+
+### 9.3 Publish liquidity and concentration metrics
+
+Lending programs should publish aggregate borrower concentration, collateral categories, liquidity buckets, and stress-test assumptions. Without these, users cannot evaluate whether yield compensates them for the risk.
+
+### 9.4 Treat related-party support as a separate asset class
+
+A parent-company note is not cash. Risk dashboards should separately identify related-party receivables, their maturity, collateral, and payment status. Counting them as ordinary liquid assets can mislead users.
+
+### 9.5 Align regulation with practical disclosure
+
+Registration debates matter because they force disclosure. For market health, the goal is practical: users should understand lending terms, borrower risk, collateral, liquidity, and bankruptcy consequences before depositing.
+
+## 10. Conclusion
+
+Genesis Global Capital's bankruptcy was a defining failure of the crypto credit cycle because it connected institutional lending losses to retail users through Gemini Earn. The direct user experience was a frozen yield product. The underlying causes included 3AC exposure, FTX-era liquidity stress, DCG related-party support disputes, and inadequate transparency around who bore the risk.
+
+The incident shows that crypto market health cannot be measured only by exchange prices or on-chain flows. Off-chain lending books, related-party receivables, and consumer-facing distribution partnerships can create large hidden exposures. A product can look like a simple exchange feature while legally and economically functioning as a loan to an institutional credit desk.
+
+For surveillance, the Genesis pattern is clear: monitor lending products where the consumer platform differs from the borrower, large defaults replaced by parent-company notes, withdrawal freezes after market shocks, regulatory allegations around unregistered lending products, and public disputes between affiliated entities over customer recoveries. Yield is a credit product; if the credit path is opaque, the market is unhealthy.


### PR DESCRIPTION
Contribution to #277.

Adds a market-health incident writeup on the Genesis Global Capital bankruptcy and Gemini Earn failure:

- Incident type: centralized crypto lending liquidity failure and retail Earn-program contagion.
- Loss framing: Genesis held about $900M from roughly 340,000 Gemini Earn investors when withdrawals stopped, per SEC settlement release.
- Technical focus: institutional lending, 3AC impairment, FTX-era liquidity stress, DCG promissory-note/related-party support risk, Gemini Earn distribution structure, and asset-liability mismatch.
- Regulatory context: SEC settlement and NYAG allegations against Genesis/Gemini/DCG, framed as settlement/allegation context rather than adjudicated findings.
- Market-health lesson: retail yield products must disclose the true borrower, liquidity, concentration, related-party receivables, and bankruptcy consequences.

Payout can be BTC, Lightning, or stablecoin if accepted.