### PR TITLE
add: Platypus Finance emergency-withdraw exploit (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-platypus-finance/index.md
+++ b/content/research/market-health/posts/2026-05-05-platypus-finance/index.md
@@ -13,12 +13,12 @@ entities:
   - id: tether
     name: Tether
     type: stablecoin-issuer
-title: "Platypus Finance flash-loan stablecoin AMM exploit and $8.5 M drain on Avalanche"
+title: "Platypus Finance flash-loan stablecoin AMM exploit and $8.5M drain on Avalanche"
 ---
 
 ## 1. Introduction and incident overview
 
-On 16 February 2023, the Avalanche-based stablecoin automated market maker (AMM) Platypus Finance was exploited through a flash-loan attack that manipulated the protocol's collateral accounting in its stablecoin lending module. The attacker extracted approximately $8.5 million in stablecoins — primarily USDC, USDT, BUSD, and DAI — from Platypus's liquidity pools. The attack exploited a logic flaw in the interaction between Platypus's staking mechanism and its lending function, which allowed the attacker to borrow against staked collateral and then withdraw the collateral without repaying the loan.
+On 16 February 2023, the Avalanche-based stablecoin automated market maker (AMM) Platypus Finance was exploited through a flash-loan attack that abused the protocol's USP stablecoin collateral accounting. The attacker extracted approximately $8.5 million in stablecoins — primarily USDC, USDT, BUSD, and DAI — from Platypus's liquidity pools. Public technical analyses identified the key flaw around the emergency-withdrawal path: the protocol allowed a user to borrow USP against collateral and then remove collateral through `emergencyWithdraw` without a sufficient solvency/debt check.
 
 Platypus Finance was a single-sided stablecoin AMM that differentiated itself from curve-style multi-asset pools by allowing users to deposit individual stablecoins (rather than balanced pairs) and earn yield from swap fees. The protocol had accumulated approximately $90 million in total value locked (TVL) before the exploit. The incident demonstrated how logic errors in the interaction between staking, lending, and withdrawal functions can create exploitable paths even when each individual function appears correct in isolation.
 
@@ -40,11 +40,11 @@ In late 2022, Platypus launched a stablecoin lending feature that allowed users 
 
 The critical design decision was that the lending module and the staking module shared state but did not enforce cross-module invariants. Specifically:
 
-- The staking contract's withdrawal function checked only the staking module's own accounting (whether the user had sufficient staked balance).
+- The emergency-withdrawal path checked only the staking module's own accounting (whether the user had sufficient staked balance).
 - The lending module checked the staking contract's balance when originating a loan, but did not place a lien or lock on the staked collateral that would prevent withdrawal.
-- There was no callback or check in the staking contract's withdrawal path that verified whether the user had outstanding loans in the lending module.
+- There was no effective callback or check in the emergency-withdrawal path that prevented removal of collateral when the user had outstanding USP debt.
 
-This meant that a user could: (1) stake LP tokens, (2) borrow USP against those staked tokens, and (3) withdraw the staked LP tokens — leaving the loan undercollateralized with no mechanism to prevent the withdrawal.
+This meant that a user could: (1) stake LP tokens, (2) borrow USP against those staked tokens, and (3) use the emergency path to remove collateral — leaving the USP debt undercollateralized.
 
 ## 3. Attack execution
 
@@ -60,7 +60,7 @@ The attacker executed the exploit through the following steps, funded by a flash
 
 **Step 4 — Borrow USP**: The attacker called the lending module to borrow USP against the staked LP collateral. The lending module checked the staking contract and confirmed the attacker had sufficient staked collateral, then issued USP tokens to the attacker.
 
-**Step 5 — Withdraw staked LP tokens**: The attacker called the staking contract's withdrawal function to retrieve the staked LP tokens. The staking contract processed the withdrawal because it did not check for outstanding loans in the lending module. The collateral backing the USP loan was now gone.
+**Step 5 — Emergency-withdraw staked LP tokens**: The attacker called the emergency-withdrawal function to retrieve the staked LP tokens. The path processed the withdrawal without sufficiently enforcing the outstanding USP debt constraint. The collateral backing the USP loan was now gone.
 
 **Step 6 — Redeem LP tokens for USDC**: The attacker redeemed the withdrawn LP tokens on Platypus, recovering the original USDC deposit.
 
@@ -72,9 +72,9 @@ The attacker executed the exploit through the following steps, funded by a flash
 
 The attacker's net profit was the value of the USP tokens converted to stablecoins (~$8.5 million), minus flash-loan fees and gas costs. The attack was profitable because the borrowed USP was never repaid — the collateral was withdrawn before the lending module could enforce liquidation.
 
-### 3.3 Repeated exploitation
+### 3.3 Related exploit activity
 
-The attacker executed the attack multiple times across different Platypus stablecoin pools (USDC, USDT, BUSD, DAI), extracting value from each pool's liquidity. Each iteration followed the same deposit-stake-borrow-withdraw pattern, suggesting an automated exploit contract.
+The primary exploit drained liquidity associated with multiple Platypus stablecoin pools and was followed by related opportunistic activity. Public reporting on the incident described more than one attacker or transaction cluster, so the safest market-health framing is that the same vulnerable accounting path created a broader incident surface rather than a single neatly isolated pool drain.
 
 ### 3.4 Post-exploit fund movement
 
@@ -82,19 +82,19 @@ The attacker initially attempted to bridge the stolen stablecoins from Avalanche
 
 ### 3.5 Attacker identification and arrest
 
-In an unusual outcome for DeFi exploits, the attacker was identified and arrested by French authorities. Blockchain analytics and IP data led to the identification of a French national who had deployed the exploit contract. The individual was arrested in France and faced criminal charges. This was one of the first cases where a DeFi exploit led to a criminal arrest in a European jurisdiction.
+In an unusual outcome for DeFi exploits, French authorities later arrested suspects linked to the incident after tracing and investigative work. Subsequent reporting said a French court cleared the defendants of criminal charges after an "ethical hacker" defense, while leaving open the possibility of civil claims. This made the case notable not only for attribution, but also for the legal uncertainty around smart-contract exploitation.
 
 ## 4. Root-cause analysis
 
 ### 4.1 Missing cross-module invariant
 
-The fundamental vulnerability was the absence of an invariant check between the staking and lending modules. The lending module treated staked LP tokens as collateral, but the staking module allowed unconditional withdrawal regardless of outstanding loans. Neither module enforced the invariant: "if collateral is pledged to a loan, it cannot be withdrawn until the loan is repaid or liquidated."
+The fundamental vulnerability was the absence of an invariant check between the staking and lending modules, especially in the emergency-withdrawal path. The lending module treated staked LP tokens as collateral, but the staking module exposed a way to remove collateral without adequately accounting for outstanding USP debt. The missing invariant was: "if collateral is pledged to a loan, it cannot be withdrawn through any path until the loan is repaid, liquidated, or otherwise safely accounted for."
 
 In well-designed lending protocols (Aave, Compound, MakerDAO), collateral deposits and loans are managed within the same contract or through tightly coupled contracts with explicit lien mechanisms. When a user deposits collateral and borrows against it, the collateral is locked and cannot be withdrawn without first repaying the loan. Platypus's architecture split these concerns across separate contracts without enforcing the necessary cross-contract invariant.
 
 ### 4.2 Audit gap
 
-Platypus Finance had undergone security audits, but the USP lending module was a later addition to the protocol. The interaction between the lending module and the existing staking contract introduced a new attack surface that was not present in the original staking-only design. Whether the lending module's integration was included in audit scope, and whether auditors examined the cross-module withdrawal path, was not clearly disclosed in Platypus's post-incident communications.
+Platypus Finance had undergone security audits, but the USP lending functionality and its interaction with existing contracts introduced a new attack surface. Whether every emergency path and cross-module withdrawal condition was covered in the relevant audit scope was not clear from short public incident summaries.
 
 This pattern — where a new feature interacts with existing contracts in ways that create vulnerabilities not present in either component individually — is a recurring source of DeFi exploits. Composability within a single protocol's contract set can be as dangerous as composability between protocols.
 
@@ -106,7 +106,7 @@ As in other DeFi exploits, the flash loan served as a capital amplifier that all
 
 ### 5.1 Immediate actions
 
-Platypus Finance paused all protocol operations within hours of detecting the exploit. The team published a preliminary post-mortem acknowledging the cross-module vulnerability and confirming that the lending module's interaction with the staking contract was the root cause.
+Platypus Finance paused protocol operations after detecting the exploit. Public post-incident analyses identified the emergency-withdrawal solvency-check failure and the lending/staking interaction as the core weakness.
 
 ### 5.2 Fund recovery
 
@@ -116,11 +116,11 @@ The team reported recovering a portion of the stolen funds through multiple chan
 - **Negotiation**: Platypus attempted to negotiate with the attacker for return of funds, offering a bug-bounty-style reward.
 - **Law enforcement**: The French arrest and subsequent legal proceedings created a pathway for additional fund recovery, though the timeline and completeness of recovery through legal channels was uncertain.
 
-Total confirmed recovery was partial, with estimates ranging from $2.4 million (the Tether freeze alone) to potentially higher amounts depending on legal outcomes.
+Total confirmed recovery was partial. Public estimates varied over time as frozen funds, tracing, and legal processes developed, so promised or legally disputed recovery should not be treated as realized user recovery until actually returned or claimable.
 
 ### 5.3 Protocol remediation
 
-Platypus implemented fixes to the lending module, adding collateral-locking mechanisms that prevent withdrawal of staked LP tokens when outstanding loans exist. The protocol resumed operations with the patched contracts, though TVL did not recover to pre-exploit levels.
+Platypus implemented fixes to the affected lending/staking interaction, including checks intended to prevent collateral removal when outstanding USP debt exists. The broader lesson was that every withdrawal path, including emergency paths, must enforce the same solvency invariants as normal user flows.
 
 ## 6. Market-health implications
 
@@ -148,9 +148,9 @@ The freeze was effective in this case because the attacker held USDT directly. I
 
 ### 6.4 Criminal enforcement as deterrent
 
-The French arrest of the Platypus attacker was notable as one of the early cases of criminal prosecution for a DeFi exploit in a European jurisdiction. While the legal outcome was pending as of early 2026, the arrest itself established a precedent that DeFi exploits can lead to criminal liability, not just civil liability or regulatory action.
+The French arrest and later reported acquittal of suspects linked to the Platypus exploit made the case notable as an early European test of criminal-law theories around DeFi exploitation. The outcome highlighted that law-enforcement success in identifying suspects does not guarantee criminal conviction, especially when courts must map smart-contract interactions onto existing computer-misuse and fraud statutes.
 
-For market health, criminal enforcement serves as a potential deterrent that economic incentives alone cannot provide. However, the deterrent effect is limited by the difficulty of attribution in most DeFi exploits: the Platypus attacker was identifiable due to operational security failures (IP exposure, on-chain patterns linking to identifiable accounts), which more sophisticated attackers would avoid.
+For market health, criminal enforcement can serve as a potential deterrent, but the Platypus case also showed the limits of relying on prosecution after the fact. Deterrence is constrained by attribution difficulty, jurisdiction, statutory fit, and whether courts treat exploit transactions as unauthorized access, fraud, or merely adversarial use of public smart contracts.
 
 ### 6.5 Comparison with similar staking-lending interaction exploits
 
@@ -195,6 +195,6 @@ While the specific mechanisms differ, the common theme is that interactions betw
 
 ## 8. Conclusion
 
-The Platypus Finance exploit of February 2023 demonstrated how a logic flaw in the interaction between a staking module and a lending module could enable a flash-loan-funded drain of $8.5 million in stablecoins from an Avalanche-based AMM. The attacker exploited the absence of a cross-module invariant — staking allowed unconditional withdrawal while lending treated staked tokens as collateral — to borrow against collateral and then remove it without repaying the loan.
+The Platypus Finance exploit of February 2023 demonstrated how a logic flaw in the interaction between a staking module and a lending module could enable a flash-loan-funded drain of $8.5 million in stablecoins from an Avalanche-based AMM. The attacker exploited the absence of a cross-module invariant — especially in the emergency-withdrawal path — to borrow against collateral and then remove it without repaying the USP debt.
 
-The incident's aftermath included partial fund recovery through Tether's USDT freeze (~$2.4M) and the arrest of the attacker in France, establishing an early precedent for criminal prosecution of DeFi exploits in European jurisdictions. For the DeFi ecosystem, the Platypus case reinforced that composability risk exists within protocols, not only between them, and that feature additions to existing contract systems require comprehensive re-auditing of cross-module interaction surfaces.
+The incident's aftermath included partial fund recovery through Tether's USDT freeze and other recovery efforts, plus French arrests followed by reported acquittals. For the DeFi ecosystem, the Platypus case reinforced that composability risk exists within protocols, not only between them, and that feature additions to existing contract systems require comprehensive re-auditing of every cross-module and emergency interaction surface.

--- a/content/research/market-health/posts/2026-05-05-platypus-finance/index.md
+++ b/content/research/market-health/posts/2026-05-05-platypus-finance/index.md
@@ -1,0 +1,200 @@
+---
+date: 2026-05-05
+entities:
+  - id: platypus-finance
+    name: Platypus Finance
+    type: defi
+  - id: aave
+    name: Aave
+    type: defi
+  - id: avalanche
+    name: Avalanche
+    type: blockchain
+  - id: tether
+    name: Tether
+    type: stablecoin-issuer
+title: "Platypus Finance flash-loan stablecoin AMM exploit and $8.5 M drain on Avalanche"
+---
+
+## 1. Introduction and incident overview
+
+On 16 February 2023, the Avalanche-based stablecoin automated market maker (AMM) Platypus Finance was exploited through a flash-loan attack that manipulated the protocol's collateral accounting in its stablecoin lending module. The attacker extracted approximately $8.5 million in stablecoins — primarily USDC, USDT, BUSD, and DAI — from Platypus's liquidity pools. The attack exploited a logic flaw in the interaction between Platypus's staking mechanism and its lending function, which allowed the attacker to borrow against staked collateral and then withdraw the collateral without repaying the loan.
+
+Platypus Finance was a single-sided stablecoin AMM that differentiated itself from curve-style multi-asset pools by allowing users to deposit individual stablecoins (rather than balanced pairs) and earn yield from swap fees. The protocol had accumulated approximately $90 million in total value locked (TVL) before the exploit. The incident demonstrated how logic errors in the interaction between staking, lending, and withdrawal functions can create exploitable paths even when each individual function appears correct in isolation.
+
+## 2. Technical background
+
+### 2.1 Platypus's stablecoin AMM design
+
+Platypus Finance used a single-sided liquidity model for stablecoin swaps on Avalanche. Unlike Curve's multi-asset pools (where liquidity providers deposit a balanced mix of stablecoins), Platypus allowed users to deposit a single stablecoin into a pool and receive a corresponding LP token. The protocol's swap mechanism used a coverage-ratio-based pricing curve that adjusted fees and slippage based on the ratio of each stablecoin's deposits to its liabilities.
+
+This single-sided model was designed to be more user-friendly than balanced-deposit models, lowering the entry barrier for liquidity providers who held only one stablecoin type.
+
+### 2.2 The PTP staking mechanism
+
+Platypus had a native governance and reward token called PTP. Users who staked their Platypus LP tokens into the MasterPlatypusV4 staking contract received PTP rewards. The staking contract tracked each user's staked LP balance and allowed withdrawal of the staked LP tokens at any time.
+
+### 2.3 The USP lending module
+
+In late 2022, Platypus launched a stablecoin lending feature that allowed users to borrow USP (Platypus's own stablecoin) against their staked LP tokens as collateral. The lending module interacted with the staking contract to check a user's staked balance and allow borrowing up to a certain collateral ratio.
+
+The critical design decision was that the lending module and the staking module shared state but did not enforce cross-module invariants. Specifically:
+
+- The staking contract's withdrawal function checked only the staking module's own accounting (whether the user had sufficient staked balance).
+- The lending module checked the staking contract's balance when originating a loan, but did not place a lien or lock on the staked collateral that would prevent withdrawal.
+- There was no callback or check in the staking contract's withdrawal path that verified whether the user had outstanding loans in the lending module.
+
+This meant that a user could: (1) stake LP tokens, (2) borrow USP against those staked tokens, and (3) withdraw the staked LP tokens — leaving the loan undercollateralized with no mechanism to prevent the withdrawal.
+
+## 3. Attack execution
+
+### 3.1 Attack sequence
+
+The attacker executed the exploit through the following steps, funded by a flash loan from Aave V3 on Avalanche:
+
+**Step 1 — Flash-loan acquisition**: The attacker borrowed 44 million USDC from Aave V3's Avalanche deployment via a flash loan.
+
+**Step 2 — Deposit into Platypus**: The attacker deposited the 44 million USDC into Platypus's USDC pool, receiving Platypus LP tokens representing the deposit.
+
+**Step 3 — Stake LP tokens**: The attacker staked the LP tokens into the MasterPlatypusV4 contract, making them eligible as collateral for the USP lending module.
+
+**Step 4 — Borrow USP**: The attacker called the lending module to borrow USP against the staked LP collateral. The lending module checked the staking contract and confirmed the attacker had sufficient staked collateral, then issued USP tokens to the attacker.
+
+**Step 5 — Withdraw staked LP tokens**: The attacker called the staking contract's withdrawal function to retrieve the staked LP tokens. The staking contract processed the withdrawal because it did not check for outstanding loans in the lending module. The collateral backing the USP loan was now gone.
+
+**Step 6 — Redeem LP tokens for USDC**: The attacker redeemed the withdrawn LP tokens on Platypus, recovering the original USDC deposit.
+
+**Step 7 — Swap USP for stablecoins**: The attacker swapped the borrowed USP tokens for other stablecoins (USDT, BUSD, DAI) through Platypus's own swap pools and other Avalanche DEXes, draining liquidity from those pools.
+
+**Step 8 — Repay flash loan**: The attacker repaid the 44 million USDC flash loan to Aave and retained the extracted stablecoins.
+
+### 3.2 Net extraction
+
+The attacker's net profit was the value of the USP tokens converted to stablecoins (~$8.5 million), minus flash-loan fees and gas costs. The attack was profitable because the borrowed USP was never repaid — the collateral was withdrawn before the lending module could enforce liquidation.
+
+### 3.3 Repeated exploitation
+
+The attacker executed the attack multiple times across different Platypus stablecoin pools (USDC, USDT, BUSD, DAI), extracting value from each pool's liquidity. Each iteration followed the same deposit-stake-borrow-withdraw pattern, suggesting an automated exploit contract.
+
+### 3.4 Post-exploit fund movement
+
+The attacker initially attempted to bridge the stolen stablecoins from Avalanche to Ethereum. However, a portion of the funds — approximately $2.4 million in USDT — was frozen by Tether, which blacklisted the attacker's address. The remaining funds were moved through various addresses on Avalanche and Ethereum.
+
+### 3.5 Attacker identification and arrest
+
+In an unusual outcome for DeFi exploits, the attacker was identified and arrested by French authorities. Blockchain analytics and IP data led to the identification of a French national who had deployed the exploit contract. The individual was arrested in France and faced criminal charges. This was one of the first cases where a DeFi exploit led to a criminal arrest in a European jurisdiction.
+
+## 4. Root-cause analysis
+
+### 4.1 Missing cross-module invariant
+
+The fundamental vulnerability was the absence of an invariant check between the staking and lending modules. The lending module treated staked LP tokens as collateral, but the staking module allowed unconditional withdrawal regardless of outstanding loans. Neither module enforced the invariant: "if collateral is pledged to a loan, it cannot be withdrawn until the loan is repaid or liquidated."
+
+In well-designed lending protocols (Aave, Compound, MakerDAO), collateral deposits and loans are managed within the same contract or through tightly coupled contracts with explicit lien mechanisms. When a user deposits collateral and borrows against it, the collateral is locked and cannot be withdrawn without first repaying the loan. Platypus's architecture split these concerns across separate contracts without enforcing the necessary cross-contract invariant.
+
+### 4.2 Audit gap
+
+Platypus Finance had undergone security audits, but the USP lending module was a later addition to the protocol. The interaction between the lending module and the existing staking contract introduced a new attack surface that was not present in the original staking-only design. Whether the lending module's integration was included in audit scope, and whether auditors examined the cross-module withdrawal path, was not clearly disclosed in Platypus's post-incident communications.
+
+This pattern — where a new feature interacts with existing contracts in ways that create vulnerabilities not present in either component individually — is a recurring source of DeFi exploits. Composability within a single protocol's contract set can be as dangerous as composability between protocols.
+
+### 4.3 Flash loan as capital amplifier
+
+As in other DeFi exploits, the flash loan served as a capital amplifier that allowed the attacker to execute the exploit at scale without holding significant capital. Without the 44 million USDC flash loan, the attacker would have needed to acquire and deposit their own capital, limiting the exploit's impact and potentially requiring multiple transactions that could have been detected and blocked.
+
+## 5. Platypus Finance's response
+
+### 5.1 Immediate actions
+
+Platypus Finance paused all protocol operations within hours of detecting the exploit. The team published a preliminary post-mortem acknowledging the cross-module vulnerability and confirming that the lending module's interaction with the staking contract was the root cause.
+
+### 5.2 Fund recovery
+
+The team reported recovering a portion of the stolen funds through multiple channels:
+
+- **Tether freeze**: Approximately $2.4 million in USDT was frozen by Tether at Platypus's request.
+- **Negotiation**: Platypus attempted to negotiate with the attacker for return of funds, offering a bug-bounty-style reward.
+- **Law enforcement**: The French arrest and subsequent legal proceedings created a pathway for additional fund recovery, though the timeline and completeness of recovery through legal channels was uncertain.
+
+Total confirmed recovery was partial, with estimates ranging from $2.4 million (the Tether freeze alone) to potentially higher amounts depending on legal outcomes.
+
+### 5.3 Protocol remediation
+
+Platypus implemented fixes to the lending module, adding collateral-locking mechanisms that prevent withdrawal of staked LP tokens when outstanding loans exist. The protocol resumed operations with the patched contracts, though TVL did not recover to pre-exploit levels.
+
+## 6. Market-health implications
+
+### 6.1 Cross-module composability risk within protocols
+
+The Platypus exploit highlighted that composability risk is not limited to interactions between separate protocols. Even within a single protocol's contract ecosystem, the addition of new features (like a lending module) that interact with existing contracts (like a staking contract) can introduce vulnerabilities if the cross-module invariants are not carefully specified and enforced.
+
+This has implications for protocol development practices:
+
+- **Feature additions require re-audit of interaction surfaces**: When a new module is added that shares state with existing contracts, the entire interaction surface must be re-examined, not just the new module in isolation.
+- **Invariant documentation**: Protocols should maintain explicit documentation of the invariants that must hold across their contract set, and new features should be checked against these invariants before deployment.
+- **Integration testing**: Unit tests that verify each contract's behavior in isolation are insufficient; integration tests that exercise cross-contract interaction paths — including adversarial paths — are necessary.
+
+### 6.2 Stablecoin AMM fragility
+
+Platypus's role as a stablecoin AMM meant that the exploit directly impacted stablecoin liquidity on Avalanche. The $8.5 million drain from pools holding USDC, USDT, BUSD, and DAI reduced available swap liquidity and temporarily increased slippage for stablecoin trades on the network.
+
+For market health, this illustrates how concentrated liquidity in a single AMM creates a single point of failure for an entire network's stablecoin infrastructure. Avalanche's stablecoin swap ecosystem was disproportionately dependent on Platypus, and the exploit's impact was amplified by that concentration.
+
+### 6.3 Centralized stablecoin freezing as incident response
+
+Tether's ability to freeze $2.4 million in USDT at the attacker's address demonstrated the incident-response utility of centralized stablecoin controls — and simultaneously highlighted the trust assumption that Tether-frozen USDT represents for DeFi users.
+
+The freeze was effective in this case because the attacker held USDT directly. In more sophisticated attacks, where proceeds are quickly swapped into decentralized assets (ETH, BTC) or passed through mixers, centralized freeze capabilities have limited impact. The Platypus case was favorable for freezing because the attacker moved funds relatively slowly, providing a window for Tether to act.
+
+### 6.4 Criminal enforcement as deterrent
+
+The French arrest of the Platypus attacker was notable as one of the early cases of criminal prosecution for a DeFi exploit in a European jurisdiction. While the legal outcome was pending as of early 2026, the arrest itself established a precedent that DeFi exploits can lead to criminal liability, not just civil liability or regulatory action.
+
+For market health, criminal enforcement serves as a potential deterrent that economic incentives alone cannot provide. However, the deterrent effect is limited by the difficulty of attribution in most DeFi exploits: the Platypus attacker was identifiable due to operational security failures (IP exposure, on-chain patterns linking to identifiable accounts), which more sophisticated attackers would avoid.
+
+### 6.5 Comparison with similar staking-lending interaction exploits
+
+The Platypus exploit's cross-module vulnerability pattern has appeared in other DeFi incidents:
+
+| Protocol | Date | Vector | Loss |
+|---|---|---|---|
+| Platypus Finance | Feb 2023 | Staking/lending module invariant | ~$8.5M |
+| Beanstalk Farms | Apr 2022 | Governance/staking flash-loan vote | ~$182M |
+| Level Finance | May 2023 | Referral/staking reward logic flaw | ~$1.1M |
+| Euler Finance | Mar 2023 | Donate/borrow accounting mismatch | ~$197M |
+
+While the specific mechanisms differ, the common theme is that interactions between protocol subsystems (staking + lending, governance + staking, referral + rewards, donate + borrow) create attack surfaces that are more subtle than vulnerabilities in any single subsystem.
+
+## 7. Lessons learned and recommendations
+
+### 7.1 For DeFi protocol developers
+
+1. **Enforce cross-module invariants**: When multiple contract modules share state (e.g., staking balances used as lending collateral), implement explicit invariant checks. The lending module should place a lien on collateral that the staking module's withdrawal function verifies before allowing withdrawal.
+
+2. **Re-audit on feature additions**: Adding a new module that interacts with existing contracts requires re-auditing the interaction surface, not just the new module. The audit scope should explicitly include adversarial interaction paths (e.g., "can a user borrow and then withdraw collateral?").
+
+3. **Integration testing with adversarial scenarios**: Write tests that simulate flash-loan-funded attack sequences across multiple contract calls. Tools like Foundry's fuzz testing and symbolic execution can help identify exploitable interaction paths.
+
+4. **Collateral locking**: Any lending mechanism that accepts staked or deposited assets as collateral must implement a locking mechanism that prevents withdrawal of collateral while loans are outstanding.
+
+### 7.2 For liquidity providers
+
+1. **Evaluate protocol complexity**: Protocols that combine staking, lending, and AMM functions in separate but interacting contracts have a larger attack surface than simpler, single-function protocols. The convenience of additional features comes with additional risk.
+
+2. **Monitor TVL concentration**: When a significant portion of a network's stablecoin liquidity is concentrated in a single protocol, the systemic risk of an exploit is higher.
+
+3. **Understand recovery mechanisms**: Centralized stablecoin freezes (Tether, Circle) can aid recovery but only for funds held in those specific assets. Recovery of funds swapped to decentralized assets is typically not possible through freeze mechanisms.
+
+### 7.3 For market surveillance
+
+1. **Monitor flash-loan-funded staking/lending sequences**: Flag transactions where a large flash-loan deposit is followed by staking, borrowing, and withdrawal within the same transaction or block.
+
+2. **Track cross-module interaction patterns**: Identify protocols where staking, lending, and withdrawal functions interact across separate contracts, and monitor for unusual sequences of calls to those functions.
+
+3. **Watch for large collateral withdrawals after borrowing**: Detect patterns where a user borrows against collateral and then withdraws the collateral in the same or subsequent transaction.
+
+## 8. Conclusion
+
+The Platypus Finance exploit of February 2023 demonstrated how a logic flaw in the interaction between a staking module and a lending module could enable a flash-loan-funded drain of $8.5 million in stablecoins from an Avalanche-based AMM. The attacker exploited the absence of a cross-module invariant — staking allowed unconditional withdrawal while lending treated staked tokens as collateral — to borrow against collateral and then remove it without repaying the loan.
+
+The incident's aftermath included partial fund recovery through Tether's USDT freeze (~$2.4M) and the arrest of the attacker in France, establishing an early precedent for criminal prosecution of DeFi exploits in European jurisdictions. For the DeFi ecosystem, the Platypus case reinforced that composability risk exists within protocols, not only between them, and that feature additions to existing contract systems require comprehensive re-auditing of cross-module interaction surfaces.


### PR DESCRIPTION
Contribution to #277.

Adds a market-health incident writeup on the February 2023 Platypus Finance exploit:

- Incident type: flash-loan-funded stablecoin AMM/lending exploit on Avalanche.
- Loss framing: approximately $8.5M stablecoin drain, with partial recovery through Tether freeze/tracing/legal processes; promised or disputed recovery is not treated as realized until returned or claimable.
- Technical focus: USP borrowing against staked LP collateral, missing cross-module invariant, vulnerable emergencyWithdraw/solvency-check path, Aave V3 flash-loan capital, and stablecoin pool liquidity concentration.
- Legal context: French arrests followed by reported acquittals, framed as legal uncertainty around smart-contract exploitation rather than guaranteed criminal precedent.
- Market-health lesson: every withdrawal path, including emergency paths, must enforce collateral/debt invariants after new lending modules are integrated.

Payout can be BTC, Lightning, or stablecoin if accepted.