### PR TITLE
add: DMM Bitcoin social-engineering custody breach (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-dmm-bitcoin/index.md
+++ b/content/research/market-health/posts/2026-05-05-dmm-bitcoin/index.md
@@ -1,0 +1,208 @@
+---
+date: 2026-05-05
+entities:
+  - id: dmm-bitcoin
+    name: DMM Bitcoin
+    type: exchange
+  - id: ginco
+    name: Ginco
+    type: wallet-infrastructure
+  - id: tradertraitor
+    name: TraderTraitor
+    type: threat-actor
+  - id: fbi
+    name: Federal Bureau of Investigation
+    type: regulatory
+  - id: japan-national-police-agency
+    name: Japan National Police Agency
+    type: regulatory
+title: "DMM Bitcoin social-engineering compromise and 4,502 BTC exchange theft"
+---
+
+## 1. Introduction and incident overview
+
+On 31 May 2024, Japanese cryptocurrency exchange DMM Bitcoin disclosed an unauthorized outflow of 4,502.9 BTC from its wallets. The stolen Bitcoin was worth roughly $305-$308 million at the time, making the incident one of the largest exchange thefts in Japanese crypto history and one of the largest global crypto hacks of 2024. DMM Bitcoin suspended some services after the incident and later announced that customer assets would be transferred to SBI VC Trade as part of a wind-down of the damaged exchange business.
+
+In December 2024, the U.S. Federal Bureau of Investigation (FBI), the Department of Defense Cyber Crime Center (DC3), and Japan's National Police Agency (NPA) publicly attributed the theft to North Korean cyber actors tracked as TraderTraitor. The official attribution described a social-engineering campaign that began outside DMM Bitcoin itself: a North Korean actor posed as a recruiter, contacted an employee of Ginco, a Japanese crypto wallet software company, and delivered malicious code under the cover of a pre-employment test. The compromised access was then used to affect a legitimate DMM Bitcoin transaction request and divert Bitcoin to attacker-controlled wallets.
+
+DMM Bitcoin is a market-health case study because it shows that exchange custody failures can originate in the software supply chain and business workflow around wallets, not only in the exchange's own perimeter. The attacker did not need to exploit Bitcoin consensus or a smart contract. The failure path ran through human recruiting deception, developer workstation or session compromise, wallet-management communications, and transaction workflow integrity. For exchanges, the lesson is that custody security includes every vendor, employee, approval channel, and transaction-signing interface that can influence where coins are sent.
+
+## 2. Background: DMM Bitcoin and Japanese exchange custody
+
+### 2.1 DMM Bitcoin's market position
+
+DMM Bitcoin was a Japanese crypto exchange operated within a large consumer internet and financial-services group. Japanese exchanges had already faced intense security scrutiny after earlier major incidents such as Mt. Gox and Coincheck. Regulatory expectations in Japan emphasized segregation of customer assets, incident reporting, and custody controls. Nevertheless, the DMM incident showed that even regulated markets remain exposed to sophisticated wallet-workflow attacks.
+
+The stolen amount was large enough to change DMM Bitcoin's business trajectory. After the hack, DMM said it would procure the equivalent amount of BTC to cover customer holdings, but the operational and reputational damage was severe. The later transfer of customer accounts and assets to SBI VC Trade showed that making customers whole on paper does not necessarily preserve the compromised platform as a going concern.
+
+### 2.2 Wallet infrastructure dependency
+
+Crypto exchanges often depend on specialized wallet infrastructure providers or internal wallet-management systems for address generation, transaction construction, policy enforcement, signing workflows, and operational monitoring. These systems are not merely support software. They are part of custody.
+
+If a vendor employee, developer, or wallet operator has access to transaction-management systems, session cookies, approval communications, or signing-related workflows, compromise of that person can become exchange compromise. The DMM case made this dependency visible because official attribution focused on an employee of Ginco, a wallet software provider, rather than only on DMM Bitcoin staff.
+
+### 2.3 Transaction workflow integrity
+
+Exchange wallet security is often described in terms of private keys and cold storage. Those controls matter, but transaction workflow integrity is equally important. A wallet system must verify:
+
+1. **Who requested a transfer**.
+
+2. **Which destination address is authorized**.
+
+3. **Whether the address was changed between request and signing**.
+
+4. **Whether approvals came through authenticated and monitored channels**.
+
+5. **Whether the transaction matches an expected withdrawal, treasury, or rebalancing purpose**.
+
+6. **Whether out-of-band confirmation is required for large or unusual transfers**.
+
+The DMM incident, as described by law enforcement, involved manipulation of transaction-related access or communications after a third-party employee was compromised. That makes it a workflow-integrity failure as much as a key-security failure.
+
+## 3. Attack chain
+
+### 3.1 Social-engineering entry
+
+According to the FBI, DC3, and NPA attribution, the campaign began in March 2024 when a North Korean cyber actor posed as a recruiter on LinkedIn and contacted an employee of Ginco. The target had access to wallet-management systems. The actor sent a malicious Python script disguised as a pre-employment test. When the target interacted with the script, the attacker obtained access that helped compromise communications or session material related to Ginco's systems.
+
+This entry path fits a broader pattern in North Korean crypto operations. TraderTraitor and related DPRK-linked clusters have repeatedly used job offers, recruiter personas, coding tests, and open-source developer workflows to target people with access to exchanges, wallet systems, DeFi projects, and trading firms. The social engineering is tailored to developers and operations staff: it looks like ordinary technical recruiting rather than a crude phishing email.
+
+### 3.2 Compromise of wallet-management context
+
+Public summaries state that the malicious script gave the attackers access to sensitive Ginco communications or session information. The exact internal architecture has not been fully published at a technical level, so it is important not to overstate what was stolen. The reliable conclusion is that the compromised access was useful enough for the attacker to influence DMM Bitcoin wallet operations.
+
+In custody systems, session cookies, authenticated chat channels, API access, or transaction-management dashboards can be powerful even if private keys are not directly exfiltrated. If an attacker can impersonate a trusted operator or modify a transaction request before it reaches a signing step, the attacker may redirect funds without defeating the cryptography of the underlying blockchain.
+
+### 3.3 Transaction manipulation
+
+Official attribution said that in late May 2024 the attackers used the compromised access to manipulate a legitimate transaction request from a DMM Bitcoin employee. The manipulated transaction resulted in 4,502.9 BTC being sent to attacker-controlled wallets. This wording matters: it suggests the attackers inserted themselves into an authorized operational process rather than simply draining a hot wallet through a leaked private key.
+
+For market-health purposes, transaction manipulation is especially dangerous because it can look like normal business activity until after settlement. A Bitcoin transaction that is validly signed and broadcast cannot be reversed just because the destination was maliciously substituted upstream. The prevention point must therefore be before signing and broadcast: address verification, transaction-intent verification, policy controls, and independent approval paths.
+
+### 3.4 On-chain movement
+
+After the theft, the Bitcoin moved through multiple addresses. Public blockchain analysis described splitting and peel-chain behavior consistent with laundering large BTC thefts. Stolen coins from major exchange hacks are usually broken into smaller tranches, moved through many wallets, and eventually routed toward mixers, cross-chain services, brokers, or over-the-counter laundering networks.
+
+Large BTC thefts differ from stablecoin thefts because there is no issuer who can freeze Bitcoin. Once the transaction is confirmed, recovery depends on tracing, exchange cooperation, law enforcement, and mistakes by the attacker. That makes prevention far more important than post-theft recovery.
+
+## 4. Attribution to TraderTraitor
+
+### 4.1 Official public attribution
+
+The December 2024 attribution by the FBI, DC3, and Japan's NPA identified North Korean cyber actors tracked as TraderTraitor as responsible for the DMM Bitcoin theft. TraderTraitor is associated with job-themed social engineering and cryptocurrency theft campaigns. The cluster overlaps in tradecraft and reporting with broader North Korean crypto-theft activity often discussed alongside Lazarus Group, Jade Sleet, UNC4899, or Slow Pisces naming conventions, though names vary by government and security vendor.
+
+Official attribution is stronger than private speculation because it reflects law-enforcement and intelligence assessment. However, the public statement still left many implementation details undisclosed, likely because of investigative, intelligence, or victim-sensitivity reasons. A market-health writeup should therefore rely on the official attribution for actor and broad method while avoiding invented details about internal DMM or Ginco systems.
+
+### 4.2 Recruiting-themed malware pattern
+
+The attack pattern fits a well-established DPRK crypto targeting playbook:
+
+1. Identify employees with access to wallet systems, trading systems, private repositories, or deployment infrastructure.
+
+2. Approach through professional platforms such as LinkedIn using a recruiter, investor, or developer persona.
+
+3. Send a coding test, repository, or script that appears relevant to the job conversation.
+
+4. Induce the target to run or copy code on a machine with valuable sessions or access.
+
+5. Use stolen sessions, credentials, or footholds to move laterally toward transaction workflows.
+
+6. Execute a high-value transfer and launder funds quickly.
+
+The playbook is effective because it abuses normal developer behavior. Developers routinely review code, clone repositories, run tests, and interact with recruiters. Security controls must assume that technical staff are high-value targets and that "pre-employment tests" can be malware delivery.
+
+### 4.3 Why attribution matters for market health
+
+Attribution matters because nation-state or state-linked actors have different persistence and risk profiles than opportunistic criminals. A financially motivated lone attacker may look for one bug and move on. A state-linked crypto theft program can run repeated campaigns, maintain tooling, conduct long reconnaissance, and target multiple firms in parallel.
+
+For exchanges, the DMM attribution means social-engineering controls are not optional awareness training. They are a core custody defense against actors whose mission is to generate revenue through crypto theft.
+
+## 5. Aftermath and user impact
+
+### 5.1 Customer protection statement
+
+DMM Bitcoin said it would procure the equivalent amount of BTC to guarantee customer holdings. This was an important customer-protection step: a theft from exchange wallets does not automatically mean customers lose if the operator or parent group can absorb the loss. However, the ability to make customers whole depends on balance-sheet resources and regulatory oversight, not on the blockchain itself.
+
+Strict market-health accounting should distinguish between the exchange's promise to cover customer assets and actual completed user recovery. A coverage plan reduces user harm if executed, but it is not the same as stolen BTC being recovered from the attacker.
+
+### 5.2 Service restrictions and business wind-down
+
+After the incident, DMM Bitcoin restricted services and later moved toward transferring accounts and assets to SBI VC Trade. The business consequence was severe even if customers were protected. In regulated exchange markets, a single custody incident can destroy the economic viability of the platform.
+
+This is a recurring pattern. Exchanges can sometimes survive technical incidents if losses are small, recovery is fast, and trust remains. A $300 million-scale Bitcoin theft creates regulatory, reputational, capital, and operational pressure that can force exit or consolidation.
+
+### 5.3 Japan's exchange-security context
+
+Japan had already experienced Mt. Gox and Coincheck, two of the most important exchange failures in crypto history. The DMM theft showed that improved regulation and industry learning reduced some risks but did not eliminate sophisticated social-engineering and workflow attacks. Attackers adapt toward the weakest remaining link.
+
+The relevant lesson for regulators is that wallet security reviews should include third-party software providers, transaction workflows, privileged communications, and personnel-targeting defenses. It is not enough to ask whether an exchange has cold wallets.
+
+## 6. Market-health warning signals
+
+### 6.1 Vendor access to wallet workflows
+
+If an exchange uses external wallet infrastructure, that vendor becomes part of the custody perimeter. Analysts should ask whether vendor access can influence transaction construction, address books, signing policies, or approval communications. Vendor compromise should be included in custody risk assessments.
+
+### 6.2 Developer recruiting attacks
+
+Repeated reports of fake recruiter outreach to crypto employees should be treated as a sector-wide warning signal. A single employee receiving a malicious coding test can become the first step in a large theft if that employee has wallet or deployment access.
+
+### 6.3 Insufficient transaction-intent verification
+
+High-value transfers should require independent confirmation that the destination address matches the original business intent. This can include out-of-band address verification, hardware display checks, policy engines, allowlists, delayed settlement, and multiple independent approvers.
+
+### 6.4 Large single-transaction exposure
+
+The 4,502.9 BTC loss suggests that a very large amount of value was able to move through a compromised workflow. Exchanges should cap single-transfer exposure, split operational liquidity, and require higher review thresholds for unusual destinations or amounts.
+
+### 6.5 Public uncertainty about wallet architecture
+
+After major incidents, users need to know whether private keys, transaction requests, session cookies, vendor systems, or approval channels were compromised. If public disclosure remains high-level, market-health risk remains elevated because users cannot assess whether the control gap has been closed.
+
+## 7. Comparison with related incidents
+
+### 7.1 Coincheck
+
+Coincheck lost more than $500 million in NEM in 2018 after hot-wallet compromise. DMM Bitcoin was smaller in dollar terms but similar in Japanese market impact. Both incidents showed that exchange custody can fail even in advanced markets, and both increased pressure for stronger wallet controls.
+
+### 7.2 Atomic Wallet
+
+Atomic Wallet was a non-custodial wallet drain with unclear public root cause and DPRK-linked attribution. DMM Bitcoin was a custodial exchange theft with official attribution and a described social-engineering path through wallet infrastructure. Both cases show that wallet software and operational workflows can be attacked without breaking blockchain consensus.
+
+### 7.3 Ronin and Harmony
+
+Ronin and Harmony involved compromised validator or multisig keys. DMM Bitcoin involved transaction-workflow manipulation after social engineering. The common theme is that attackers target the human and operational systems that authorize transfers, not just cryptographic primitives.
+
+### 7.4 Mixin Network
+
+Mixin's disclosed cloud database compromise and DMM's wallet-workflow compromise both show that application-layer infrastructure can become custody-critical. Public blockchains do not protect users from compromised service layers that can authorize or redirect withdrawals.
+
+## 8. Lessons for exchanges and wallet providers
+
+### 8.1 Treat vendors as custody insiders
+
+Wallet software providers, custody platforms, and managed-service vendors should be governed like internal custody teams. Their employees need phishing-resistant authentication, device controls, session monitoring, code-execution isolation, and incident reporting obligations.
+
+### 8.2 Isolate recruiting and code-review activity
+
+Employees with wallet access should not run recruiter-supplied code on machines that hold production sessions, credentials, or access tokens. Coding tests should be opened only in isolated sandboxes with no production credentials and no persistent session cookies.
+
+### 8.3 Verify destination addresses out of band
+
+High-value transactions should require destination-address verification through a channel independent from the one used to construct the transaction. If an attacker compromises chat or wallet-management sessions, the independent confirmation path should still catch address substitution.
+
+### 8.4 Enforce transaction policy engines
+
+Policy engines should flag abnormal transfers by amount, destination, frequency, asset, and workflow origin. A 4,502.9 BTC transfer should require exceptional review, time delay, and possibly board-level or regulator-visible escalation depending on the exchange's custody model.
+
+### 8.5 Design for post-compromise containment
+
+Assume a vendor employee or exchange employee will eventually be compromised. The system should limit what that compromise can do: short session lifetimes, least privilege, allowlisted withdrawals, hardware-backed approvals, threshold signatures, and automatic pauses on unusual transaction construction.
+
+## 9. Conclusion
+
+The DMM Bitcoin theft was not a failure of Bitcoin. It was a failure of the human, vendor, and transaction-workflow systems around Bitcoin custody. A North Korean-linked actor reportedly used a fake recruiting process and malicious code to compromise a wallet-infrastructure access path, then manipulated a legitimate transaction request so that 4,502.9 BTC moved to attacker-controlled wallets.
+
+The incident's market-health lesson is direct: exchange custody security extends beyond private-key storage. It includes LinkedIn messages, developer coding tests, vendor employees, session cookies, transaction-management tools, approval channels, and address-verification procedures. Attackers target the weakest part of that chain.
+
+For surveillance, the DMM pattern is clear: monitor exchanges and wallet providers for vendor concentration, social-engineering exposure, opaque transaction workflows, unusually large operational transfers, and disclosure gaps after incidents. A custody system is only as strong as the least verified step before signing.


### PR DESCRIPTION
Contribution to #277.

Adds a market-health incident writeup on the 2024 DMM Bitcoin theft:

- Incident type: exchange custody/workflow compromise through social engineering of wallet-infrastructure access.
- Loss framing: 4,502.9 BTC, approximately $305-$308M at the time.
- Attribution: FBI/DC3/Japan NPA attribution to North Korean TraderTraitor actors, with malicious recruiter/coding-test tradecraft.
- Technical focus: Ginco wallet-infrastructure dependency, transaction-request manipulation, vendor-as-custody-insider risk, destination-address verification, session/workflow integrity, and BTC laundering constraints.
- Market-health lesson: exchange custody includes vendors, developer workstations, session cookies, transaction-management tools, approval channels, and address-verification procedures, not only private-key storage.

Payout can be BTC, Lightning, or stablecoin if accepted.