### PR TITLE
add: JPEX unlicensed exchange scandal and Hong Kong retail losses (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-jpex/index.md
+++ b/content/research/market-health/posts/2026-05-05-jpex/index.md
@@ -1,0 +1,200 @@
+---
+date: 2026-05-05
+entities:
+  - id: jpex
+    name: JPEX
+    type: exchange
+  - id: hong-kong-sfc
+    name: Hong Kong Securities and Futures Commission
+    type: regulator
+  - id: hong-kong-police
+    name: Hong Kong Police Force
+    type: law-enforcement
+  - id: hong-kong
+    name: Hong Kong
+    type: jurisdiction
+title: "JPEX unlicensed exchange scandal and Hong Kong's retail crypto losses"
+---
+
+## 1. Introduction and incident overview
+
+In September 2023, the Hong Kong virtual-asset market was shaken by the collapse of confidence in JPEX, an unlicensed cryptocurrency trading platform that had aggressively marketed itself to retail users through social media influencers, key opinion leaders, and over-the-counter crypto shops. The Securities and Futures Commission (SFC) warned that no entity in the JPEX group was licensed by the SFC, that no JPEX entity had applied for a Hong Kong virtual asset trading platform licence, and that the platform displayed multiple suspicious features, including high-yield products, misleading licensing claims, and withdrawal complaints.
+
+The warning was followed by user reports of withdrawal difficulty, drastic withdrawal-fee changes, police raids, arrests, asset freezes, and a broader reassessment of how Hong Kong's new virtual asset trading platform regime should handle public promotion by unlicensed exchanges. Later reporting and police updates put alleged losses at roughly HK$1.4 billion to HK$1.6 billion, or about US$180 million to US$206 million, with thousands of complaints and a continuing criminal investigation.
+
+Unlike a pure smart-contract exploit, JPEX was primarily a market-conduct and custody failure. The core risk was not a public-chain vulnerability that any user could inspect. It was a combination of unlicensed platform operation, opaque custody, high advertised returns, influencer-driven credibility, and withdrawal-gate asymmetry: users could be convinced to deposit assets quickly, but had little practical control once the venue changed withdrawal rules or ceased ordinary operation.
+
+## 2. Regulatory and market background
+
+### 2.1 Hong Kong's new VATP regime
+
+Hong Kong's Anti-Money Laundering and Counter-Terrorist Financing Ordinance amendments introduced a licensing regime for virtual asset trading platforms. From 1 June 2023, a person carrying on a business of providing a virtual asset service in Hong Kong, or actively marketing such services to the Hong Kong public, generally needed to operate within the licensing framework or transitional arrangements.
+
+The regime was designed to separate regulated exchanges from offshore or unlicensed platforms that could reach Hong Kong customers through websites, messaging apps, OTC shops, and paid online promotion. It created a clear compliance question for platforms: either obtain a licence, fit within permitted transitional protection, or avoid actively marketing to Hong Kong users.
+
+JPEX became the first major public stress test of that framework. It was already on the SFC Alert List from July 2022, but by 2023 it had built substantial visibility in Hong Kong through local advertising, influencer promotion, event sponsorship, and claims that appeared to imply legitimacy or regulatory progress.
+
+### 2.2 Why retail users relied on JPEX signals
+
+Retail users rarely perform legal due diligence on an exchange's corporate entities, custody arrangements, or licence status. They instead infer credibility from visible signals:
+
+1. **Local promotion**: A platform advertised in public spaces and on social media appears to be tolerated or mainstream.
+2. **Influencer endorsement**: Key opinion leaders and celebrities transfer trust from their audience to the platform.
+3. **OTC shop presence**: Physical or semi-physical conversion points make deposits feel less like sending money to an offshore website.
+4. **Yield products**: Advertised returns provide an apparently concrete reason to keep assets on-platform.
+5. **Regulatory language**: Claims about registrations, licences, partnerships, or pending applications can sound like official approval even when they are not.
+
+The JPEX scandal showed that these signals can be dangerous substitutes for regulated custody, audited reserves, clear corporate accountability, and independently verifiable withdrawal capacity.
+
+## 3. SFC warning and alleged red flags
+
+### 3.1 No SFC licence or application
+
+On 13 September 2023, the SFC issued a public warning naming JPEX. The regulator stated that no entity in the JPEX group was licensed by the SFC or had applied for a licence to operate a virtual asset trading platform in Hong Kong. That statement directly contradicted social-media narratives suggesting that JPEX was licensed, recognised, or on a path to authorised operation in Hong Kong.
+
+This distinction matters because a foreign registration is not equivalent to a Hong Kong exchange licence. Many offshore crypto businesses hold company registrations, money-service registrations, or other limited approvals that do not authorise exchange operation for Hong Kong retail users. JPEX's marketing appeared to blur that line by using licence-like language and references to overseas regulators.
+
+### 3.2 High-return products
+
+The SFC also noted that JPEX offered very high returns for some products. The official warning cited advertised annual percentage yields of 21% for ETH, 20% for BTC, and 19% for USDT as of 12 September 2023. High-yield products are not automatically fraudulent, but they are a critical exchange-risk signal because sustainable yield on liquid crypto assets is difficult to generate without leverage, rehypothecation, proprietary trading, counterparty exposure, or undisclosed risk transfer.
+
+For retail users, the danger is that the yield is presented as a platform feature while the underlying risk is hidden. If a platform uses client assets to fund lending, liquidity provision, market making, or affiliated trading, users are not simply "earning interest"; they are taking credit and operational risk against a venue whose balance sheet they cannot inspect.
+
+### 3.3 Withdrawal complaints and account-balance changes
+
+The SFC warning referred to complaints and media reports that retail investors were unable to withdraw virtual assets from JPEX accounts or had seen account balances reduced or altered. Soon after, users reported a withdrawal-fee structure that was economically equivalent to a freeze: a fee of 999 USDT against a 1,000 USDT withdrawal cap meant that a user attempting to withdraw the capped amount would receive almost nothing.
+
+This is one of the clearest market-health signals in any custodial crypto failure. A platform does not need to announce insolvency to trap users. It can instead impose limits, fees, maintenance windows, token-conversion requirements, or identity-review delays that preserve the appearance of functionality while preventing meaningful exits.
+
+### 3.4 Influencer and OTC-shop promotion
+
+The SFC said JPEX had been actively promoted to the Hong Kong public through social media influencers, key opinion leaders, and OTC virtual asset money changers. The regulator also stated that some promoters had made false or misleading statements suggesting JPEX had applied for a Hong Kong virtual asset trading platform licence, either independently or through a partnership, when no JPEX entity had submitted such an application.
+
+This promotional layer was central to the incident. Crypto exchange risk usually appears technical, but the JPEX case demonstrates a distribution problem: retail harm can scale when unlicensed platform claims are amplified through trusted local channels. Even if an influencer does not control custody, the influencer can materially lower the user's perceived risk of depositing assets.
+
+## 4. Collapse sequence
+
+### 4.1 Warning, denial, and user pressure
+
+After the SFC warning, JPEX publicly pushed back and accused the regulator of unfair treatment. The platform suggested that the SFC's action disrupted its operations and partners. From a market-health perspective, that response did not solve the core problem: users needed liquid withdrawals and clear custody assurance, not a public dispute over regulatory treatment.
+
+The timing created a classic run dynamic. Once the regulator publicly stated that the platform was unlicensed and users were reporting withdrawal trouble, rational users had reason to withdraw immediately. If the venue lacked full liquid backing, such a run would expose the shortfall quickly. If the venue did have full liquid backing, the economically rational response would have been to process withdrawals and publish credible proof. Instead, the reported fee and withdrawal changes intensified suspicion.
+
+### 4.2 Police action and arrests
+
+Hong Kong Police began arresting individuals connected to the promotion and operation of JPEX in September 2023. Early arrests included prominent influencer Joseph Lam Chok and other figures alleged to have promoted the platform. Authorities described the investigation as suspected fraud, and later updates reported many more arrests, charges against multiple individuals, and asset freezes.
+
+The exact criminal liability of each person is a matter for the courts, and not every promoter or arrested person should be treated as proven guilty. The market-health lesson is narrower and more durable: when exchange promotion depends on paid or incentivised intermediaries, the boundary between marketing, referral, and fraudulent inducement becomes a major risk surface.
+
+### 4.3 Loss estimates
+
+Loss estimates for JPEX have varied with time and source. Early reporting discussed roughly HK$1 billion in potential losses. Later updates commonly cited approximately HK$1.4 billion to HK$1.6 billion, or about US$180 million to US$206 million, and more than 2,600 user complaints. Those figures should be treated as reported or alleged losses rather than fully adjudicated final loss amounts.
+
+For market-health analysis, the exact final number is less important than the scale: JPEX was large enough to become one of Hong Kong's most significant retail crypto scandals. It was not a small phishing site or a single compromised wallet. It was a public-facing exchange brand that attracted broad retail participation before withdrawal access deteriorated.
+
+## 5. Risk mechanics
+
+### 5.1 Custodial opacity
+
+Users who deposited assets to JPEX lost direct control of those assets. They held a platform account balance, not a self-custodied on-chain position. That account balance was only as good as the platform's willingness and ability to process withdrawals. Without transparent reserves, segregated client assets, audited liabilities, or regulated custody controls, users could not independently verify whether JPEX had the assets it owed them.
+
+This is the same structural weakness seen across many exchange and lending failures. A user interface can show a balance even when the underlying assets have been lent, traded, misappropriated, frozen, or never held in full. The screen balance is a claim; it is not proof of custody.
+
+### 5.2 Yield as a liability-growth engine
+
+High-yield products accelerate custodial risk because they encourage users to keep assets on-platform rather than withdraw them. They also create a growing liability for the venue. If the platform promises or advertises double-digit annual returns on BTC, ETH, or stablecoins, it must either generate those returns through real economic activity, subsidise them from other revenue, or pay old users with new deposits.
+
+That does not prove a Ponzi structure in every case, but it creates a solvency question that cannot be answered from marketing materials. Sustainable exchange yield should be accompanied by transparent risk disclosures, clear source-of-yield explanation, segregation of assets, and evidence that liabilities match assets.
+
+### 5.3 Withdrawal gates as insolvency signal
+
+Withdrawal gates are among the most reliable early warnings of custodial distress. In JPEX, reports of withdrawal difficulty and extreme withdrawal fees appeared around the same period as the SFC warning. The fee structure was especially important because it preserved the form of withdrawal access while destroying the economic substance.
+
+From a surveillance perspective, a 999 USDT fee on a 1,000 USDT withdrawal cap should be treated the same as a freeze. Users may still technically be able to press a withdrawal button, but the transaction no longer provides a meaningful exit. Monitoring systems that only track whether withdrawals are "enabled" will miss this type of soft freeze.
+
+### 5.4 Licence arbitrage and marketing ambiguity
+
+JPEX's alleged use of licence-like language illustrates a recurring crypto-market problem: regulatory terms are jurisdiction-specific, but marketing language is global and vague. A platform may say it is "registered," "recognised," "regulated," "licensed," "compliant," or "applying," while none of those claims means it is authorised to provide retail exchange services in a user's jurisdiction.
+
+This ambiguity is especially dangerous in cross-border crypto markets. Users see a website in their language, local influencers promoting it, and claims about overseas registrations. They may assume local legality and recourse where none exists. Regulators, by contrast, assess specific legal entities, specific services, and specific jurisdictions.
+
+## 6. Market-health implications
+
+### 6.1 Influencer marketing as financial infrastructure
+
+The JPEX case shows that influencer marketing can function as financial infrastructure. It is not merely advertising. It determines which platforms retail users trust, where they deposit assets, and whether they ignore risk warnings. When influencers present exchange participation as a lifestyle, investment opportunity, or insider community, they can turn reputational capital into user deposits.
+
+This creates several market risks:
+
+1. **Asymmetric incentives**: Promoters may be paid upfront while users bear long-tail custody risk.
+2. **Poor due diligence**: Influencers may not verify licence status, reserves, ownership, or custody controls.
+3. **Social proof loops**: Multiple promoters create the impression of broad legitimacy even if all are relying on the same weak claims.
+4. **Delayed risk recognition**: Followers may dismiss official warnings as hostile to the community or innovation.
+
+For regulators, policing only the exchange entity may be insufficient. The distribution network that brings users to an unlicensed platform can be just as important as the platform itself.
+
+### 6.2 OTC shops as trust bridges
+
+OTC crypto shops can bridge online exchange risk into the physical world. A user who might distrust an offshore website may feel safer if a local shop helps them convert cash or transfer assets. In the JPEX context, the SFC specifically mentioned OTC virtual asset money changers as part of the promotional channel.
+
+The trust bridge matters because retail users often interpret physical presence as accountability. A shopfront, local staff member, or face-to-face transaction can make the platform seem reachable. But unless the shop is legally responsible for the exchange's custody and withdrawals, that comfort may be misplaced.
+
+### 6.3 Regulated-market credibility spillover
+
+Hong Kong had positioned itself as a regulated virtual-asset hub. That created a positive signal for compliant firms, but it also created an opportunity for unlicensed firms to borrow credibility from the broader policy environment. If users hear that Hong Kong is embracing digital assets, they may be more receptive to platforms claiming to be part of that ecosystem.
+
+The JPEX incident therefore became a credibility test for the regime. Swift public warnings, arrests, and enforcement activity signalled that the licensing framework was not merely symbolic. At the same time, the size of the alleged losses showed that warning lists and public statements may not prevent harm once an unlicensed platform has already built distribution.
+
+### 6.4 Proof of reserves is necessary but not sufficient
+
+One lesson from exchange failures is the need for proof of reserves. For a JPEX-like platform, however, proof of reserves would only be one control. A venue also needs proof of liabilities, segregation of client assets, clear legal entity responsibility, withdrawal-history reliability, and regulation over how products are marketed.
+
+An exchange could publish wallet balances while still hiding liabilities, related-party lending, tokenised internal claims, or withdrawal restrictions. Market-health monitoring should therefore combine on-chain reserve analysis with off-chain legal and conduct indicators.
+
+## 7. Detection and prevention framework
+
+### 7.1 Red flags for users
+
+Users evaluating a custodial crypto platform should treat the following as high-risk signals:
+
+1. **Licence ambiguity**: The platform claims to be registered or recognised but does not appear on the local regulator's licensed-platform list.
+2. **High fixed yields**: BTC, ETH, or stablecoin returns are advertised without clear risk, borrower, or strategy disclosure.
+3. **Influencer-heavy distribution**: Promotion relies more on personalities than on audited financial and custody information.
+4. **Withdrawal friction**: Withdrawal limits, extreme fees, repeated maintenance windows, or new verification demands appear during negative news.
+5. **Opaque ownership**: Users cannot identify the legal entity, jurisdiction, directors, custodian, or dispute forum responsible for their account.
+
+Any one of these signals warrants caution. Multiple signals together should be treated as a serious custody-risk warning.
+
+### 7.2 Controls for regulators
+
+The JPEX scandal points to several practical regulatory controls:
+
+1. **Fast public warning mechanisms**: Warning lists need to be visible, searchable, and pushed to the public before a platform reaches crisis scale.
+2. **Promotion liability**: Influencers, affiliates, and OTC shops should face clear obligations when promoting virtual asset platforms.
+3. **Licence-claim enforcement**: Misleading claims about applications, overseas registrations, or partnerships should be corrected quickly.
+4. **Withdrawal-gate monitoring**: Regulators should treat extreme fee changes and withdrawal caps as potential investor-protection events.
+5. **Public education**: Users need simple guidance that "registered somewhere" is not the same as "licensed here."
+
+### 7.3 Controls for exchanges
+
+Compliant exchanges can reduce JPEX-like contagion by making the contrast visible:
+
+1. Publish exact legal-entity and licence information.
+2. Avoid implying approval before a licence is actually granted.
+3. Separate marketing teams from compliance approval of public claims.
+4. Disclose yield-product risks and sources of return.
+5. Maintain withdrawal capacity and publish incident-response procedures.
+
+The most important control is not a slogan about transparency. It is operational evidence: users should be able to verify who is holding their assets, under what licence, under what custody model, and with what withdrawal rights.
+
+## 8. Lessons learned
+
+The JPEX scandal was a reminder that crypto-market failures are not limited to hacks and smart-contract bugs. Retail losses can arise from old financial-fraud patterns expressed through new crypto distribution channels: unlicensed platforms, unrealistic returns, paid promoters, opaque custody, and withdrawal gates.
+
+For market observers, JPEX belongs in the same risk taxonomy as other centralized crypto failures, but with a distinct Hong Kong regulatory lesson. The platform's risk was visible before the final collapse of confidence: it was on the SFC Alert List, it made licence-like claims, it offered high returns, it used influencer promotion, and users reported withdrawal trouble. The failure was not that no signals existed. The failure was that those signals did not stop enough users from depositing assets before the gate came down.
+
+## 9. Conclusion
+
+JPEX became one of Hong Kong's defining retail crypto scandals because it combined custody opacity, aggressive marketing, high-yield claims, and regulatory ambiguity at the exact moment the city was building a formal virtual asset trading platform regime. The alleged losses, commonly reported in the HK$1.4 billion to HK$1.6 billion range, made clear that unlicensed exchange risk can scale quickly when promoters and OTC channels convert social trust into deposits.
+
+The central lesson is simple: a crypto account balance on an unlicensed platform is only a promise. Without regulated custody, transparent reserves and liabilities, credible withdrawal rights, and truthful promotion, that promise can disappear behind fee changes, withdrawal limits, and legal disputes. For users, regulators, and compliant exchanges, JPEX is a case study in why market health depends as much on conduct, licensing, and custody governance as it does on blockchain technology.


### PR DESCRIPTION
Contribution to #277.

Adds a market-health article on the 2023 JPEX unlicensed exchange scandal in Hong Kong, covering the SFC warning, influencer/KOL and OTC-shop promotion, withdrawal-gate mechanics, alleged HK$1.4B-HK$1.6B retail losses, police action, and custody/market-conduct controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Added a new market-health research article documenting the September 2023 JPEX unlicensed exchange scandal in Hong Kong and its implications for financial market infrastructure and retail investor protection.

## Changes
- **New file:** `content/research/market-health/posts/2026-05-05-jpex/index.md` (+200 lines)
  - Comprehensive post-mortem analysis of the JPEX incident covering regulatory warnings, influencer promotion channels, withdrawal mechanics, and estimated retail losses of HK$1.4B-HK$1.6B
  - Structured narrative spanning incident background (VATP licensing regime context), trigger events (SFC warning, red flags), collapse sequence (public denial, arrests), underlying risk mechanics (custody opacity, yield-driven liability growth, withdrawal gates), and market-health implications
  - Includes detection/prevention framework for users, regulators, and exchanges, plus lessons learned and guidance

## Scope
Market-health content documentation only; no code changes or public API alterations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->