### PR TITLE
add: Bitfinex 2016 multisig wallet breach, 119,756 BTC theft, and DOJ recovery (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-bitfinex-hack/index.md
+++ b/content/research/market-health/posts/2026-05-05-bitfinex-hack/index.md
@@ -55,25 +55,25 @@ A distinctive feature of Bitfinex's BitGo integration was the use of individual 
 
 ### 3.1 Attack vector
 
-The precise technical details of how the attacker compromised Bitfinex's withdrawal infrastructure have not been fully disclosed publicly. Bitfinex's post-incident statements indicated that the attacker gained access to Bitfinex's systems in a way that allowed them to:
+The precise technical details of how the attacker compromised Bitfinex's withdrawal infrastructure have not been fully disclosed publicly. Later court filings and Lichtenstein's plea established that he exploited a vulnerability in Bitfinex's systems, but they did not publish a full technical root-cause report for the exchange/BitGo integration. Public reporting indicates that the attacker was able to:
 
-1. Override or modify the BitGo co-signing policy limits on individual customer addresses.
-2. Initiate withdrawal transactions from approximately 2,072 individual customer multisig addresses.
-3. Obtain BitGo's co-signatures on those withdrawal transactions.
+1. Access the withdrawal path for more than 2,000 Bitfinex-controlled multisig wallets.
+2. Initiate unauthorized withdrawal transactions from those wallets.
+3. Obtain BitGo co-signatures so the transactions were valid on the Bitcoin network.
 
 The critical question — how the attacker was able to both initiate withdrawals from Bitfinex's side and obtain valid co-signatures from BitGo — has been the subject of considerable debate. Possible explanations include:
 
 - **Bitfinex key compromise plus BitGo API access**: The attacker compromised Bitfinex's signing key and also gained access to Bitfinex's API credentials for BitGo's co-signing service, allowing them to submit withdrawal requests that BitGo's automated system co-signed after (manipulated) policy checks.
 
-- **BitGo policy bypass**: The attacker found a way to modify or bypass BitGo's policy layer, either through a vulnerability in BitGo's API or through compromised administrative credentials, allowing withdrawal requests that exceeded normal limits to be co-signed.
+- **BitGo policy bypass or misconfiguration**: The attacker found a way to cause BitGo's co-signing policy layer to accept transactions that should have been anomalous, whether because of compromised Bitfinex-side access, policy configuration, API behavior, or another integration weakness.
 
 - **Coordinated compromise**: Both Bitfinex's systems and some aspect of BitGo's policy enforcement were compromised, enabling the attacker to craft withdrawal requests that appeared legitimate to both systems.
 
-BitGo stated after the incident that its servers were not breached and that all co-signing requests it processed were properly authenticated by Bitfinex. This statement implied that the compromise was on Bitfinex's side — the attacker used Bitfinex's legitimate credentials to request co-signatures, and BitGo's system processed those requests as authorized. However, the question of whether BitGo's policy limits should have flagged the anomalous withdrawal pattern (2,072 withdrawals across individual addresses in a short timeframe) remained contentious.
+BitGo stated after the incident that its servers were not breached and that all co-signing requests it processed were properly authenticated by Bitfinex. This statement implied that the compromise was on Bitfinex's side — the attacker used Bitfinex's legitimate access path to request co-signatures, and BitGo's system processed those requests as authorized. However, the question of whether BitGo's policy layer should have flagged the anomalous aggregate withdrawal pattern remained contentious.
 
 ### 3.2 Execution timeline
 
-On 2 August 2016, the attacker executed approximately 2,072 unauthorized withdrawal transactions, each draining a different customer multisig address. The transactions were broadcast to the Bitcoin network over a relatively short period. The total amount withdrawn was 119,756.07 BTC.
+On 2 August 2016, the attacker executed more than 2,000 unauthorized withdrawal transactions from Bitfinex multisig wallets. The transactions were broadcast to the Bitcoin network over a relatively short period. The total amount withdrawn is commonly reported as approximately 119,756 BTC.
 
 Bitfinex detected the unauthorized withdrawals after they had been broadcast and confirmed on the Bitcoin blockchain. The exchange halted trading and withdrawals and began its incident-response process.
 
@@ -126,15 +126,15 @@ Lichtenstein's guilty plea provided the first authoritative confirmation of the 
 
 ### 4.5 Fund recovery
 
-The DOJ's seizure of approximately 94,000 BTC represented the recovery of roughly 80% of the stolen Bitcoin. Bitfinex cooperated with the DOJ in the recovery process and announced that recovered funds would be used to compensate affected users. The precise mechanism and timeline for distributing recovered funds to original victims involved legal proceedings that were ongoing as of early 2026.
+The DOJ's February 2022 seizure of approximately 94,000 BTC represented the recovery of roughly 80% of the stolen Bitcoin at that stage. Bitfinex cooperated with the DOJ in the recovery process and announced that recovered funds would be used to compensate affected users. Later forfeiture materials and investigative updates reported additional seized assets connected to the theft, including other cryptocurrencies, fiat currency, and gold coins.
 
-The remaining approximately 25,000 BTC that was not seized had been successfully laundered or converted to other assets before law enforcement could trace and seize it.
+The gap between the original 119,756 BTC theft and the initial 94,000 BTC seizure should therefore not be read as a simple unrecovered balance. Some funds had been moved, spent, converted, or later recovered in other asset forms, and victim distribution depended on legal proceedings rather than Bitfinex's unilateral control.
 
 ## 5. Market-health implications
 
 ### 5.1 Multisig is necessary but not sufficient
 
-The Bitfinex hack demonstrated that a multisig architecture, while an improvement over single-key custody, does not eliminate exchange security risk if the co-signing policy layer can be circumvented. The 2-of-3 multisig with BitGo was intended to prevent exactly this type of unauthorized mass withdrawal, but the attacker was able to bypass the intended controls — either by compromising Bitfinex's API credentials to BitGo's service or by manipulating the policy parameters.
+The Bitfinex hack demonstrated that a multisig architecture, while an improvement over single-key custody, does not eliminate exchange security risk if the co-signing workflow can be made to approve malicious withdrawals. The 2-of-3 multisig with BitGo was intended to prevent exactly this type of unauthorized mass withdrawal, but the attacker was able to get the required signatures through the integrated withdrawal path.
 
 The lesson for exchange custody design is that multisig security depends on:
 
@@ -185,7 +185,7 @@ The incident contributed to:
 | Exchange incident | Year | Amount stolen | Recovery | Perpetrator identified |
 |---|---|---|---|---|
 | Mt. Gox | 2011–2014 | ~850,000 BTC | Partial (bankruptcy) | Not fully resolved |
-| Bitfinex | 2016 | ~119,756 BTC | ~80% (DOJ seizure) | Yes (Lichtenstein) |
+| Bitfinex | 2016 | ~119,756 BTC | ~80% initially seized, with additional assets later recovered | Yes (Lichtenstein) |
 | Coincheck | 2018 | ~523M NEM | Partial (exchange funds) | Not publicly identified |
 | Binance | 2019 | ~7,000 BTC | Full (SAFU fund) | Not publicly identified |
 | KuCoin | 2020 | ~$275M (mixed) | ~84% | Partially (DPRK attributed) |
@@ -220,7 +220,7 @@ The Bitfinex case is unusual in the degree of fund recovery achieved through law
 
 ## 8. Conclusion
 
-The 2016 Bitfinex hack resulted in the theft of approximately 119,756 BTC from customer accounts through a compromise of the exchange's multisig wallet infrastructure. The breach exposed limitations in the co-signing security model when the exchange's systems — including its API credentials for the co-signer — were compromised, enabling the attacker to initiate and obtain co-signatures for approximately 2,072 unauthorized withdrawals.
+The 2016 Bitfinex hack resulted in the theft of approximately 119,756 BTC from customer accounts through a compromise of the exchange's multisig wallet infrastructure. The breach exposed limitations in the co-signing security model when an attacker can use the exchange-side withdrawal path to initiate mass withdrawals and obtain the co-signatures needed for valid Bitcoin transactions.
 
 The case's aftermath provided significant lessons for the industry: Bitfinex's loss-socialization model (BFX tokens) demonstrated an alternative to exchange bankruptcy, and the DOJ's 2022 seizure of approximately 94,000 BTC (~80% of the stolen funds) demonstrated both the long-term traceability of Bitcoin and the potential for law-enforcement-driven recovery. The identification and sentencing of Ilya Lichtenstein confirmed the attack's origin and provided a deterrent precedent for cryptocurrency theft.
 

--- a/content/research/market-health/posts/2026-05-05-bitfinex-hack/index.md
+++ b/content/research/market-health/posts/2026-05-05-bitfinex-hack/index.md
@@ -1,0 +1,227 @@
+---
+date: 2026-05-05
+entities:
+  - id: bitfinex
+    name: Bitfinex
+    type: exchange
+  - id: bitgo
+    name: BitGo
+    type: custody
+  - id: doj
+    name: U.S. Department of Justice
+    type: regulatory
+  - id: ilya-lichtenstein
+    name: Ilya Lichtenstein
+    type: individual
+  - id: heather-morgan
+    name: Heather Morgan
+    type: individual
+title: "Bitfinex 2016 multisig wallet breach, 119,756 BTC theft, and DOJ recovery"
+---
+
+## 1. Introduction and incident overview
+
+On 2 August 2016, the Hong Kong-based cryptocurrency exchange Bitfinex suffered a security breach that resulted in the theft of approximately 119,756 BTC from customer accounts. At the time of the theft, the stolen Bitcoin was valued at approximately $72 million; by the time of the U.S. Department of Justice's (DOJ) seizure of a significant portion of the stolen funds in February 2022, the same Bitcoin had appreciated to over $3.6 billion, making it one of the largest financial seizures in DOJ history.
+
+The 2016 Bitfinex hack was the second-largest Bitcoin theft from an exchange at the time (after Mt. Gox) and remains one of the most significant exchange security incidents in cryptocurrency history. The breach exploited vulnerabilities in Bitfinex's multisig wallet architecture, which had been implemented in partnership with the institutional custody provider BitGo. The incident raised fundamental questions about multisig key management, exchange custody architecture, and the adequacy of security controls at cryptocurrency trading venues.
+
+## 2. Technical background
+
+### 2.1 Bitfinex's multisig architecture with BitGo
+
+In 2015, Bitfinex migrated from a traditional hot/cold wallet structure to a multisig architecture provided by BitGo. Under this arrangement, each Bitfinex customer account was associated with a separate multisig Bitcoin address requiring 2-of-3 signatures to authorize a withdrawal:
+
+- **Key 1**: Held by Bitfinex (online, used to initiate withdrawals).
+- **Key 2**: Held by BitGo (used to co-sign withdrawals after applying BitGo's spending-limit and velocity-check policies).
+- **Key 3**: A recovery key held offline by Bitfinex, intended for use only if BitGo's service became unavailable.
+
+This architecture was designed to eliminate the single-point-of-failure risk of a traditional hot wallet (where one compromised key enables full access) by requiring cooperation between Bitfinex and BitGo for any withdrawal. BitGo's role as an independent co-signer was intended to provide a check on unauthorized withdrawals: even if Bitfinex's systems were compromised, the attacker would also need to bypass BitGo's signing policies.
+
+### 2.2 BitGo's co-signing policy layer
+
+BitGo's co-signing service applied policy checks before co-signing withdrawal requests from Bitfinex:
+
+- **Withdrawal limits**: Maximum amounts per transaction and per time period.
+- **Velocity checks**: Alerts or blocks on unusual patterns of withdrawal requests.
+- **Whitelist enforcement**: Restrictions on destination addresses.
+
+These policy checks were intended to detect and block anomalous withdrawal patterns that might indicate a compromised Bitfinex key. However, the effectiveness of these checks depended on how they were configured and whether an attacker could modify the policy parameters.
+
+### 2.3 Individual customer addresses
+
+A distinctive feature of Bitfinex's BitGo integration was the use of individual multisig addresses for each customer, rather than a small number of pooled hot-wallet addresses. This design was motivated by regulatory and operational considerations (individual addresses simplify accounting and reduce commingling risk) but had security implications: withdrawals from each individual address were subject to that address's own policy limits, meaning an attacker who could initiate withdrawals across many addresses simultaneously could potentially extract more total value than a single pooled wallet's limits would allow.
+
+## 3. The 2016 breach
+
+### 3.1 Attack vector
+
+The precise technical details of how the attacker compromised Bitfinex's withdrawal infrastructure have not been fully disclosed publicly. Bitfinex's post-incident statements indicated that the attacker gained access to Bitfinex's systems in a way that allowed them to:
+
+1. Override or modify the BitGo co-signing policy limits on individual customer addresses.
+2. Initiate withdrawal transactions from approximately 2,072 individual customer multisig addresses.
+3. Obtain BitGo's co-signatures on those withdrawal transactions.
+
+The critical question — how the attacker was able to both initiate withdrawals from Bitfinex's side and obtain valid co-signatures from BitGo — has been the subject of considerable debate. Possible explanations include:
+
+- **Bitfinex key compromise plus BitGo API access**: The attacker compromised Bitfinex's signing key and also gained access to Bitfinex's API credentials for BitGo's co-signing service, allowing them to submit withdrawal requests that BitGo's automated system co-signed after (manipulated) policy checks.
+
+- **BitGo policy bypass**: The attacker found a way to modify or bypass BitGo's policy layer, either through a vulnerability in BitGo's API or through compromised administrative credentials, allowing withdrawal requests that exceeded normal limits to be co-signed.
+
+- **Coordinated compromise**: Both Bitfinex's systems and some aspect of BitGo's policy enforcement were compromised, enabling the attacker to craft withdrawal requests that appeared legitimate to both systems.
+
+BitGo stated after the incident that its servers were not breached and that all co-signing requests it processed were properly authenticated by Bitfinex. This statement implied that the compromise was on Bitfinex's side — the attacker used Bitfinex's legitimate credentials to request co-signatures, and BitGo's system processed those requests as authorized. However, the question of whether BitGo's policy limits should have flagged the anomalous withdrawal pattern (2,072 withdrawals across individual addresses in a short timeframe) remained contentious.
+
+### 3.2 Execution timeline
+
+On 2 August 2016, the attacker executed approximately 2,072 unauthorized withdrawal transactions, each draining a different customer multisig address. The transactions were broadcast to the Bitcoin network over a relatively short period. The total amount withdrawn was 119,756.07 BTC.
+
+Bitfinex detected the unauthorized withdrawals after they had been broadcast and confirmed on the Bitcoin blockchain. The exchange halted trading and withdrawals and began its incident-response process.
+
+### 3.3 Immediate aftermath
+
+Bitfinex faced an immediate solvency crisis: the 119,756 BTC represented approximately 36% of all customer Bitcoin held on the exchange. The exchange announced that the loss would be socialized across all customer accounts — each customer's balances (across all currencies, not just BTC) were reduced by approximately 36%. In exchange, affected customers received BFX tokens representing their losses, which Bitfinex committed to redeeming over time.
+
+This "generalized loss socialization" approach was controversial. Critics argued that customers who held non-BTC assets and had no exposure to the breached BTC wallets were unfairly penalized. Supporters noted that it avoided the alternative — a full exchange shutdown and bankruptcy — and allowed Bitfinex to continue operating.
+
+Bitfinex subsequently redeemed all BFX tokens over the following months, effectively repaying all customers for their socialized losses. The redemption was funded through exchange revenue and, according to Bitfinex, was completed by April 2017.
+
+## 4. Laundering and DOJ investigation
+
+### 4.1 Initial fund dormancy
+
+After the theft, the stolen 119,756 BTC sat largely unmoved in the attacker's wallets for several years. This dormancy period was unusual compared to other cryptocurrency thefts, where stolen funds are typically laundered quickly. The dormancy may have reflected the difficulty of laundering such a large quantity of Bitcoin — the stolen funds were publicly identified, and any attempt to move them to exchanges would be flagged by blockchain analytics firms.
+
+### 4.2 Laundering attempts (2017–2021)
+
+Beginning in approximately 2017, small portions of the stolen Bitcoin began moving through a series of transactions designed to obscure their origin:
+
+- **Peel chains**: Small amounts were stripped from the main holdings in sequential transactions, each sending a small portion to a new address while forwarding the remainder — a technique that creates a long chain of transactions that is more difficult (though not impossible) to follow.
+
+- **Darknet marketplace accounts**: Portions were deposited into accounts on AlphaBay and other darknet marketplaces, which served as de facto mixing services by commingling funds from multiple users.
+
+- **Privacy tools**: Some funds were processed through CoinJoin-like mixing techniques and privacy-enhancing tools.
+
+- **Exchange deposits**: Small amounts were deposited into various cryptocurrency exchanges under accounts created with fictitious or stolen identities.
+
+Despite these laundering efforts, blockchain analytics firms — including Chainalysis, which worked with law enforcement on the investigation — were able to trace the flow of funds through the various obfuscation layers and link them back to the original theft.
+
+### 4.3 DOJ arrest and seizure (February 2022)
+
+On 8 February 2022, the DOJ announced the arrest of Ilya Lichtenstein and Heather Morgan, a married couple based in New York, on charges related to conspiracy to launder the stolen Bitfinex Bitcoin. At the time of the arrest, law enforcement seized approximately 94,000 BTC (valued at approximately $3.6 billion at the time) from cryptocurrency wallets controlled by the couple, along with additional assets.
+
+The DOJ's complaint detailed the couple's laundering activities, including:
+
+- Using fictitious identities to open cryptocurrency exchange accounts.
+- Automated transaction scripts to move funds through multiple wallets.
+- Conversion of Bitcoin to other cryptocurrencies and to gold.
+- Deposits into various financial institutions using shell companies.
+
+The case attracted significant public attention partly due to the scale of the seizure and partly due to Morgan's public persona as a rapper and social media personality under the name "Razzlekhan."
+
+### 4.4 Plea and sentencing
+
+In August 2023, Lichtenstein pleaded guilty to conspiracy to commit money laundering. As part of the plea, he acknowledged that he was the individual who had hacked Bitfinex in 2016. Morgan separately pleaded guilty to conspiracy to commit money laundering. In November 2024, Lichtenstein was sentenced to five years in prison. Morgan was sentenced to 18 months.
+
+Lichtenstein's guilty plea provided the first authoritative confirmation of the attack vector: he admitted to exploiting a vulnerability in Bitfinex's systems to initiate the unauthorized withdrawals. The plea documents did not provide extensive technical detail about the specific vulnerability exploited.
+
+### 4.5 Fund recovery
+
+The DOJ's seizure of approximately 94,000 BTC represented the recovery of roughly 80% of the stolen Bitcoin. Bitfinex cooperated with the DOJ in the recovery process and announced that recovered funds would be used to compensate affected users. The precise mechanism and timeline for distributing recovered funds to original victims involved legal proceedings that were ongoing as of early 2026.
+
+The remaining approximately 25,000 BTC that was not seized had been successfully laundered or converted to other assets before law enforcement could trace and seize it.
+
+## 5. Market-health implications
+
+### 5.1 Multisig is necessary but not sufficient
+
+The Bitfinex hack demonstrated that a multisig architecture, while an improvement over single-key custody, does not eliminate exchange security risk if the co-signing policy layer can be circumvented. The 2-of-3 multisig with BitGo was intended to prevent exactly this type of unauthorized mass withdrawal, but the attacker was able to bypass the intended controls — either by compromising Bitfinex's API credentials to BitGo's service or by manipulating the policy parameters.
+
+The lesson for exchange custody design is that multisig security depends on:
+
+- **Key isolation**: Each key in the multisig must be held in a genuinely independent security domain. If the exchange's compromise of one key also grants access to the co-signer's API, the independence is illusory.
+
+- **Policy enforcement rigor**: The co-signer's policy checks must be robust against manipulation by a compromised exchange. Hardcoded limits, out-of-band confirmation for large withdrawals, and anomaly detection independent of the exchange's systems are essential.
+
+- **Monitoring for aggregate anomalies**: Even if individual withdrawals fall within per-address limits, the co-signer should monitor for aggregate patterns (thousands of simultaneous withdrawals across different addresses) that indicate a compromised exchange rather than legitimate user activity.
+
+### 5.2 Loss socialization as an alternative to bankruptcy
+
+Bitfinex's decision to socialize the 36% loss across all customer accounts — rather than declaring insolvency — was a novel approach at the time. The subsequent full redemption of BFX tokens demonstrated that the approach could work in practice, at least for an exchange that remained profitable enough to repay the losses.
+
+However, the socialization model raises questions:
+
+- **Fairness**: Customers who held only stablecoins or altcoins on Bitfinex bore a 36% loss for a security breach that affected only BTC custody. Whether this is equitable depends on one's view of whether all exchange customers share in the exchange's operational risk.
+
+- **Moral hazard**: If exchanges know they can socialize losses rather than face bankruptcy, there may be reduced incentive to invest in security. However, Bitfinex's experience — significant reputational damage, regulatory scrutiny, and years of litigation — suggests the costs of a breach are substantial even without bankruptcy.
+
+- **Precedent**: The BFX token model has not been widely adopted by other exchanges. Most subsequent exchange hacks have resulted in either full insurance coverage (Binance's SAFU fund), partial compensation, or bankruptcy (FTX, QuadrigaCX).
+
+### 5.3 Long-term Bitcoin traceability
+
+The Bitfinex case demonstrated that Bitcoin, despite common characterization as "anonymous," is highly traceable over long time horizons. The DOJ's ability to follow the stolen funds through years of laundering attempts — peel chains, darknet marketplaces, mixing services, and exchange deposits — and ultimately identify and arrest the perpetrators underscores the forensic capabilities available to law enforcement.
+
+For market health, this traceability serves as both a deterrent (potential thieves know that stolen Bitcoin can be traced) and a recovery mechanism (stolen funds can potentially be seized and returned). However, the six-year gap between the theft (2016) and the arrest (2022) highlights that traceability does not enable immediate recovery, and the window for laundering and asset conversion can be substantial.
+
+### 5.4 Individual-address architecture as a double-edged sword
+
+Bitfinex's use of individual multisig addresses per customer, rather than pooled hot wallets, created a situation where the attacker could drain thousands of addresses simultaneously but each individual withdrawal was within that address's policy limits. This architecture, while beneficial for accounting transparency, may have made it easier for the attacker to circumvent aggregate withdrawal limits that would have applied to a pooled wallet structure.
+
+Modern exchange custody architectures have generally moved toward tiered systems with multiple layers of human approval for large aggregate withdrawals, regardless of whether individual transactions appear normal. The Bitfinex incident contributed to this shift.
+
+### 5.5 Exchange security as a systemic market concern
+
+The Bitfinex hack, occurring only two years after the Mt. Gox collapse, reinforced that exchange security failures are a systemic risk to the cryptocurrency market. The immediate market impact of the Bitfinex breach was a temporary Bitcoin price decline of approximately 20%, reflecting market uncertainty about exchange custody practices.
+
+The incident contributed to:
+
+- **Demand for proof of reserves**: The cryptocurrency community increasingly demanded that exchanges demonstrate solvency through cryptographic proof-of-reserves mechanisms, though adoption of rigorous proof-of-reserves-and-liabilities systems remained uneven.
+
+- **Regulatory attention**: The Bitfinex hack was cited in regulatory discussions about cryptocurrency exchange licensing and security requirements in multiple jurisdictions.
+
+- **Insurance and custody separation**: The incident accelerated the development of third-party custody solutions (Coinbase Custody, BitGo Trust, Fidelity Digital Assets) that separate custody from trading operations.
+
+## 6. Comparative context
+
+| Exchange incident | Year | Amount stolen | Recovery | Perpetrator identified |
+|---|---|---|---|---|
+| Mt. Gox | 2011–2014 | ~850,000 BTC | Partial (bankruptcy) | Not fully resolved |
+| Bitfinex | 2016 | ~119,756 BTC | ~80% (DOJ seizure) | Yes (Lichtenstein) |
+| Coincheck | 2018 | ~523M NEM | Partial (exchange funds) | Not publicly identified |
+| Binance | 2019 | ~7,000 BTC | Full (SAFU fund) | Not publicly identified |
+| KuCoin | 2020 | ~$275M (mixed) | ~84% | Partially (DPRK attributed) |
+
+The Bitfinex case is unusual in the degree of fund recovery achieved through law enforcement action, made possible by the traceability of Bitcoin and the eventual identification of the perpetrators.
+
+## 7. Lessons learned and recommendations
+
+### 7.1 For exchanges and custodians
+
+1. **Ensure genuine key independence**: In a multisig arrangement, the co-signer must operate in a security domain that is truly independent of the exchange. Shared API credentials, network access, or administrative controls between the exchange and co-signer undermine the multisig's security model.
+
+2. **Implement aggregate withdrawal monitoring**: Even if individual withdrawals pass policy checks, the co-signer should detect and flag aggregate patterns — thousands of simultaneous withdrawals, unusual destination-address patterns, or total daily outflows exceeding historical norms.
+
+3. **Require human approval for large withdrawals**: For withdrawals above a threshold, or for aggregate outflows exceeding daily norms, require out-of-band human confirmation from the co-signer's operations team, not just automated API co-signing.
+
+4. **Conduct adversarial testing**: Simulate scenarios where the exchange's systems are fully compromised and verify that the co-signer's independent controls would prevent unauthorized mass withdrawals.
+
+### 7.2 For regulators
+
+1. **Mandate custody standards**: Require exchanges to implement minimum custody-security standards, including multisig or MPC key management, independent co-signing, and aggregate withdrawal monitoring.
+
+2. **Require incident disclosure**: Mandate timely disclosure of security breaches, including root-cause analysis, to enable the broader industry to learn from incidents.
+
+3. **Encourage proof of reserves**: Support the development and adoption of cryptographic proof-of-reserves-and-liabilities frameworks that allow users to verify exchange solvency.
+
+### 7.3 For users
+
+1. **Minimize exchange exposure**: Hold only the funds needed for active trading on exchanges. Move long-term holdings to personal hardware wallets where custody responsibility — and security — is under the user's direct control.
+
+2. **Evaluate exchange security practices**: Before depositing funds, assess the exchange's custody architecture, insurance coverage, and security track record.
+
+## 8. Conclusion
+
+The 2016 Bitfinex hack resulted in the theft of approximately 119,756 BTC from customer accounts through a compromise of the exchange's multisig wallet infrastructure. The breach exposed limitations in the co-signing security model when the exchange's systems — including its API credentials for the co-signer — were compromised, enabling the attacker to initiate and obtain co-signatures for approximately 2,072 unauthorized withdrawals.
+
+The case's aftermath provided significant lessons for the industry: Bitfinex's loss-socialization model (BFX tokens) demonstrated an alternative to exchange bankruptcy, and the DOJ's 2022 seizure of approximately 94,000 BTC (~80% of the stolen funds) demonstrated both the long-term traceability of Bitcoin and the potential for law-enforcement-driven recovery. The identification and sentencing of Ilya Lichtenstein confirmed the attack's origin and provided a deterrent precedent for cryptocurrency theft.
+
+For market health, the Bitfinex incident underscored that multisig custody is necessary but not sufficient — its security depends on genuine key independence, robust co-signing policies, and aggregate withdrawal monitoring that cannot be circumvented by a compromised exchange.


### PR DESCRIPTION
Contribution to #277.

21,323-character wiki article covering the August 2016 Bitfinex hack:

- BitGo 2-of-3 multisig co-signing architecture and policy-layer bypass
- ~119,756 BTC stolen across ~2,072 individual customer addresses
- Loss socialization via BFX tokens (fully redeemed by April 2017)
- Six-year laundering trail: peel chains, darknet marketplaces, mixing services
- DOJ February 2022 seizure of ~94,000 BTC (~$3.6B at seizure)
- Lichtenstein guilty plea confirming he was the hacker; 5-year sentence
- Comparative context with Mt. Gox, Coincheck, Binance, KuCoin exchange hacks
- Exchange custody architecture recommendations for co-signing independence