### PR TITLE
add: Orbit Chain cross-chain bridge compromise and $82M validator key theft (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-orbit-chain/index.md
+++ b/content/research/market-health/posts/2026-05-05-orbit-chain/index.md
@@ -1,0 +1,193 @@
+---
+date: 2026-05-05
+entities:
+  - id: orbit-chain
+    name: Orbit Chain
+    type: defi
+  - id: ozys
+    name: Ozys
+    type: company
+  - id: lazarus-group
+    name: Lazarus Group
+    type: threat-actor
+  - id: klaytn
+    name: Klaytn
+    type: blockchain
+title: "Orbit Chain cross-chain bridge compromise, $82 M multi-asset theft, and validator key risk"
+---
+
+## 1. Introduction and incident overview
+
+On 31 December 2023 (with public disclosure on 1 January 2024), the South Korea-based cross-chain bridge protocol Orbit Chain suffered a security breach that resulted in the theft of approximately $82 million in cryptocurrency. The stolen assets included ETH, DAI, USDT, USDC, and WBTC, drained from the bridge's Ethereum-side vaults. The attack was attributed to a compromise of the multisig validator keys that controlled the bridge's cross-chain transfer authorization.
+
+Orbit Chain was developed by the South Korean blockchain company Ozys and served as a cross-chain bridge connecting Klaytn (a Korean Layer 1 blockchain) and other networks to Ethereum. The protocol used a multisig-based validation model where a set of validator signers authorized cross-chain transfers. The compromise of sufficient validator keys enabled the attacker to authorize fraudulent withdrawals from the bridge's Ethereum-side reserves without corresponding deposits on the source chains.
+
+## 2. Technical background
+
+### 2.1 Orbit Chain's bridge architecture
+
+Orbit Chain operated as a cross-chain bridge using a validator-based security model. The bridge's architecture consisted of:
+
+- **Deposit contracts**: On source chains (Klaytn, BSC, etc.), users deposited tokens into the bridge's deposit contracts to initiate a cross-chain transfer.
+- **Validator set**: A group of validator nodes monitored deposit events on source chains and, upon confirmation, collectively signed authorization messages for the corresponding withdrawal on the destination chain.
+- **Withdrawal contracts (vaults)**: On Ethereum, the bridge held reserves of ETH, stablecoins, and other tokens. When validators authorized a withdrawal (by providing sufficient multisig signatures), the vault released the corresponding assets to the recipient.
+
+The security of this model depended on the integrity of the validator set: if an attacker compromised enough validators to meet the multisig threshold, they could authorize arbitrary withdrawals from the bridge's vaults without corresponding deposits.
+
+### 2.2 Validator key management
+
+The bridge's validator set consisted of a relatively small number of signers, with the multisig threshold requiring a subset of them to authorize withdrawals. The specific number of total validators and the required threshold were not prominently disclosed in Orbit Chain's public documentation before the attack.
+
+Each validator held a private key used to sign withdrawal authorizations. The security of these keys — whether stored in HSMs, software wallets, or on internet-connected servers — determined the bridge's resilience against key-compromise attacks.
+
+### 2.3 Korean blockchain ecosystem context
+
+Orbit Chain was part of the Korean blockchain ecosystem centered around Klaytn, a Layer 1 blockchain developed by Kakao's blockchain subsidiary. The bridge facilitated cross-chain liquidity between Klaytn's DeFi ecosystem and Ethereum-based assets, making it an infrastructure-critical component for Korean blockchain users. Ozys, the developer, also operated other products in the Korean DeFi space.
+
+## 3. Attack execution
+
+### 3.1 Timeline
+
+The unauthorized withdrawals began on 31 December 2023 at approximately 21:00 UTC. The attacker executed a series of withdrawal transactions from Orbit Chain's Ethereum-side vaults over a period of several hours:
+
+- **ETH**: Approximately $30 million in ETH was withdrawn across multiple transactions.
+- **DAI**: Approximately $10 million in DAI.
+- **USDT**: Approximately $10 million in USDT.
+- **USDC**: Approximately $10 million in USDC.
+- **WBTC**: Approximately $22 million in wrapped Bitcoin.
+
+The total extraction was approximately $82 million. Each withdrawal transaction was accompanied by valid multisig signatures from the compromised validator keys, making the transactions indistinguishable from legitimate bridge operations at the protocol level.
+
+### 3.2 Attack vector
+
+Orbit Chain's post-incident investigation, conducted in collaboration with Korean law enforcement and blockchain security firms, identified the attack as a validator-key compromise. The specific mechanism of key compromise was described as an "unauthorized access to the multisig signers" without detailed public disclosure of the attack vector.
+
+Based on the pattern of the attack and subsequent attribution analysis, the likely attack vectors include:
+
+- **Social engineering of validator operators**: Phishing or social engineering targeting individuals who controlled validator keys, similar to the Radiant Capital attack pattern.
+- **Server compromise**: Exploitation of vulnerabilities in the servers hosting validator signing infrastructure.
+- **Insider access**: A compromise or collusion involving an individual with access to validator key material.
+
+The fact that the attacker obtained enough keys to meet the multisig threshold suggests either that the threshold was low relative to the total number of validators, or that the key-management infrastructure had a shared vulnerability that allowed multiple keys to be compromised simultaneously.
+
+### 3.3 Fund movement and laundering
+
+After the initial theft, the attacker moved the stolen funds through a series of addresses on Ethereum:
+
+1. **Stablecoin conversion**: USDT and USDC were at risk of being frozen by Tether and Circle. The attacker swapped portions to DAI (a decentralized stablecoin without a blacklist function) and ETH through DEXes.
+
+2. **Consolidation**: Funds were consolidated into a smaller number of addresses.
+
+3. **Mixer usage**: Portions of the ETH were sent to Tornado Cash despite OFAC sanctions on the mixer. This indicated that the attacker prioritized obfuscation over sanctions compliance, consistent with state-sponsored actors who are already sanctioned.
+
+4. **Staging**: Consistent with DPRK-linked patterns, the attacker distributed funds across multiple addresses rather than immediately liquidating, suggesting a staged laundering approach.
+
+## 4. Attribution
+
+### 4.1 DPRK linkage
+
+Blockchain analytics firms identified patterns consistent with North Korean-linked operations:
+
+- **Laundering infrastructure overlap**: The addresses and mixer usage matched patterns from confirmed DPRK operations.
+- **Timing and targeting**: The attack targeted a Korean blockchain bridge, consistent with DPRK cyber operations that have historically targeted South Korean financial and technology infrastructure.
+- **Operational pattern**: The multi-asset drain, rapid stablecoin-to-ETH conversion, and staged laundering through Tornado Cash matched the Lazarus Group playbook.
+
+While no official governmental attribution was publicly announced specifically for the Orbit Chain hack as of early 2026, the behavioral evidence strongly suggested DPRK involvement. The FBI included Orbit Chain-linked addresses in subsequent DPRK cryptocurrency-theft advisories.
+
+### 4.2 Korean law enforcement involvement
+
+Orbit Chain and Ozys cooperated with Korean law enforcement (specifically the Korean National Police Agency's cyber investigation division) and blockchain analytics firms to investigate the breach and trace the stolen funds. South Korea has been increasingly active in cryptocurrency crime investigation, partly driven by the high frequency of DPRK-linked attacks targeting Korean blockchain infrastructure.
+
+## 5. Orbit Chain's response
+
+### 5.1 Immediate actions
+
+Orbit Chain suspended all bridge operations immediately upon detecting the unauthorized withdrawals. The team published a notification on 1 January 2024 acknowledging the security incident and confirming that bridge services were paused.
+
+### 5.2 Communication
+
+Orbit Chain's communication was relatively prompt but light on technical detail. The team confirmed the approximate loss amount, stated that the attack involved unauthorized access to validator keys, and announced cooperation with law enforcement. A detailed technical post-mortem or root-cause analysis was not publicly released.
+
+### 5.3 Fund recovery efforts
+
+Orbit Chain stated that it was working with law enforcement and blockchain analytics firms to trace and potentially recover stolen funds. The team also contacted exchanges and stablecoin issuers to request freezing of identified attacker addresses.
+
+Tether froze a portion of the stolen USDT at attacker addresses. However, because the attacker had rapidly converted much of the stablecoins to ETH and DAI before freeze actions took effect, the frozen amount represented only a fraction of the total theft.
+
+### 5.4 User compensation
+
+As of early 2026, Orbit Chain had not announced a comprehensive user-compensation plan. The protocol's bridge remained suspended, and the status of user funds locked in the bridge's contracts on non-Ethereum chains (where depositors had sent tokens expecting cross-chain delivery) was uncertain.
+
+## 6. Market-health implications
+
+### 6.1 Cross-chain bridge validator-key risk
+
+The Orbit Chain hack added to a growing list of cross-chain bridge compromises caused by validator-key or multisig-key failures:
+
+| Bridge | Date | Amount | Key mechanism |
+|---|---|---|---|
+| Ronin Bridge | Mar 2022 | ~$625M | 5-of-9 validator key compromise |
+| Harmony Horizon | Jun 2022 | ~$100M | 2-of-5 validator key compromise |
+| Multichain | Jul 2023 | ~$126M | MPC key centralization (CEO) |
+| Orbit Chain | Dec 2023 | ~$82M | Multisig validator key compromise |
+
+The common pattern is that bridge security reduces to the security of the validator or multisig key set, and compromising a sufficient subset of keys enables full bridge drainage. This represents a fundamental architectural risk for bridges that use validator-based security models.
+
+### 6.2 Bridge security models compared
+
+Cross-chain bridges use several security models, each with different risk profiles:
+
+- **Validator/multisig bridges** (Ronin, Harmony, Orbit Chain): Security depends on the integrity of a small validator set. Compromising enough keys = full bridge control.
+- **MPC bridges** (Multichain): Security depends on the distribution and management of key shares. Concentrating shares = single point of failure.
+- **Optimistic bridges** (Nomad): Security depends on fraud-proof watchers. Initialization bugs or watcher failures = exploitable.
+- **ZK/proof-based bridges**: Security depends on the correctness of the cryptographic proof system. More theoretically robust but still immature.
+
+The Orbit Chain hack reinforced the industry consensus that validator-based bridge security is the weakest of these models, particularly when the validator set is small and the key-management infrastructure has shared vulnerabilities.
+
+### 6.3 New Year's Eve timing
+
+The attack's timing — New Year's Eve — may have been deliberate, exploiting a period when response teams are likely to be less available. Security incidents timed to holidays and weekends can benefit from slower detection and response, extending the window during which the attacker can move and launder funds.
+
+For exchange and protocol operators, this highlights the need for 24/7 automated monitoring with automated response capabilities that do not depend on human availability.
+
+### 6.4 Korean blockchain ecosystem concentration risk
+
+The Orbit Chain hack affected the Klaytn ecosystem disproportionately, as the bridge was a primary pathway for cross-chain liquidity to and from Klaytn. The loss of bridge functionality and the $82 million in lost funds reduced confidence in the Korean blockchain ecosystem's security and infrastructure maturity.
+
+For market surveillance, ecosystem-level concentration risk — where a single bridge or infrastructure provider handles a disproportionate share of cross-chain activity for a particular chain — creates systemic fragility. A bridge failure in such a concentrated ecosystem can effectively isolate the chain from cross-chain liquidity.
+
+## 7. Lessons learned and recommendations
+
+### 7.1 For bridge operators
+
+1. **Increase validator-set size and threshold**: Use larger validator sets with higher signing thresholds (e.g., 7-of-12 or higher). The cost of operating additional validators is small relative to the assets they secure.
+
+2. **Diversify validator infrastructure**: Ensure validators use different hardware, software stacks, cloud providers, and geographic locations. Shared infrastructure creates correlated compromise risk.
+
+3. **Implement withdrawal rate limits**: Enforce time-delayed, rate-limited withdrawals that create a detection window even if validator keys are compromised. Large withdrawals should trigger automatic pauses and require additional human confirmation.
+
+4. **Migrate toward proof-based security**: Where possible, move toward ZK-proof-based bridge architectures that do not depend on validator trust assumptions.
+
+5. **Maintain 24/7 monitoring**: Ensure that automated monitoring and response systems operate continuously, including during holidays and weekends.
+
+### 7.2 For users
+
+1. **Minimize funds locked in bridges**: Hold the minimum necessary amount in bridge contracts. Cross-chain bridging inherently involves trust in the bridge's security model, which has repeatedly proven fragile.
+
+2. **Prefer bridges with stronger security models**: When multiple bridge options exist, prefer bridges with larger validator sets, higher thresholds, timelocks, or proof-based security over those with small multisig validator sets.
+
+3. **Monitor bridge security disclosures**: Pay attention to bridge security audits, validator-set disclosures, and incident histories when choosing which bridges to use.
+
+### 7.3 For market surveillance
+
+1. **Track bridge vault balances**: Monitor the Ethereum-side vault balances of major bridges. Sudden, large decreases in vault balances outside normal operating patterns indicate potential exploitation.
+
+2. **Flag holiday-timed transactions**: Apply heightened scrutiny to large bridge-vault withdrawals that occur during holidays, weekends, or outside normal business hours.
+
+3. **Monitor Tornado Cash and mixer inflows**: Despite OFAC sanctions, Tornado Cash continues to be used for laundering stolen funds. Tracking inflows from newly funded addresses can identify theft proceeds in near real time.
+
+## 8. Conclusion
+
+The Orbit Chain bridge compromise of December 2023 resulted in the theft of approximately $82 million from the bridge's Ethereum-side vaults through compromised validator keys. The incident added to the growing evidence that validator-based bridge security models represent one of the weakest links in the cross-chain ecosystem, with multiple high-value bridges (Ronin, Harmony, Multichain, Orbit Chain) suffering key-compromise attacks within a two-year period.
+
+The attack's timing on New Year's Eve, the rapid stablecoin-to-ETH conversion to evade freeze responses, and the Tornado Cash laundering pattern were consistent with DPRK-linked operations. For the broader market, the Orbit Chain hack reinforced the need for bridges to adopt larger and more diverse validator sets, implement withdrawal rate limits and timelocks, and ultimately transition toward cryptographic proof-based security models that do not depend on the integrity of a small group of key holders.


### PR DESCRIPTION
Contribution to #277.

15,612-character wiki article covering the December 2023 Orbit Chain bridge hack:

- Multisig validator key compromise enabling fraudulent withdrawal authorization
- ~$82M drained from Ethereum vaults: ETH ($30M), WBTC ($22M), DAI ($10M), USDT ($10M), USDC ($10M)
- New Year's Eve timing potentially exploiting reduced staff availability
- DPRK attribution patterns: Tornado Cash laundering, staged fund distribution
- Comparative analysis with Ronin, Harmony, Multichain bridge key compromises
- Bridge security model taxonomy: validator, MPC, optimistic, ZK-proof
- Korean blockchain ecosystem concentration risk (Klaytn dependency)
- Recommendations for validator-set expansion, rate limits, and proof-based migration