### PR TITLE
add: xToken flash loan oracle manipulation and $24.5M xSNX vault drain (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-xtoken/index.md
+++ b/content/research/market-health/posts/2026-05-05-xtoken/index.md
@@ -1,0 +1,160 @@
+---
+date: 2026-05-05
+entities:
+  - id: xtoken
+    name: xToken
+    type: defi-protocol
+  - id: kyber-network
+    name: Kyber Network
+    type: defi-protocol
+  - id: synthetix
+    name: Synthetix
+    type: defi-protocol
+title: "xToken flash loan oracle manipulation exploits: xSNX and xBNT vault drains totaling $24.5M"
+---
+
+## Introduction
+
+xToken was a decentralized finance protocol on Ethereum that offered simplified exposure to DeFi governance tokens through a set of "x-asset" wrapper vaults. Each vault — xSNX, xBNT, xKNC, xAAVE, and others — accepted deposits of the underlying governance token (Synthetix SNX, Bancor BNT, Kyber KNC, Aave AAVE), deployed the tokens into the corresponding protocol's staking or governance system, and distributed yields back to depositors through an auto-compounding mechanism. The "x" wrapper tokens represented proportional claims on the vault's total holdings, abstracting away the complexity of directly managing staking positions, claiming rewards, and participating in governance votes.
+
+xToken suffered two major exploit incidents. On May 12, 2021, an attacker used flash loans to manipulate the price oracles used by the xSNX vault, draining approximately $24.5 million in a single transaction. Less than three months later, on August 28, 2021, a second exploit targeted xToken's xSNX contract through a different vulnerability, extracting an additional $4.5 million. This article focuses primarily on the May 2021 exploit — the larger and more technically significant of the two — while contextualizing it within xToken's broader security trajectory.
+
+## Background
+
+### Governance Token Wrapper Vaults
+
+By mid-2021, the DeFi ecosystem hosted dozens of governance tokens that required active management to capture their full yield. Synthetix (SNX) required stakers to manage their collateralization ratio and claim weekly rewards. Kyber Network (KNC) required token holders to vote on governance proposals to earn staking rewards. Bancor (BNT) required liquidity providers to manage single-sided liquidity positions. Aave (AAVE) required participation in governance to influence protocol parameters.
+
+xToken addressed this complexity by offering passive "set and forget" vaults. Users deposited their governance tokens, received x-asset tokens in return, and the vault contracts automated all yield-generating activities. The x-asset tokens themselves were fungible and tradeable, providing liquidity for users who wanted exposure to governance token staking yields without committing to lock-up periods.
+
+The value of each x-asset token was determined by the total assets under management (AUM) in the vault divided by the total supply of x-asset tokens. As the vault earned staking rewards, the AUM grew while the x-asset supply remained constant, causing each x-asset token to represent an increasing amount of the underlying governance token — a standard auto-compounding wrapper model.
+
+### xSNX Vault Architecture
+
+The xSNX vault was the largest and most complex of xToken's offerings. Its operation involved multiple steps: accepting SNX deposits from users and minting xSNX tokens proportionally, staking the deposited SNX in the Synthetix staking system to earn SNX staking rewards and sUSD (Synthetix's stablecoin), maintaining the SNX collateralization ratio within Synthetix's required bounds (managing the debt position), converting earned sUSD rewards back to SNX through DEX swaps to compound the vault's SNX holdings, and claiming and reinvesting staking rewards periodically.
+
+The vault's smart contract needed to perform several operations that depended on external price data. Converting sUSD to SNX required knowing the current market price of SNX. Maintaining the collateralization ratio required knowing the value of the SNX staked and the value of the minted sUSD debt. Calculating the net asset value (NAV) of the vault — used to determine the mint/burn ratio for xSNX tokens — required an accurate valuation of all vault assets.
+
+For these price-dependent operations, the xSNX contract relied on a combination of on-chain price sources, including the Kyber Network on-chain price oracle (which aggregated prices across Kyber's liquidity reserves) and spot prices from Uniswap and other DEXes. The use of spot on-chain prices rather than time-weighted average prices (TWAPs) or external oracle networks (like Chainlink) created the vulnerability that the attacker exploited.
+
+### Flash Loan Landscape in 2021
+
+By May 2021, flash loans were a well-established DeFi primitive available through Aave, dYdX, and numerous other lending protocols. The interaction between flash loans and spot price oracles had been identified as a dangerous vulnerability pattern since at least February 2020, when the bZx protocol was exploited through flash loan-assisted price manipulation. Despite this well-documented risk, many DeFi protocols continued to rely on spot on-chain prices for critical operations, making them vulnerable to the same class of attack.
+
+## The Attack
+
+### Vulnerability: Spot Price Oracle in NAV Calculation
+
+The core vulnerability in the xSNX vault was its use of on-chain spot prices for the net asset value calculation that determined how many xSNX tokens to mint for a given SNX deposit, and how much SNX to return for a given xSNX burn (redemption). The NAV calculation queried the Kyber Network oracle for the current SNX price and used this price to value the vault's total holdings.
+
+The Kyber Network oracle derived its prices from the liquidity reserves in Kyber's trading pools. If the Kyber trading pools were manipulated — for example, by executing a large swap that moved the pool's spot price — the oracle would report the manipulated price. Because the oracle returned the current (post-manipulation) price rather than a historical average, the NAV calculation would use the manipulated price, producing an incorrect valuation.
+
+The attacker could exploit this in two directions: inflating the NAV to mint xSNX tokens cheaply (buying the underlying SNX at a discount), or deflating the NAV to redeem xSNX tokens at an inflated rate (selling the underlying SNX at a premium). The May 2021 attacker used the latter approach — deflating the apparent value of the vault's SNX holdings to make xSNX tokens appear overvalued, then minting a large number of xSNX tokens and redeeming them at the artificially favorable rate.
+
+### Attack Execution
+
+The attack was executed in a single transaction on May 12, 2021, with the following sequence:
+
+**Step 1: Flash loan acquisition.** The attacker obtained a flash loan of approximately 61,833 ETH (worth approximately $270 million at the time) from multiple sources including Aave and dYdX. This capital provided the firepower needed to significantly manipulate on-chain liquidity pool prices.
+
+**Step 2: SNX price manipulation on Kyber.** The attacker used a large portion of the flash-loaned ETH to execute massive swaps on Kyber Network's SNX liquidity pools, dramatically moving the SNX spot price. By selling ETH for SNX in such volume that the pool's reserves were severely imbalanced, the attacker depressed the reported SNX price on the Kyber oracle.
+
+**Step 3: Manipulation of the xSNX mint/burn ratio.** With the Kyber oracle reporting an artificially low SNX price, the xSNX vault's NAV calculation undervalued the vault's SNX holdings. This meant that the mint function would issue more xSNX tokens per unit of SNX deposited than it should at the true market price, and the burn function would return more SNX per xSNX token burned.
+
+**Step 4: Exploitation of the mispriced vault.** The attacker interacted with the xSNX vault — either minting xSNX tokens at the deflated NAV and then waiting for the price to recover (capturing the difference), or performing a more complex sequence of mints and burns that extracted value through the NAV discrepancy. The specific mechanism allowed the attacker to withdraw more SNX from the vault than the value of the xSNX tokens they burned.
+
+**Step 5: Price restoration and swap reversal.** The attacker reversed the Kyber pool manipulation by swapping back to approximately restore the original balance ratios. This recovered most of the ETH used for the manipulation swaps (minus slippage and fees).
+
+**Step 6: Flash loan repayment and profit extraction.** The attacker repaid the flash loan with the required fee and retained the profit — approximately $24.5 million in SNX and ETH extracted from the xSNX vault.
+
+### Transaction Analysis
+
+The entire attack was executed in a single Ethereum transaction. On-chain analysis revealed that the transaction consumed approximately 10 million gas, reflecting the complexity of the multi-step manipulation and extraction process. The profit of approximately $24.5 million made this one of the largest single-transaction DeFi exploits at the time.
+
+The attacker's wallet was funded with a small amount of ETH from Tornado Cash to pay for gas. After the exploit, the stolen funds were routed through multiple intermediary wallets and converted to ETH before being sent to Tornado Cash for mixing. Some funds were also bridged to other chains (BSC, Polygon) in an attempt to further obscure the trail.
+
+## Impact
+
+### Financial Losses
+
+The xSNX vault lost approximately $24.5 million in total value — effectively its entire TVL. xSNX token holders were left with tokens representing claims on an empty or near-empty vault. Because xSNX was also traded on secondary markets (Uniswap, SushiSwap), traders who had purchased xSNX on the open market were also affected as the token's value collapsed.
+
+The xToken protocol's other vaults (xBNT, xKNC, xAAVE) were not directly affected by the May 2021 exploit, as each vault was a separate smart contract with its own funds. However, user confidence in all xToken products was severely damaged, leading to significant withdrawals from the remaining vaults.
+
+### Second Exploit (August 2021)
+
+Less than three months after the May exploit, xToken was attacked again on August 28, 2021. The second exploit targeted a different vulnerability in the xSNX contract — a mint function that could be called with a crafted input to bypass intended validation checks. The attacker extracted approximately $4.5 million in the second incident.
+
+The occurrence of a second exploit on the same protocol within three months severely damaged xToken's reputation and user trust. The protocol had implemented fixes and security improvements after the May exploit, but the presence of a second critical vulnerability suggested deeper issues with the codebase's security posture.
+
+### Broader Impact on Wrapper Vault Security
+
+The xToken exploits contributed to a broader reassessment of wrapper vault security in DeFi. The oracle manipulation vector demonstrated that any vault that relies on spot on-chain prices for NAV calculations is potentially vulnerable to flash loan manipulation. This led to several industry-wide improvements including the widespread adoption of Chainlink price feeds and other decentralized oracle networks for vault NAV calculations, the implementation of TWAP (time-weighted average price) calculations as a manipulation-resistant alternative to spot prices, the addition of per-block mint/burn limits to bound the maximum extraction possible through a single-transaction exploit, and the development of "oracle-free" vault designs that derive NAV from internal accounting rather than external price feeds.
+
+## Response and Remediation
+
+### Immediate Response
+
+The xToken team detected the exploit within minutes and published an immediate disclosure on social media. They paused the xSNX vault contract to prevent further exploitation and began a comprehensive investigation into the attack vector. The team also engaged security firms to perform an emergency audit of the remaining vault contracts.
+
+### Oracle Migration
+
+The primary remediation was migrating the xSNX vault's price oracle from Kyber Network spot prices to Chainlink price feeds. Chainlink oracles aggregate prices from multiple off-chain data sources and update on-chain at fixed intervals or when prices move beyond a deviation threshold. Because Chainlink prices are derived from off-chain market data (aggregated from multiple exchanges), they cannot be manipulated through on-chain flash loan swaps — the oracle's reported price reflects the broader market, not the state of any single on-chain liquidity pool.
+
+The migration to Chainlink addressed the root cause of the May 2021 exploit. However, the team also implemented additional safeguards including per-block mint/burn caps (limiting the maximum amount of xSNX that could be minted or burned in a single block), a cooldown period between mints and burns for the same address, and enhanced monitoring with automated circuit breakers that would pause the vault if anomalous price movements or large single-transaction operations were detected.
+
+### Protocol Trajectory
+
+Despite the remediation efforts, xToken struggled to rebuild user confidence after two major exploits within three months. TVL never recovered to pre-exploit levels, and the protocol gradually wound down operations over the following year. The team transitioned to building new products (including "Terminal," a DeFi aggregation and management platform) but the xToken brand was irreparably associated with the exploits.
+
+## Technical Analysis
+
+### Spot Price Oracle Manipulation Pattern
+
+The xToken exploit is a canonical example of the flash loan oracle manipulation pattern, which was first demonstrated at scale in the bZx exploits of February 2020. The pattern consists of three phases: price manipulation (using flash-loaned capital to move on-chain liquidity pool prices), exploitation (interacting with a protocol that uses the manipulated price for a critical calculation), and reversal (restoring the manipulated prices to recover the flash-loaned capital).
+
+The pattern is effective against any protocol that uses spot on-chain prices (from Uniswap, Kyber, or similar AMMs) as input to value-sensitive calculations. The defense landscape includes three main approaches.
+
+Decentralized oracle networks (Chainlink, Band Protocol, Pyth) aggregate prices from off-chain sources and are immune to on-chain flash loan manipulation. They are the most widely adopted defense and provide the strongest guarantees, but introduce trust assumptions (the oracle operators and data sources must be honest) and may have stale prices during periods of extreme volatility.
+
+Time-weighted average prices (TWAPs) compute the average price over a defined window (e.g., the last 30 minutes or 24 hours) rather than the instantaneous spot price. TWAPs are manipulation-resistant because moving the average requires sustaining the manipulation over the entire window — which is impossible within a single flash loan transaction. However, TWAPs can diverge from the true current price during rapid market movements.
+
+Internal accounting approaches avoid external price feeds entirely, deriving valuations from the protocol's own internal state (deposits, withdrawals, yield accrued). This approach is immune to oracle manipulation but may not reflect true market values and can be vulnerable to other types of accounting manipulation.
+
+### Flash Loan Scale and Capital Efficiency
+
+The xToken attacker used approximately $270 million in flash-loaned capital to extract $24.5 million — a "return" of approximately 9% on the flash-loaned amount. This ratio illustrates both the power and the constraints of flash loan attacks: the attacker needed $270 million to move Kyber's SNX pools sufficiently, but only extracted $24.5 million because the vault's TVL and the manipulation's effectiveness bounded the total extraction.
+
+The capital efficiency of flash loan attacks varies based on the depth of the liquidity pool being manipulated (deeper pools require more capital to move prices), the sensitivity of the target protocol's calculations to the manipulated price, and the TVL of the target protocol (bounding the maximum extraction). Protocols can increase the cost of flash loan attacks by ensuring that any price-dependent calculations use deep, well-funded price sources that are expensive to manipulate.
+
+### Comparison with Other Oracle Manipulation Exploits
+
+The xToken exploit belongs to a well-populated category of DeFi exploits. The bZx exploits (February 2020, approximately $900,000) were among the first to demonstrate flash loan oracle manipulation, using Kyber prices to manipulate the margin trading platform's collateral valuations. The Harvest Finance exploit (October 2020, approximately $34 million) manipulated Curve pool prices used by Harvest's vault to determine deposit and withdrawal ratios — a closely analogous vulnerability to xToken's NAV calculation manipulation. The Warp Finance exploit (December 2020, approximately $7.7 million) manipulated Uniswap LP token prices used as collateral valuations in a lending protocol, demonstrating that LP tokens themselves could be subject to flash loan price manipulation.
+
+The common thread is the use of spot on-chain prices for value-sensitive calculations in the presence of flash loan capital. The defense is consistent across all cases: use manipulation-resistant price feeds (Chainlink, TWAPs, or internal accounting) rather than spot AMM prices for any calculation that determines minting, burning, borrowing, or liquidation.
+
+### Vault NAV Calculation Best Practices
+
+The xToken case informed the development of best practices for vault NAV calculations that are now widely adopted across the DeFi industry. Key principles include never using spot AMM prices for NAV calculations, as any on-chain price that can be moved within a single transaction is vulnerable to flash loan manipulation; preferring internal accounting where the vault tracks deposits and withdrawals internally rather than querying external prices, deriving NAV from the vault's known holdings rather than their market value; implementing mint/burn rate limits where per-block or per-epoch caps on minting and burning bound the maximum extraction from any single-transaction exploit; and adding price deviation circuit breakers where the vault automatically pauses if the oracle price moves beyond a threshold (e.g., 10%) within a single block, preventing exploitation during periods of extreme price manipulation.
+
+## Lessons Learned
+
+### Spot On-Chain Prices Are Not Oracle-Quality Data
+
+The fundamental lesson of the xToken exploit is that spot prices from on-chain AMMs are not suitable for use as oracle data in value-sensitive DeFi calculations. While AMM prices reflect the current market for that specific pool, they can be arbitrarily manipulated by anyone with sufficient capital — and flash loans provide effectively unlimited capital for a single transaction. Any protocol that uses spot AMM prices for minting, burning, lending, borrowing, liquidation, or other value-sensitive operations is inherently vulnerable to oracle manipulation.
+
+### Flash Loan Threat Modeling Must Be Standard
+
+By May 2021, flash loan oracle manipulation was a well-documented attack vector with multiple high-profile precedents (bZx, Harvest, Warp, and others). xToken's use of Kyber spot prices for NAV calculations in the face of this known risk suggests either a gap in the team's threat modeling or a conscious decision to accept the risk. Either way, flash loan threat modeling should be a standard requirement for all DeFi protocols that handle user funds and rely on price data.
+
+### Redundant Defenses for Critical Calculations
+
+The xToken vault had a single point of failure in its NAV calculation: the Kyber oracle. Had the vault implemented redundant price checks — for example, requiring that the Kyber price, a Uniswap TWAP, and a Chainlink feed all agree within a tolerance — the attacker would have needed to manipulate all three sources simultaneously, dramatically increasing the attack's complexity and cost. Defense in depth through redundant, independent price sources should be standard for any calculation that determines the minting or burning of tokens representing user funds.
+
+### Repeated Exploits Signal Systemic Issues
+
+The occurrence of a second exploit on xToken within three months of the first suggests that the May 2021 fix addressed the specific vulnerability but did not resolve underlying systemic issues with the codebase's security posture. When a protocol is exploited, the remediation should extend beyond patching the specific vulnerability to include a comprehensive security review of the entire codebase, recognizing that the same design philosophy that produced one vulnerability may have produced others.
+
+## Conclusion
+
+The xToken flash loan oracle manipulation exploit of May 12, 2021, drained approximately $24.5 million from the xSNX governance token wrapper vault through a single-transaction attack that manipulated Kyber Network spot prices to distort the vault's net asset value calculation. The attacker used approximately $270 million in flash-loaned capital to move Kyber's SNX pool prices, causing the xSNX vault to miscalculate the mint/burn ratio for xSNX tokens and allowing the attacker to extract far more SNX than their xSNX tokens warranted at true market prices. The vulnerability — reliance on manipulable spot on-chain prices for a value-sensitive NAV calculation — was a well-documented attack vector by the time of the exploit, with multiple high-profile precedents demonstrating the same pattern. The incident, compounded by a second $4.5 million exploit three months later, ultimately contributed to the protocol's decline and reinforced the DeFi industry's migration toward manipulation-resistant oracle solutions (Chainlink, TWAPs) and multi-layered vault security architectures with rate limits, circuit breakers, and redundant price validation.


### PR DESCRIPTION
Comprehensive wiki article on the May 2021 xToken flash loan oracle manipulation exploit.

- 21,981 characters covering the $24.5M xSNX vault drain
- Kyber Network spot price oracle manipulation via flash loan
- NAV calculation vulnerability in governance token wrapper vaults
- Second exploit context (August 2021, $4.5M additional loss)
- Comparison with bZx, Harvest Finance, Warp Finance oracle attacks

Closes #277 (partial)