### PR TITLE
add: Fortress Protocol governance and oracle dual-vector exploit on BSC (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-fortress-protocol/index.md
+++ b/content/research/market-health/posts/2026-05-05-fortress-protocol/index.md
@@ -1,0 +1,144 @@
+---
+date: 2026-05-05
+entities:
+  - id: fortress-protocol
+    name: Fortress Protocol
+    type: defi-protocol
+  - id: fortress-loans
+    name: Fortress Loans
+    type: defi-product
+  - id: binance-smart-chain
+    name: Binance Smart Chain
+    type: blockchain
+title: "Fortress Protocol governance and oracle manipulation: dual-vector exploit draining $3M from BSC lending pools"
+---
+
+## Introduction
+
+Fortress Protocol was a decentralized lending and borrowing platform on Binance Smart Chain (BSC) that offered two primary products: Fortress Loans (a Compound-style money market allowing deposits and borrows of various BSC tokens) and Fortress Stableswap (a Curve-style stablecoin swap mechanism). The lending protocol allowed users to deposit supported assets as collateral, earn interest, and borrow other assets against their collateral at variable interest rates determined by utilization-based rate curves. The protocol was governed by the FTS (Fortress) governance token, which granted voting power over protocol parameters, asset listings, and oracle configurations.
+
+On May 9, 2022, an attacker executed a sophisticated dual-vector exploit against Fortress Protocol, combining governance manipulation with oracle price manipulation to drain approximately $3 million from the protocol's lending pools. The attack was notable for its two-phase design: first, the attacker used a governance attack to add a malicious token as a supported collateral asset with a manipulable oracle; second, the attacker manipulated the malicious token's oracle price to inflate the collateral value, allowing them to borrow far more than the collateral was actually worth. This combination of governance and price oracle exploitation represented a relatively rare multi-vector attack that exploited weaknesses in two separate protocol subsystems simultaneously.
+
+## Background
+
+### Fortress Protocol Architecture
+
+Fortress Protocol's lending platform was forked from Compound Finance (via Venus Protocol, a popular BSC fork of Compound). The protocol maintained a set of supported assets, each with configurable parameters: collateral factor (the percentage of deposited value that could be used as borrowing collateral), borrow cap (the maximum amount that could be borrowed), interest rate model (the curve determining borrow/supply rates based on utilization), and oracle source (the price feed used to value the asset for collateral and debt calculations).
+
+The Compound-style architecture meant that when a user deposited an asset, they received fTokens (analogous to Compound's cTokens) representing their deposit and accrued interest. Borrowers could borrow any supported asset up to the limit determined by their collateral's value (adjusted by the collateral factor). If a borrower's collateral value fell below the liquidation threshold (due to price movements or accrued interest), their position could be liquidated by third parties.
+
+### Governance Structure
+
+Fortress Protocol's governance was controlled by FTS token holders who could submit and vote on proposals. Proposals could modify protocol parameters including adding or removing supported assets, changing collateral factors and borrow caps, updating oracle configurations, and modifying interest rate models. The governance system had a relatively low quorum requirement and a short timelock (the delay between proposal approval and execution), which made it potentially vulnerable to governance attacks if an attacker could acquire sufficient voting power.
+
+### Oracle Configuration
+
+The protocol used a configurable oracle system where each supported asset had a designated price feed. For established assets (BNB, BTCB, ETH, BUSD, etc.), the oracle was typically set to a Chainlink price feed or another reputable decentralized oracle. However, the oracle source for any asset was a governable parameter — meaning a governance proposal could change an asset's oracle to an arbitrary address, including one controlled by the attacker.
+
+## The Attack
+
+### Phase 1: Governance Manipulation
+
+The first phase of the attack involved acquiring sufficient FTS tokens to pass a malicious governance proposal. The attacker acquired FTS tokens through open market purchases and potentially flash-borrowed FTS tokens (though governance voting typically requires tokens to be held for a snapshot period, limiting flash loan utility for governance attacks).
+
+The attacker submitted a governance proposal that added a new token as a supported collateral asset in the Fortress Loans market. The proposal specified a high collateral factor for the new token (allowing significant borrowing against it) and set the token's price oracle to a contract address controlled by the attacker. Because the quorum was low and the Fortress community's governance participation was limited, the proposal passed without meaningful opposition.
+
+After the timelock expired, the proposal was executed, officially adding the attacker's chosen token as accepted collateral with a manipulable oracle.
+
+### Phase 2: Oracle Manipulation and Drain
+
+With the governance setup complete, the attacker executed the drain:
+
+**Step 1: Collateral deposit.** The attacker deposited the governance-approved token into the Fortress Loans market, receiving fTokens in return. The deposited tokens had negligible real market value.
+
+**Step 2: Oracle price inflation.** The attacker called a function on their controlled oracle contract to set the token's reported price to an arbitrarily high value. Because the governance proposal had set this contract as the authoritative oracle for the token, the Fortress Protocol accepted the inflated price as the true valuation of the attacker's collateral.
+
+**Step 3: Borrowing against inflated collateral.** With the oracle reporting an inflated price for their deposited collateral, the attacker's position appeared to have enormous collateral value. The attacker called the borrow function on Fortress Loans, borrowing the maximum possible amount of valuable assets (BNB, BTCB, ETH, BUSD, USDT) against their "valuable" collateral.
+
+**Step 4: Extraction.** The attacker withdrew the borrowed assets from the protocol. Because the collateral backing these borrows was worthless (the deposited token had no real value, only an artificially reported price), the borrows were effectively uncollateralized — the protocol would never be able to liquidate the position for sufficient value to cover the debt.
+
+**Step 5: Exit.** The attacker bridged the borrowed assets to Ethereum and other chains, converting them to ETH and routing them through mixing services.
+
+### Attack Coordination
+
+The dual-phase design required patience: the attacker needed to wait for the governance proposal to pass through the voting period and timelock before executing Phase 2. This multi-day timeline (typically 2-7 days for governance proposals) meant the attack was pre-planned well in advance of the actual fund extraction. The governance proposal was submitted days before the drain, and the attacker executed the oracle manipulation and borrowing immediately after the timelock expired.
+
+## Impact
+
+### Financial Losses
+
+The total extraction was approximately $3 million in various BSC assets (primarily BNB, BTCB, and stablecoins). These losses were borne by depositors in the Fortress Loans market — their deposits were used to fund the attacker's uncollateralized borrows, and the "collateral" backing those borrows was worthless. The protocol was left with bad debt (outstanding borrows backed by worthless collateral) that it could never recover.
+
+### Protocol Insolvency
+
+The $3 million in bad debt rendered portions of the Fortress Loans market insolvent — depositors who attempted to withdraw faced a shortfall because the protocol's assets had been reduced by the amount the attacker borrowed. The insolvency was particularly acute for the most-drained asset pools (BNB and stablecoins), where the bad debt exceeded the remaining deposits.
+
+### FTS Token Impact
+
+The FTS governance token collapsed by over 80% following the exploit, reflecting both the protocol's insolvency and the irony that the governance token had been used as the vector for the attack. Holders who had acquired FTS for governance participation found their tokens worthless, and the governance system itself was discredited.
+
+### Lessons for Governance Security
+
+The Fortress Protocol exploit highlighted a fundamental tension in DeFi governance: the same flexibility that makes governance useful (the ability to add new assets, change oracles, modify parameters) also makes it dangerous. If governance power is concentrated or cheaply acquired, it becomes an attack vector rather than a security feature. The Fortress case was one of the clearest demonstrations that governance attacks were not just theoretical — they were practical, profitable, and executable by a determined attacker willing to invest in acquiring voting power.
+
+## Response and Remediation
+
+### Immediate Response
+
+The Fortress Protocol team acknowledged the exploit and paused the lending markets. They published an incident report identifying both the governance manipulation and oracle attack vectors. The team advised remaining depositors about the bad debt situation and the likelihood of withdrawal shortfalls.
+
+### Limited Recovery
+
+Unlike protocols with substantial treasuries or team funds, Fortress Protocol lacked the resources to compensate affected depositors. The protocol's TVL had been modest before the attack (approximately $10-15 million), and the team's token allocation (in the now-worthless FTS token) could not fund meaningful compensation. Affected users were largely left to absorb the losses.
+
+### Governance Reform Proposals
+
+The broader DeFi community discussed governance reforms inspired by the Fortress incident. Proposed mitigations included increasing quorum requirements for sensitive operations (adding assets, changing oracles), implementing longer timelocks for governance proposals that modify security-critical parameters, requiring multi-step approval for asset additions (separate proposals for listing and for setting collateral parameters), implementing "guardian" or "security council" roles that can veto or delay suspicious proposals, and using vote-escrowed governance tokens that require long lock-up periods, increasing the cost of acquiring governance power for short-term attacks.
+
+## Technical Analysis
+
+### Dual-Vector Attack Design
+
+The Fortress Protocol exploit is notable for combining two distinct attack vectors (governance manipulation and oracle manipulation) into a single coherent attack. Neither vector alone would have been sufficient: governance manipulation alone could add a new asset but would not allow borrowing without price manipulation; oracle manipulation alone would fail because the attacker could not change a legitimate asset's oracle without governance authority.
+
+This dual-vector design represents a more sophisticated class of DeFi exploits compared to single-vector attacks (pure flash loan manipulation, pure reentrancy, etc.). Dual-vector attacks are harder to defend against because each vector may appear relatively safe in isolation — governance is designed to add new assets, and oracle configurations are designed to be updatable — but their combination creates a critical vulnerability.
+
+### Governance Attack Economics
+
+The economics of governance attacks depend on the cost of acquiring sufficient voting power versus the value that can be extracted once governance is controlled. For Fortress Protocol, the FTS token's low market capitalization (relatively few dollars needed to acquire a controlling stake) combined with the high potential extraction (millions in borrowable assets) made the attack highly profitable.
+
+The general formula for governance attack viability is: if `cost_of_voting_power < extractable_value * probability_of_success`, the attack is economically rational. For protocols with low governance token market caps and high TVL, this inequality is easily satisfied. Defenses must either increase the cost of acquiring governance power (through lock-up requirements, increasing market cap, or requiring diverse stakeholder approval) or reduce the extractable value (through stricter parameter limits, time-delays, and guardian vetoes).
+
+### Oracle Trust Model in Governable Systems
+
+The Fortress exploit reveals a fundamental design tension: in a governable system, the oracle configuration is only as secure as the governance mechanism. If governance can set oracles to arbitrary addresses, then compromising governance is equivalent to compromising the oracle. This means that oracle security and governance security are not independent — they are linked through the governance system's ability to modify oracle configurations.
+
+Defenses against this coupling include making oracle configurations immutable (only allowing oracle addresses from a hardcoded whitelist of trusted providers), requiring multi-sig or time-delayed approval for oracle changes separate from standard governance, and implementing automated oracle validation that rejects feeds with implausible price reports (e.g., prices that deviate more than 50% from the last known good price within a single block).
+
+### Comparison with Other Governance Exploits
+
+The Fortress Protocol governance attack belongs to a growing category of DeFi governance exploits. The Beanstalk exploit (April 2022, approximately $182 million) used a flash loan to acquire governance tokens, pass a malicious proposal in a single transaction (enabled by a flash-loan-compatible governance mechanism), and drain the protocol's treasury. The Beanstalk case was more dramatic (single-transaction execution) but relied on a governance system that did not require token holding across blocks.
+
+The Tornado Cash governance exploit (May 2023, approximately $1.2 million in TORN tokens) used a CREATE2/selfdestruct pattern to substitute a malicious proposal implementation after the vote, effectively backdooring the governance contract itself. The Fortress case was more straightforward — the governance proposal was transparently malicious (adding an attacker-controlled oracle), but governance participation was too low to detect and block it.
+
+## Lessons Learned
+
+### Governance Cannot Self-Secure Without Participation
+
+The fundamental lesson is that governance security requires active community participation. A governance system with low participation is inherently vulnerable to hostile takeover because the cost of acquiring a majority is proportional to the participating vote share, not the total token supply. Protocols must either ensure high governance participation (through incentives, delegation, and active community engagement) or implement non-governance safeguards (timelocks, guardians, security councils) that provide security independent of participation levels.
+
+### Separate Governance Tracks for Security-Critical Operations
+
+Adding new collateral assets and changing oracle configurations are security-critical operations that should require heightened approval thresholds compared to routine governance actions. Implementing separate governance tracks — a "normal" track for parameter adjustments and a "critical" track with higher quorum, longer timelock, and potentially multi-sig requirements for asset additions and oracle changes — would have made the Fortress attack significantly more expensive and detectable.
+
+### Oracle Whitelisting
+
+Protocol oracle configurations should be restricted to a whitelist of known, audited oracle providers (Chainlink, Band Protocol, Pyth, Uniswap TWAP oracles from verified pool addresses). Allowing governance to set arbitrary addresses as oracles — including attacker-controlled contracts — is a fundamental security violation that no governance reform can fully mitigate. The oracle whitelist should be immutable or require a separate, higher-security governance process to modify.
+
+### Asset Addition Should Require Time and Scrutiny
+
+The process of adding new collateral assets should include mandatory time delays (minimum 7-14 days from proposal to execution), public notice periods where the community can review and challenge the proposal, automated security checks that verify the proposed asset has real market liquidity and a legitimate oracle feed, and graduated collateral factor increases (starting at a low factor and increasing over time as the asset proves stable).
+
+## Conclusion
+
+The Fortress Protocol dual-vector exploit of May 9, 2022, drained approximately $3 million from the BSC lending platform through a coordinated governance manipulation and oracle price inflation attack. The attacker first passed a governance proposal adding a worthless token as supported collateral with an attacker-controlled oracle, then inflated the oracle price to borrow valuable assets against worthless collateral. The attack demonstrated that in governable DeFi systems, governance security and oracle security are fundamentally linked — compromising governance enables oracle manipulation, and the two vectors together enable catastrophic fund extraction. The incident reinforced that DeFi governance systems require active participation to remain secure, that security-critical operations (asset additions, oracle changes) need heightened approval requirements, and that oracle configurations should be restricted to verified whitelists rather than arbitrary governance-settable addresses. The dual-vector attack pattern represents an evolution in DeFi exploitation sophistication, requiring defenses that address both governance capture and oracle manipulation as interrelated rather than independent threats.


### PR DESCRIPTION
Comprehensive wiki article on the May 2022 Fortress Protocol dual-vector exploit on BSC.

- 17,767 characters covering the $3M lending pool drain
- Governance manipulation: malicious asset listing with attacker-controlled oracle
- Oracle price inflation enabling uncollateralized borrowing
- Governance attack economics and dual-vector design analysis
- Comparison with Beanstalk and Tornado Cash governance exploits

Closes #277 (partial)