### PR TITLE
Add ForceDAO xFORCE false-return exploit analysis

### DIFF
--- a/content/research/market-health/posts/2026-05-05-forcedao/index.md
+++ b/content/research/market-health/posts/2026-05-05-forcedao/index.md
@@ -1,0 +1,357 @@
+---
+date: 2026-05-05
+entities:
+  - id: forcedao
+    name: ForceDAO
+    type: defi
+  - id: force-token
+    name: FORCE
+    type: token
+  - id: xforce
+    name: xFORCE
+    type: token
+  - id: minime-token
+    name: MiniMeToken
+    type: token-standard
+title: "ForceDAO xFORCE false-return bug, unchecked transferFrom, and the launch-day FORCE staking drain"
+---
+
+## 1. Introduction and incident overview
+
+On 4 April 2021, shortly after ForceDAO launched its FORCE token and xFORCE staking/vault mechanism, a bug in the FORCE/xFORCE contract path allowed users to mint or redeem value without actually transferring the required tokens. The core issue was deceptively simple: the relevant contract called `transferFrom` on a token implementation that could return `false` instead of reverting, but the calling contract did not check that return value before continuing.
+
+Rekt summarized the key failure with a quote from samczsun: "the xforce vault didn't check the return value on transferFrom." The token implementation involved the older MiniMeToken pattern, where failed transfers can return `false` rather than throwing. If a vault treats any completed call as success, it may credit users even when the transfer did not happen.
+
+The incident was relatively small compared with later nine-figure DeFi losses, but it was highly instructive. A whitehat reportedly found the bug and removed funds "for the safety of the token" while contacting the team. The team warned users not to trade FORCE, but the message came after the community had already dumped tokens. FORCE fell roughly 90% in minutes. Other actors then arrived to exploit leftovers.
+
+Rekt listed an on-chain sequence in which 347,432,986 xFORCE were minted, 4,112 FORCE were withdrawn using minted xFORCE, FORCE was sold through 1inch, and 14,833 FORCE was returned. Public summaries commonly describe about 183 ETH worth of FORCE at risk or extracted before recovery dynamics. The exact net economic outcome was softened by returns, but the market-health lesson remains: unchecked ERC-20 return values can turn staking accounting into unbacked minting.
+
+## 2. Background: ForceDAO, FORCE, and xFORCE
+
+### 2.1 ForceDAO launch context
+
+ForceDAO was a DeFi project that launched with a community distribution and governance/yield mechanics around the FORCE token. The incident happened early, during the fragile launch period when contracts, token claims, liquidity, and user attention were all concentrated.
+
+Launch periods are especially risky because:
+
+- many users interact at once;
+- liquidity is thin and volatile;
+- contracts may be newly deployed;
+- bots and searchers watch every transaction;
+- team communication is time-sensitive; and
+- a small bug can become public and copied immediately.
+
+ForceDAO's exploit showed how a token-distribution event can become a market-confidence crisis even if the direct technical bug is narrow.
+
+### 2.2 xFORCE as a vault/share token
+
+xFORCE represented a staked or vault version of FORCE. In a standard staking model, users deposit FORCE and receive xFORCE shares. Those shares should be backed by real FORCE held in the contract. Later, holders can redeem xFORCE for FORCE according to the vault/share accounting.
+
+The critical invariant is:
+
+> xFORCE supply must be backed by successfully received FORCE.
+
+If the vault mints xFORCE without receiving FORCE, every legitimate staker is diluted. The attacker can redeem unbacked shares for real FORCE, draining the pool.
+
+### 2.3 MiniMeToken and non-reverting transfers
+
+The FORCE/xFORCE path used an older token pattern associated with MiniMeToken. Rekt's source discussion noted that MiniMeToken's `transferFrom` does not necessarily revert on failure; it can return `false`. That behavior is legal enough to exist in real deployed tokens, but it is dangerous for contracts that assume every failed token transfer reverts.
+
+Modern Solidity developers often use SafeERC20 wrappers because ERC-20 behavior is not perfectly uniform. Some tokens:
+
+- return `true` or `false`;
+- return no value;
+- revert on failure;
+- charge transfer fees;
+- rebase balances; or
+- implement additional hooks.
+
+The ForceDAO bug sits in the first category: a return value was meaningful, but ignored.
+
+## 3. Root cause: unchecked `transferFrom`
+
+### 3.1 The vulnerable pattern
+
+The vulnerable pattern is conceptually:
+
+```solidity
+token.transferFrom(msg.sender, address(this), amount);
+mintShares(msg.sender, amount);
+```
+
+If `transferFrom` fails by returning `false`, the second line still executes. The contract mints shares as if funds arrived. The correct pattern is:
+
+```solidity
+require(token.transferFrom(msg.sender, address(this), amount), "transfer failed");
+mintShares(msg.sender, amount);
+```
+
+or, more generally, a SafeERC20 wrapper that handles nonstandard return behavior.
+
+### 3.2 Why return values matter
+
+In Solidity, an external call can complete successfully at the EVM level even if the called token function returns `false`. "The call did not revert" is not the same as "the transfer succeeded." A contract must inspect the return value when a token uses boolean success semantics.
+
+ForceDAO's vault logic appears to have treated call completion as success. That allowed minting or redemption logic to proceed after a failed token movement.
+
+### 3.3 Failure of backing invariant
+
+Once xFORCE could be minted without actual FORCE transfer, xFORCE no longer represented a backed claim. The attacker could create unbacked xFORCE, then withdraw real FORCE from the pool. The pool's accounting believed it was processing a valid share redemption, but the share supply was fraudulent.
+
+This is a vault-accounting failure, not a market-price oracle failure. No external price needed to be manipulated. The internal relationship between deposits and shares broke.
+
+## 4. Attack flow
+
+### 4.1 Discover unchecked transfer behavior
+
+The attacker or whitehat recognized that the xFORCE vault did not check the return value from `transferFrom`. Because the underlying token could return `false` rather than revert, it was possible to run the deposit/redeem path without transferring the expected backing tokens.
+
+This is the kind of bug that static analysis and code review should catch. Any ERC-20 `transfer` or `transferFrom` whose return value is ignored is a red flag.
+
+### 4.2 Mint unbacked xFORCE
+
+Rekt lists a transaction that minted 347,432,986 xFORCE. The important point is not the nominal number alone, but that xFORCE could be created without corresponding FORCE backing. Once unbacked shares exist, the vault can be drained by redemption.
+
+This is similar to other share-inflation failures: if the share token is not tightly linked to real deposits, shares become a claim against other users' assets.
+
+### 4.3 Withdraw FORCE using unbacked xFORCE
+
+Rekt then lists a withdrawal of 4,112 FORCE using minted xFORCE. In a healthy system, a withdrawal burns or consumes shares that were minted from a prior deposit. In the exploit path, the shares were not properly backed.
+
+The vault therefore paid out real FORCE against a false accounting claim.
+
+### 4.4 Sell FORCE into market liquidity
+
+FORCE was sold through 1inch. Because the incident occurred during launch and uncertainty spread quickly, selling pressure and community panic pushed the token price down sharply. Rekt reported a 90% fall in minutes.
+
+Even when funds are later returned, market damage can already be done. Users who bought or sold during the panic realize losses based on the event, not only the final protocol balance.
+
+### 4.5 Return and opportunistic follow-on activity
+
+Rekt lists a return of 14,833 FORCE and states that the money was returned, sparing ForceDAO from its leaderboard. It also notes that other hackers arrived to feed on leftovers after the initial issue became visible.
+
+This is typical DeFi exploit dynamics. Once the vulnerability is public on-chain, the response window is measured in blocks. Whitehat action, malicious copying, frontrunning, and panic trading all happen at once.
+
+## 5. Market impact
+
+### 5.1 Price collapse despite recovery
+
+FORCE price reportedly fell about 90% in minutes. This illustrates that market impact is not limited to unrecovered stolen funds. A bug can destroy confidence, trigger panic selling, and change the token's perceived quality instantly.
+
+For launch-stage tokens, confidence is part of liquidity. A simple transfer-return bug can become a large market event if it occurs during distribution.
+
+### 5.2 Whitehat ambiguity
+
+The ForceDAO Discord message described an individual who found the bug and removed tokens for safety while contacting the team. But by the time that message arrived, users had already reacted. Rekt framed the whitehat as being left holding the bag after the community dumped.
+
+Whitehat interventions create communication challenges:
+
+- Is the actor trusted?
+- Are funds safe?
+- Should users stop trading?
+- Will tokens be returned?
+- Are there copycats?
+
+Teams need preplanned disclosure channels and emergency controls because ambiguity can itself cause losses.
+
+### 5.3 Airdrop and gas-cost irony
+
+Rekt noted that what was considered one of the smallest airdrops could end up net negative for users after gas costs and market disruption. This is a reminder that "free" token claims still expose users to transaction costs, volatility, and protocol risk.
+
+Launch incentives can become liabilities when the token contract fails immediately.
+
+## 6. Why the bug was preventable
+
+### 6.1 SafeERC20 wrappers
+
+The most direct prevention is using a SafeERC20 wrapper for all token transfers. SafeERC20 handles tokens that return booleans, tokens that return no data, and tokens that revert. It prevents the calling contract from silently ignoring failure.
+
+Every vault and staking contract should treat token movement as a critical dependency. If the transfer does not succeed, minting shares must not proceed.
+
+### 6.2 Unit tests with false-return tokens
+
+Testing only with a token that always reverts on failure misses this class of bug. A test suite should include a mock token whose `transferFrom` returns `false` without reverting. The expected behavior is that the vault reverts and does not mint shares.
+
+ForceDAO's bug is exactly the case such a mock is designed to catch.
+
+### 6.3 Share-backing invariant
+
+The vault should maintain a simple invariant:
+
+> Total redeemable xFORCE value cannot exceed actual FORCE held by the vault, except for explicitly modeled rewards.
+
+Invariant tests can fuzz deposits, failed transfers, withdrawals, and transfers to ensure unbacked shares cannot be created.
+
+### 6.4 Launch readiness review
+
+Launch contracts should receive a focused pre-launch review. Common launch bugs include:
+
+- unchecked transfer returns;
+- missing initializer guards;
+- wrong mint authority;
+- unsafe airdrop claim logic;
+- permissive staking deposits;
+- stale approvals;
+- missing emergency pause; and
+- insufficient monitoring.
+
+The ForceDAO incident happened at exactly the moment when a narrow bug could cause maximum public damage.
+
+## 7. Market-health indicators
+
+### 7.1 Ignored return values
+
+Static analysis should flag any use of:
+
+- `token.transfer(...)` without checking return;
+- `token.transferFrom(...)` without checking return;
+- low-level calls where returned data is ignored; and
+- custom token interactions that assume revert-on-failure.
+
+This is a basic but high-value market-health signal.
+
+### 7.2 Older token implementations
+
+MiniMeToken and other older token implementations may behave differently from modern OpenZeppelin ERC-20 patterns. Integrations should not assume uniform behavior.
+
+When a protocol integrates an older token, analysts should inspect:
+
+- whether failed transfers revert or return false;
+- whether allowances behave normally;
+- whether transfer hooks exist;
+- whether snapshots affect balances;
+- whether decimals are standard; and
+- whether SafeERC20 is used.
+
+### 7.3 Unbacked share creation
+
+Any vault or staking token should be monitored for share issuance without matching asset inflow. If xFORCE supply increases but FORCE balance does not, the vault is insolvent or under attack.
+
+This can be monitored on-chain by comparing:
+
+- share-token mint events;
+- underlying-token transfer events into the vault;
+- vault balance changes; and
+- redemption events.
+
+### 7.4 Launch-day abnormal sell pressure
+
+Launch tokens are volatile, but sell pressure following contract-level anomalies is different from normal price discovery. Monitoring should connect contract alerts to market alerts. If unbacked shares are minted and tokens are sold through an aggregator, users need immediate warning.
+
+## 8. Broader implications for DeFi vaults
+
+### 8.1 ERC-20 is not one behavior
+
+The ERC-20 ecosystem contains many variants. Some return booleans, some return no values, some revert, and some include additional behavior. Protocols that handle valuable assets must code defensively against all common variants.
+
+ForceDAO's mistake was assuming transfer failure would stop execution. That assumption was wrong.
+
+### 8.2 Small bugs can have large narrative impact
+
+The direct ForceDAO incident was not a massive nine-figure exploit, and funds were reportedly returned. But the narrative impact was large because it happened immediately after launch and demonstrated weak basic controls.
+
+Market confidence is path-dependent. A launch-day bug can define a protocol's reputation long after balances are restored.
+
+### 8.3 Whitehat rescues are not security controls
+
+Whitehat action may prevent permanent loss, but it is not a substitute for correct code. A protocol should not rely on a benevolent actor discovering and safely handling a critical bug before malicious actors do.
+
+The ForceDAO story shows both the value and the limits of whitehat intervention.
+
+### 8.4 Share tokens amplify small accounting mistakes
+
+Vault shares are leverage on accounting correctness. A failed transfer is one missed boolean. But if that missed boolean mints shares, the mistake becomes a transferable claim on real assets. That is why share-token systems need stronger checks than ordinary payment flows.
+
+In a simple payment, ignoring a failed transfer may mean one recipient is not paid. In a vault, ignoring a failed transfer can create a new asset that other contracts and users may accept as valid. The damage spreads from one function call to the entire share economy.
+
+This is especially dangerous when the share token is integrated into:
+
+- governance voting;
+- staking rewards;
+- liquidity pools;
+- collateral systems;
+- airdrop eligibility; or
+- vesting contracts.
+
+ForceDAO's xFORCE bug was a direct vault drain, but the same pattern can also contaminate governance and reward accounting.
+
+## 9. Practical review checklist
+
+### 9.1 Token-transfer review
+
+Before launch, reviewers should enumerate every token movement:
+
+- deposits into staking contracts;
+- withdrawals from staking contracts;
+- reward claims;
+- treasury transfers;
+- liquidity provisioning;
+- airdrop claims; and
+- emergency rescues.
+
+For each call, reviewers should ask:
+
+- Is the return value checked?
+- Is SafeERC20 used?
+- What happens if the token returns `false`?
+- What happens if the token returns no data?
+- What happens if the token reverts?
+- What happens if the token charges a fee?
+- What happens if the token reenters?
+
+The ForceDAO incident would fail this checklist at the first question.
+
+### 9.2 Share-minting review
+
+Every share mint should be tied to observed asset inflow. A robust vault can calculate the actual amount received by comparing pre-transfer and post-transfer balances. This protects not only against false-return tokens, but also against fee-on-transfer tokens that transfer less than requested.
+
+A safer pattern is:
+
+1. read underlying balance before transfer;
+2. execute safe transfer;
+3. read underlying balance after transfer;
+4. mint shares based on actual received amount; and
+5. revert if received amount is zero or below expectations.
+
+This pattern is not always necessary for simple tokens, but it is valuable for launch-stage protocols that may not fully control token behavior.
+
+### 9.3 Emergency communication review
+
+The Discord message telling users not to trade came after market damage had already begun. Teams should prepare emergency communication before launch:
+
+- prewritten "pause trading/interactions" notices;
+- verified announcement channels;
+- contact path for whitehats;
+- escalation to exchanges and aggregators;
+- on-chain pause transaction templates; and
+- a plan for distinguishing whitehat rescue from malicious theft.
+
+Speed matters. If the first clear message arrives after users have already sold into panic, the protocol has lost the narrative.
+
+## 10. Timeline
+
+- **Before 4 April 2021**: ForceDAO prepares FORCE distribution and xFORCE staking/vault mechanics.
+- **4 April 2021**: A bug is found in the FORCE/xFORCE contract path.
+- **08:50 UTC**: ForceDAO posts in Discord that an individual found a bug, removed tokens for safety, and contacted the team; users are told not to trade FORCE.
+- **Exploit sequence**: xFORCE is minted, FORCE is withdrawn using minted xFORCE, FORCE is sold through 1inch, and FORCE is later returned.
+- **Market reaction**: FORCE falls roughly 90% in minutes as users panic and follow-on actors exploit remaining opportunity.
+- **Aftermath**: Funds are returned or substantially recovered, but the launch suffers a major reputational shock.
+
+## 11. Lessons for builders, users, and analysts
+
+For builders, the lesson is simple: never ignore token transfer return values. Use SafeERC20, test with false-return tokens, and enforce share-backing invariants before launching any staking or vault product.
+
+For users, the lesson is that new staking tokens and airdrop mechanics can fail in basic ways. A token launch is not safe merely because the economic design is simple.
+
+For analysts, ForceDAO provides a checklist: scan for unchecked `transferFrom`, inspect token implementations that return false, compare share minting against actual deposits, and watch launch-day vaults for unbacked share creation.
+
+The ForceDAO incident was therefore not just an embarrassing launch bug. It was a compact demonstration of how a single unchecked boolean can break an entire staking market.
+
+## References
+
+- Rekt, [Force - REKT](https://rekt.news/force-rekt/)
+- Etherscan, [xFORCE mint transaction referenced by Rekt](https://etherscan.io/tx/0xdf05020d5d3c3a975627ce29f24b4eb8ccb8807f9f9c9aa05e644c61fe5f0141)
+- Etherscan, [FORCE withdrawal transaction referenced by Rekt](https://etherscan.io/tx/0x3b60252b36d2de2930a64f360926bfcba44d12ff44719de3c6dd486b9dafe118)
+- Etherscan, [FORCE sale through 1inch referenced by Rekt](https://etherscan.io/tx/0x03c84e3f7d9c117260a49bab6bd9cb1b2d7e1cbc6d9362e74c10ef6d48a987e6)
+- Etherscan, [FORCE return transaction referenced by Rekt](https://etherscan.io/tx/0xfda56d853714860e79512791d065a626e5102d52934c769e981619daf3c85f33)
+- Giveth, [MiniMeToken reference implementation](https://github.com/Giveth/minime)


### PR DESCRIPTION
Contribution to #277

Adds a market-health analysis of the April 2021 ForceDAO xFORCE exploit, covering unchecked transferFrom return values, MiniMeToken false-return behavior, unbacked xFORCE minting, FORCE withdrawal/sale, recovery dynamics, and controls for vault share backing.