### PR TITLE
Add Meerkat Finance vault-control rug pull analysis

### DIFF
--- a/content/research/market-health/posts/2026-05-05-meerkat-finance/index.md
+++ b/content/research/market-health/posts/2026-05-05-meerkat-finance/index.md
@@ -1,0 +1,331 @@
+---
+date: 2026-05-05
+entities:
+  - id: meerkat-finance
+    name: Meerkat Finance
+    type: defi
+  - id: binance-smart-chain
+    name: Binance Smart Chain
+    type: blockchain
+  - id: busd
+    name: BUSD
+    type: stablecoin
+  - id: bnb
+    name: BNB
+    type: token
+title: "Meerkat Finance vault-control rug pull, BSC launch risk, and the $31 M BUSD/BNB drain"
+---
+
+## 1. Introduction and incident overview
+
+On 4 March 2021, Meerkat Finance, a newly launched yield-farming protocol on Binance Smart Chain, was drained of approximately 13.96 million BUSD and 73,653 BNB. Public reporting placed the total loss around $31 million to $32 million. The incident occurred roughly one day after launch and quickly became one of the earliest large rug-pull scandals in the BSC DeFi ecosystem.
+
+Meerkat initially claimed it had been hacked. But the circumstances were immediately suspicious: the website stopped functioning, the Twitter account disappeared, and observers reported that the original deployer account had been used to alter the smart contract containing the project's vault business logic. Community analysts and media reports therefore treated the event as an apparent rug pull or insider-enabled drain rather than a conventional third-party exploit.
+
+The Meerkat incident is important for market-health analysis because it highlights a different kind of DeFi failure from flash-loan math bugs or oracle manipulation. The central risk was privileged control over vault logic at launch. Users deposited into vaults that could be changed or controlled by deployer authority, and that authority path was enough to move funds out.
+
+In a launch-stage yield farm, technical trust and social trust overlap. If the team is anonymous, the contracts are upgradeable or owner-controlled, audits are absent, and social channels vanish after funds move, users have little practical recourse. Meerkat showed how quickly "new farm APY" can become exit liquidity.
+
+## 2. Background: Binance Smart Chain yield-farm boom
+
+### 2.1 BSC in early 2021
+
+In early 2021, Binance Smart Chain grew rapidly as users sought cheaper alternatives to Ethereum mainnet. Low fees and fast transactions attracted retail users, yield farms, DEX forks, and anonymous teams. This created a fertile environment for experimentation, but also for low-quality launches and opportunistic rug pulls.
+
+Many users were attracted by:
+
+- high advertised APYs;
+- cheap deposits and withdrawals;
+- fast farm launches;
+- Ethereum-style DeFi interfaces;
+- BNB and BUSD liquidity; and
+- the perception that BSC was easier to use than Ethereum during gas spikes.
+
+The same features also reduced friction for scammers. A team could deploy a farm quickly, attract deposits with high yields, and disappear before meaningful review occurred.
+
+### 2.2 Meerkat Finance launch
+
+Meerkat Finance launched as a BSC yield-farming project. Users deposited assets into vaults expecting yield. AMBCrypto reported that the project had launched the night before the drain. That timing is central: users had little history, operational reputation, or battle-tested contract behavior to rely on.
+
+Launch-stage protocols require extra skepticism because:
+
+- contract code may be unaudited;
+- admin keys may still be active;
+- ownership may not be renounced;
+- users may not understand permissions;
+- liquidity can accumulate quickly;
+- emergency controls may be untested; and
+- malicious insiders can act before scrutiny catches up.
+
+Meerkat's failure occurred before the project had time to establish trust.
+
+### 2.3 Vaults as custody surfaces
+
+Yield-farm vaults are custody surfaces. Even if they are marketed as smart-contract systems rather than centralized accounts, users deposit assets into contracts controlled by code and permissions. If vault business logic can be changed by a deployer or owner, the vault is not purely autonomous.
+
+The core question for users is:
+
+> Can anyone with a key or owner role alter vault logic or withdraw funds?
+
+In Meerkat's case, reporting indicated that deployer-associated control over vault business logic was the critical path.
+
+## 3. What happened
+
+### 3.1 Funds drained
+
+AMBCrypto reported that 13.96 million BUSD and 73,653 BNB were drained from Meerkat Finance shortly after launch. The total was reported near $32 million. Other summaries described the amount as roughly $31 million.
+
+These were not minor testing funds. They represented substantial user deposits in a brand-new BSC protocol. The size of the drain showed how quickly capital could accumulate in high-APY farms even before the market had time to assess security.
+
+### 3.2 Claimed hack versus rug-pull suspicion
+
+Meerkat reportedly claimed its systems had been hacked. But several signals contradicted a clean external-hack narrative:
+
+- the website became unavailable;
+- the Twitter account was deleted;
+- community observers suspected a scam;
+- reporting said the original deployer account was used to alter vault logic; and
+- users filed scam reports and tracked affected stakes in community channels.
+
+These signals are consistent with a rug pull or insider-enabled drain. Even if a private key had been compromised, the user-facing lesson is the same: a privileged deployer path existed that could drain vault funds.
+
+### 3.3 Vault business logic alteration
+
+The most important technical point in public reporting is that the smart contract containing vault business logic was altered using the original deployer's account. That implies the contracts were not immutable in the way many users may have assumed.
+
+This is a market-health red flag:
+
+- if vault logic can be changed after deposits;
+- if owner/deployer can upgrade or redirect funds;
+- if no timelock gives users time to exit; and
+- if ownership is not multisig-controlled or renounced,
+
+then users are effectively trusting the operator, not only the code.
+
+### 3.4 Disappearance of communication channels
+
+The disappearance of Meerkat's website and Twitter account worsened the incident. In a legitimate exploit, teams typically keep communication channels open to coordinate response, publish affected addresses, and guide users. Vanishing channels are a strong rug-pull signal.
+
+The lack of reliable communication also made recovery harder. Users had to coordinate through external community reports and Binance forums rather than official incident handling.
+
+## 4. Technical and governance failure modes
+
+### 4.1 Privileged vault control
+
+The apparent core failure was privileged control over vault logic. In DeFi, privileged control is not inherently malicious. Protocols may need upgradeability during early development. But privileged control must be constrained and disclosed.
+
+Safe upgrade controls include:
+
+- multisig ownership;
+- timelock delays;
+- public upgrade proposals;
+- verified implementation code;
+- emergency pause without withdrawal power;
+- clear event monitoring; and
+- ownership renunciation once stable.
+
+Meerkat's incident showed what happens when users deposit before those controls are proven.
+
+### 4.2 Deployer account as single point of failure
+
+If an original deployer account can alter vault behavior, that account becomes a single point of failure. The risk is not limited to malicious developers. It also includes:
+
+- private-key theft;
+- compromised developer machine;
+- malicious cofounder;
+- social-engineering compromise;
+- intentional exit scam; and
+- rushed launch with unsafe owner permissions.
+
+Users cannot easily distinguish among those after funds are gone. The protection must be structural.
+
+### 4.3 Upgradeability without exit window
+
+Upgradeability is especially dangerous when users have no exit window. If a vault can be changed and drained in the same block or within a short time, users cannot respond. Timelocks exist to create a review period between "dangerous change queued" and "dangerous change executed."
+
+Without a timelock, monitoring becomes postmortem analysis.
+
+### 4.4 Anonymous-team risk
+
+Anonymous teams can build legitimate protocols, but anonymity increases the importance of on-chain constraints. If users cannot rely on legal accountability or reputation, they need stronger code-level guarantees. That means no owner drain path, no instant upgrades, and no opaque vault privileges.
+
+Meerkat had the worst combination: launch-stage anonymity/opacity plus privileged vault control plus rapid fund accumulation.
+
+## 5. Market impact
+
+### 5.1 BSC ecosystem trust shock
+
+The incident was widely described as one of the first major BSC exploits or rug pulls. It arrived during BSC's rapid growth and challenged the narrative that low fees and fast execution were enough to make DeFi safer or more accessible.
+
+The problem was not BSC consensus or BNB/BUSD themselves. The problem was application-layer trust. A cheap chain makes it easier for both users and scammers to interact.
+
+### 5.2 User coordination after the drain
+
+AMBCrypto noted that affected users filed reports on Binance Community pages, listing staked amounts and asking for solutions. This is a common post-rug pattern: users turn to exchanges, chain operators, and public forums when protocol operators vanish.
+
+But DeFi deposits into unaudited or owner-controlled contracts may not be recoverable through exchange support. If stolen funds are bridged, mixed, swapped, or split across addresses, recovery becomes difficult.
+
+### 5.3 Contagion to new farm perception
+
+After Meerkat, users had more reason to distrust new BSC farms. The incident reinforced several heuristics:
+
+- brand-new protocol plus very high APY is high risk;
+- deleted socials are a severe warning;
+- unaudited vaults should be treated as custodial;
+- owner privileges matter more than UI polish; and
+- "hack" claims need on-chain evidence.
+
+The broader market effect was increased skepticism toward copycat yield farms.
+
+## 6. Distinguishing exploit, key compromise, and rug pull
+
+### 6.1 Why labels matter
+
+An "exploit" suggests an external attacker abused a bug. A "key compromise" suggests an attacker stole administrative credentials. A "rug pull" suggests insiders intentionally drained user funds. Meerkat reporting contained elements of all three narratives, but public suspicion leaned strongly toward rug pull because deployer authority was reportedly involved and communication channels disappeared.
+
+Market-health analysis should avoid overclaiming identity when facts are uncertain. The safer framing is:
+
+> Meerkat was drained through privileged vault-control paths consistent with rug-pull or deployer-key compromise risk.
+
+This captures the user-facing risk without needing to prove who held the key.
+
+### 6.2 Same control failure, different actor
+
+Whether the actor was an insider or a private-key thief, the same control failed: one authority path could alter vault logic and move user funds. Good protocol design should limit damage in both cases.
+
+If a malicious insider can drain funds, the design is unsafe.
+
+If a stolen key can drain funds, the design is unsafe.
+
+If users cannot tell the difference, the design is not transparent enough.
+
+### 6.3 Evidence users can check
+
+Before depositing into a new farm, users and analysts can check:
+
+- Is the vault source verified?
+- Is ownership renounced?
+- If not renounced, who owns it?
+- Is the owner an EOA or multisig?
+- Is there a timelock?
+- Can the owner upgrade logic?
+- Can the owner withdraw user funds?
+- Are admin functions documented?
+- Is there an audit matching deployed bytecode?
+- Do social channels have credible history?
+
+Meerkat would have failed several of these checks.
+
+## 7. Controls that would have reduced loss
+
+### 7.1 Timelocked vault upgrades
+
+Any upgrade to vault business logic should be delayed by a timelock. Users need time to inspect the change and withdraw if they disagree. A timelock does not prevent every malicious upgrade, but it converts instant theft into an observable warning period.
+
+For new farms, even a 24-48 hour timelock can significantly reduce rug-pull risk.
+
+### 7.2 Multisig ownership
+
+Vault ownership should not sit behind a single deployer EOA. A multisig with independent signers reduces the risk of one compromised or malicious key. It also creates accountability and slows unilateral action.
+
+The multisig should be public, and signers should be known or otherwise reputation-backed.
+
+### 7.3 Clear privilege disclosure
+
+Users should not have to reverse-engineer admin functions to know whether funds can be moved. Protocols should publish:
+
+- owner address;
+- upgrade permissions;
+- withdrawal permissions;
+- emergency pause behavior;
+- timelock address;
+- multisig signer list;
+- audit commit hash; and
+- deployment transaction.
+
+If a team refuses to disclose privileges, users should treat the vault as high risk.
+
+### 7.4 Deposit caps during launch
+
+Launch-stage protocols should cap deposits until code and operations have been proven. If Meerkat had strict caps, the maximum loss would have been lower. Deposit caps are not only for technical exploits; they also limit insider and key-compromise blast radius.
+
+Caps can increase over time as audits, monitoring, and reputation mature.
+
+### 7.5 Independent monitoring
+
+Monitoring should flag:
+
+- vault owner changes;
+- implementation upgrades;
+- changes to strategy or vault business logic;
+- large withdrawals by privileged addresses;
+- social-channel deletion;
+- website DNS changes;
+- sudden liquidity removal; and
+- funds splitting across new addresses.
+
+For a new farm, these events should be treated as emergency alerts.
+
+## 8. Market-health indicators
+
+### 8.1 Brand-new farm with large deposits
+
+Large TVL shortly after launch is not proof of safety. It can be a honeypot for admin abuse. Analysts should discount TVL quality when a protocol lacks history, audits, and owner constraints.
+
+The Meerkat case shows that one night is not enough time for market validation.
+
+### 8.2 Owner-upgradeable vaults
+
+Owner-upgradeable vaults without timelocks should be treated as custodial or semi-custodial. Users are trusting the owner not to change logic. That risk should be priced similarly to exchange custody or multisig custody, not like immutable DeFi.
+
+### 8.3 Disappearing communications
+
+Deleted Twitter accounts, unavailable websites, and silent admins after a drain are strong rug-pull signals. Even if technical recovery is possible, absent communication undermines coordination and trust.
+
+### 8.4 Chain-level reputation impact
+
+Application-layer scams can affect the reputation of an entire chain ecosystem. Meerkat was framed as a BSC ecosystem event because it happened during BSC's growth phase. Chains that attract fast deployments also need user education, explorers, verification tooling, and security norms to reduce repeat incidents.
+
+## 9. Broader implications for yield-farm users
+
+### 9.1 APY is not compensation for rug risk
+
+High APY can compensate for ordinary market risk only if the protocol is expected to continue operating. It cannot compensate for a vault owner who can drain funds instantly. If principal can disappear overnight, nominal APY is irrelevant.
+
+Users should ask whether yield comes from real economic activity or from attracting deposits into a privileged contract.
+
+### 9.2 "Burned LP tokens" can be misleading
+
+AMBCrypto quoted an observer who argued this was not a traditional rug because LP tokens and team tokens were burned, but vaults were deployed and upgraded in a way that still allowed a rug. This is an important lesson. Burning one control token does not remove all control paths.
+
+Teams can burn LP tokens while retaining vault owner privileges, upgrade keys, or strategy withdrawal authority. Users must inspect all privileged paths, not only the most visible one.
+
+### 9.3 Recovery depends on fast tracing
+
+Once funds leave vaults, recovery depends on tracing, exchange freezes, negotiation, or law enforcement. These are uncertain and slow relative to on-chain movement. Prevention through permission design is far better than trying to recover after a rug.
+
+## 10. Timeline
+
+- **3 March 2021**: Meerkat Finance launches on Binance Smart Chain, according to contemporary reporting.
+- **4 March 2021**: 13.96 million BUSD and 73,653 BNB are drained from Meerkat Finance vaults, totaling roughly $31 million to $32 million.
+- **Immediate aftermath**: The team claims a hack, but the website stops functioning and the Twitter account is deleted.
+- **Community response**: Users file reports, track stolen amounts, and appeal to Binance/BSC community channels.
+- **Ongoing analysis**: Observers report that the original deployer account altered vault business logic, leading to broad rug-pull suspicion.
+- **Aftermath**: Meerkat becomes a reference case for BSC launch-farm rug risk and privileged vault-control failures.
+
+## 11. Lessons for builders, users, and analysts
+
+For builders, the lesson is that vault upgrade authority must be constrained from day one. If a deployer can alter business logic after users deposit, the system is not meaningfully trustless.
+
+For users, the lesson is to inspect owner privileges before chasing yield. A brand-new farm with high APY, anonymous operators, and upgradeable vaults is a custody risk even if the interface looks like DeFi.
+
+For analysts, Meerkat provides a checklist: verify owner/upgrade paths, compare deployed code with audited code, monitor social-channel disappearance, track privileged transactions, and treat burned LP tokens as insufficient if vault logic remains mutable.
+
+The Meerkat Finance drain was therefore more than an early BSC scandal. It was a clear example of how privileged vault control can turn yield farming into a one-day custody failure.
+
+## References
+
+- AMBCrypto, [Meerkat Finance drained of almost $32M after launch on Binance Smart Chain](https://ambcrypto.com/meerkat-finance-drained-of-almost-32m-after-launch-on-binance-smart-chain/)
+- The Block, [Rug pull? DeFi project Meerkat drained by $31M on Binance Smart Chain](https://www.theblock.co/linked/97082/rug-pull-defi-meerkat-31-million)
+- Yahoo Finance, [DeFi Project Meerkat Raises Eyebrows With Claimed $31M Hack a Day After Launch](https://finance.yahoo.com/news/defi-project-meerkat-raises-eyebrows-144425368.html)
+- BscScan, [Meerkat Finance token launch reference cited by AMBCrypto](https://bscscan.com/token/0xc65f62d372aa50e99b2a564ddb418a6bc84faa15)


### PR DESCRIPTION
Contribution to #277

Adds a market-health analysis of the March 2021 Meerkat Finance BSC drain, covering privileged vault-control risk, deployer-associated business-logic changes, the 13.96M BUSD / 73,653 BNB loss, disappearing communications, and controls for launch-stage yield farms.