### PR TITLE
add: Atlantis Loans abandoned protocol governance-oracle exploit on BSC (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-atlantis-loans/index.md
+++ b/content/research/market-health/posts/2026-05-05-atlantis-loans/index.md
@@ -1,0 +1,121 @@
+---
+date: 2026-05-05
+entities:
+  - id: atlantis-loans
+    name: Atlantis Loans
+    type: defi-protocol
+  - id: binance-smart-chain
+    name: Binance Smart Chain
+    type: blockchain
+title: "Atlantis Loans governance-oracle exploit: abandoned protocol takeover and $1M BSC lending drain"
+---
+
+## Introduction
+
+Atlantis Loans was a decentralized lending and borrowing protocol operating on Binance Smart Chain (BSC), forked from Compound Finance. The protocol allowed users to deposit assets as collateral, earn interest, and borrow other supported assets at algorithmically determined interest rates. Like many Compound forks on BSC, Atlantis offered governance through its native token, which granted voting power over protocol parameters including supported asset listings, collateral factors, and oracle configurations.
+
+On June 10, 2023, an attacker exploited Atlantis Loans through a governance manipulation attack, passing a malicious proposal that reconfigured the protocol's price oracle for a supported collateral asset. The attacker then used the manipulated oracle to inflate their collateral's reported value and borrow far more than the collateral was actually worth, extracting approximately $1 million from the protocol's lending pools. The attack was notable because it targeted an effectively abandoned protocol — the development team had ceased active maintenance, leaving the governance system operational but unmonitored, making it trivial for the attacker to pass proposals without opposition.
+
+## Background
+
+### Abandoned Protocol Risk
+
+By mid-2023, the BSC DeFi ecosystem contained numerous protocols that had been launched during the 2021 bull market but had since been effectively abandoned by their development teams. These "zombie protocols" continued to operate on-chain (smart contracts don't stop running without explicit pausing), and some still held user funds from depositors who had forgotten to withdraw or were unaware the team had departed. Critically, their governance systems also continued to operate — proposals could be submitted, voted on, and executed without any team oversight or community moderation.
+
+This created a unique attack surface: protocols with functional governance, minimal oversight, and residual TVL could be exploited by anyone who acquired enough governance tokens to pass proposals unilaterally. The cost of acquiring governance tokens for abandoned protocols was typically minimal (the tokens traded at near-zero values on thin liquidity), making governance attacks economically viable even for protocols with relatively small remaining TVL.
+
+### Atlantis Loans State
+
+By June 2023, Atlantis Loans had been effectively abandoned for several months. The team had stopped communicating on social channels, the protocol's website was poorly maintained, and there were no governance participants monitoring proposal activity. However, the protocol still held approximately $2-3 million in deposited assets from users who had not withdrawn, and the governance system remained fully operational — proposals could be created, voted on, and executed with standard timelock delays.
+
+### Governance-Oracle Attack Pattern
+
+The governance-oracle attack pattern exploits the fact that in many Compound-fork lending protocols, the price oracle configuration is a governable parameter. An attacker who controls governance can set a supported asset's oracle to a contract they control, then report any price they choose for that asset. By inflating the reported price of their collateral, they can borrow against it at a hugely favorable rate — effectively borrowing without real collateral.
+
+This is the same dual-vector pattern used in the Fortress Protocol exploit (May 2022), applied to a different target with a different governance acquisition mechanism (cheap token purchase on thin liquidity vs. accumulation during active protocol operation).
+
+## The Attack
+
+### Phase 1: Governance Token Acquisition
+
+The attacker acquired Atlantis governance tokens through open market purchases on BSC DEXes. Because the protocol was abandoned and the governance token had minimal trading activity, the attacker was able to acquire a controlling stake (sufficient to meet the quorum and pass proposals) at very low cost — estimated at a few hundred dollars worth of BNB for tokens that would control millions in protocol TVL.
+
+### Phase 2: Malicious Governance Proposal
+
+The attacker submitted a governance proposal that changed the price oracle for a supported collateral asset to a contract address controlled by the attacker. The proposal was crafted to appear routine (using the standard governance function for oracle updates) and targeted a lower-profile asset to reduce the likelihood of detection.
+
+With no active governance participants to vote against the proposal, the attacker voted in favor with their acquired tokens, easily meeting the quorum requirement. The proposal passed and entered the timelock period (typically 24-48 hours for Compound forks).
+
+### Phase 3: Timelock Execution and Drain
+
+After the timelock expired, the attacker executed the proposal, officially updating the protocol's oracle for the targeted asset. The attacker then deposited the asset as collateral, set the oracle to report an artificially high price (making the collateral appear extremely valuable), and borrowed the maximum amount of other assets (BNB, BUSD, USDT) against the inflated collateral.
+
+The borrowed assets were withdrawn from the protocol and converted to BNB or bridged off BSC. The protocol was left with bad debt — outstanding borrows backed by collateral whose real value was a fraction of what the manipulated oracle reported.
+
+### Extraction Total
+
+The total extraction was approximately $1 million in various BSC assets, limited by the remaining TVL in the protocol's lending pools. The attacker could not extract more than the available liquidity in each asset's pool.
+
+## Impact
+
+### Financial Losses
+
+Depositors who still had funds in Atlantis Loans lost approximately $1 million collectively. These were primarily users who had deposited during the protocol's active period (2021-2022) and had not withdrawn their funds despite the team's departure. The losses were distributed across all remaining depositors proportionally — each depositor's claim on the pool was reduced by the amount the attacker borrowed.
+
+### Abandoned Protocol Ecosystem Risk
+
+The Atlantis exploit highlighted a systemic risk across the DeFi ecosystem: dozens of abandoned protocols on BSC, Ethereum, and other chains held residual user funds with active governance systems that could be hijacked cheaply. Security researchers subsequently identified multiple other protocols vulnerable to the same attack pattern, prompting community efforts to alert remaining depositors and advocating for protocols to include "wind-down" mechanisms that deactivate governance if the team abandons the project.
+
+### Governance Design Implications
+
+The incident demonstrated that governance systems designed for active community participation become security liabilities when the community departs. A governance system that functions identically with one participant (the attacker) as with a thousand represents a fundamental design flaw for protocols that may outlive their teams.
+
+## Response and Remediation
+
+### No Team Response
+
+Because the Atlantis Loans team had already abandoned the protocol, there was no official response, no post-mortem, and no compensation plan. Affected users had no entity to appeal to for recovery. The protocol's smart contracts continued to operate post-exploit (with the depleted pools), and remaining depositors eventually withdrew whatever residual assets were available.
+
+### Community Response
+
+The DeFi security community used the Atlantis exploit as a case study for abandoned protocol risk. Several initiatives emerged. DefiSafety and similar protocol rating services began flagging "abandoned" protocols more prominently, warning users about the governance attack risk. Community members compiled lists of BSC protocols with similar vulnerability profiles (abandoned team, active governance, residual TVL). Some protocols with concerned community members proactively submitted governance proposals to remove governance power or pause operations before they could be similarly exploited.
+
+## Technical Analysis
+
+### Governance Attack Cost Model
+
+The economics of attacking abandoned protocols are straightforward. The cost is: `market_cap_of_governance_token * quorum_percentage + gas_costs`. For Atlantis, the governance token's market cap was effectively near zero (thin liquidity, no buy pressure), and the quorum requirement was modest. The attacker likely spent under $1,000 to acquire governance control over $1+ million in protocol TVL — an extremely favorable attack ratio.
+
+This cost model means that any abandoned protocol with `residual_TVL > governance_acquisition_cost` is an economically rational target for governance attacks. The lower the governance token's market cap and the lower the quorum requirement, the more vulnerable the protocol is.
+
+### Timelock as an Inadequate Defense
+
+Compound-fork governance systems typically include a timelock (24-72 hours) between proposal approval and execution. This timelock is designed to give the community time to respond to malicious proposals — users can withdraw funds before the malicious proposal takes effect.
+
+However, timelocks are only effective when someone is monitoring governance activity and alerting depositors. For abandoned protocols with no monitoring, the timelock provides no practical protection — the proposal passes, the timelock expires, and the attack executes with no intervention. The timelock assumes active community vigilance, which by definition does not exist for abandoned protocols.
+
+### Comparison with Other Abandoned Protocol Exploits
+
+The Atlantis attack pattern has been replicated across multiple abandoned protocols. Similar incidents include Venus Protocol's governance concerns (though Venus maintained an active team and avoided exploitation), multiple unnamed BSC Compound forks that were exploited through identical governance-oracle manipulation, and the broader pattern of "governance capture" on protocols where governance tokens concentrate in the hands of attackers due to low market caps and thin liquidity.
+
+## Lessons Learned
+
+### Protocols Need Wind-Down Mechanisms
+
+DeFi protocols should include explicit "wind-down" or "sunset" mechanisms that activate when the team departs or governance participation drops below a minimum threshold. These mechanisms could include automatic pausing of deposit/borrow functions if no governance activity occurs for a defined period, automatic freezing of oracle updates after a period of governance inactivity, gradual reduction of borrowing caps toward zero in the absence of active governance oversight, and permanent locking of sensitive parameters (oracle configs, collateral factors) if the protocol enters a "sunset" state.
+
+### Governance Quorum Must Scale with Risk
+
+Governance quorum requirements should be proportional to the sensitivity of the action being approved. Asset additions and oracle changes (which can enable complete fund extraction) should require significantly higher quorum than routine parameter adjustments. For critical operations, quorum should be expressed as a percentage of circulating supply rather than a fixed absolute number, ensuring that governance capture requires acquiring a meaningful fraction of all outstanding tokens regardless of market price.
+
+### Monitoring as Critical Infrastructure
+
+The DeFi ecosystem needs infrastructure for monitoring governance activity across all active protocols and alerting depositors when potentially malicious proposals are submitted. This could be provided by protocol teams, by third-party security services, or by decentralized monitoring networks. Without monitoring, the timelock defense mechanism is useless.
+
+### User Responsibility for Dormant Positions
+
+Users who deposit into DeFi protocols take on an ongoing responsibility to monitor those positions — including governance activity that could affect their deposits. Protocols that become abandoned do not automatically return funds; the smart contracts continue to operate with whatever governance activity occurs. Users with positions in protocols showing signs of abandonment (team departure, communication cessation, declining TVL) should withdraw proactively rather than assuming their funds are safe indefinitely.
+
+## Conclusion
+
+The Atlantis Loans governance-oracle exploit of June 2023 drained approximately $1 million from the abandoned BSC lending protocol through a governance manipulation attack that was trivially cheap to execute due to the protocol's near-zero governance token value and complete lack of community monitoring. The attacker acquired governance control for minimal cost, passed a proposal replacing a collateral asset's oracle with an attacker-controlled contract, inflated the oracle price, and borrowed against worthless collateral. The incident was enabled entirely by the protocol's abandonment — the governance system continued to function as designed, but without community participation to block malicious proposals or alert depositors to withdraw. The exploit demonstrated that DeFi governance systems become security liabilities when protocols are abandoned, and that the ecosystem needs wind-down mechanisms, enhanced monitoring infrastructure, and governance designs that scale security requirements with the sensitivity of governable parameters to prevent identical attacks on the dozens of other abandoned protocols holding residual user funds across the multi-chain DeFi ecosystem.


### PR DESCRIPTION
Comprehensive wiki article on the June 2023 Atlantis Loans governance-oracle exploit.

- 13,810 characters covering the $1M drain from abandoned BSC lending protocol
- Governance token acquisition at near-zero cost for abandoned protocol
- Oracle reconfiguration through uncontested governance proposal
- Abandoned protocol risk model and wind-down mechanism analysis
- Comparison with Fortress Protocol governance capture pattern

Closes #277 (partial)