### PR TITLE
add: DFX Finance curve pool flash-loan reentrancy and $7.5M stablecoin drain (#277)

### DIFF
--- a/content/research/market-health/posts/2026-05-05-dfx-finance/index.md
+++ b/content/research/market-health/posts/2026-05-05-dfx-finance/index.md
@@ -1,0 +1,170 @@
+---
+date: 2026-05-05
+entities:
+  - id: dfx-finance
+    name: DFX Finance
+    type: defi-protocol
+  - id: ethereum
+    name: Ethereum
+    type: blockchain
+title: "DFX Finance curve pool reentrancy: flash-loan callback exploitation and $7.5M stablecoin drain"
+---
+
+## Introduction
+
+DFX Finance was a decentralized exchange protocol on Ethereum specializing in foreign exchange (FX) stablecoin trading. The protocol implemented custom bonding curve mathematics optimized for stablecoin-to-stablecoin swaps, supporting pairs like CADC (Canadian Dollar), EUROC (Euro), XSGD (Singapore Dollar), and other non-USD stablecoins against USDC. The bonding curves were designed to maintain tight spreads near the expected exchange rate while allowing price discovery during periods of peg deviation. The protocol's pools operated similarly to Curve Finance but with custom curve parameters tuned for FX rates rather than USD-pegged stablecoin equivalence.
+
+On November 11, 2022, an attacker exploited a reentrancy vulnerability in DFX Finance's curve pool contracts, extracting approximately $7.5 million in stablecoins (primarily USDC and EUROC) from multiple pools. The vulnerability existed in the flash loan callback mechanism of the pool contracts, which allowed the attacker to re-enter the pool's deposit function during a flash loan, manipulating the pool's accounting state to withdraw more tokens than they were entitled to.
+
+## Background
+
+### DFX Finance Architecture
+
+DFX Finance launched in 2021 as a specialized AMM for non-USD stablecoin pairs. The protocol's architecture included several components:
+
+**Curve Pools**: Custom AMM pools implementing bonding curves optimized for FX stablecoin trading. Each pool held two stablecoins (e.g., CADC/USDC) and used mathematical curves to determine swap prices. The curve parameters incorporated external Chainlink oracle data for the expected FX rate, allowing the curve to center around the fair exchange rate.
+
+**LP Token System**: Liquidity providers deposited stablecoin pairs into pools and received LP tokens representing their proportional share. The LP token minting and burning logic was integrated into the pool contract.
+
+**Flash Loan Functionality**: DFX pools supported flash loans, allowing users to borrow pool reserves within a single transaction, provided the borrowed amount was returned before the transaction completed. Flash loans triggered a callback function on the borrower's contract, allowing arbitrary logic execution between the borrow and repay steps.
+
+**Viewcurve Library**: The core mathematical library implementing the bonding curve calculations, including deposit/withdrawal amount computations based on current pool reserves and curve parameters.
+
+### The Reentrancy Vector
+
+The reentrancy vulnerability existed in the interaction between DFX's flash loan mechanism and its deposit function. The critical sequence was:
+
+1. A flash loan is initiated, transferring tokens from the pool to the borrower
+2. The pool calls a callback function on the borrower's contract
+3. During this callback, the borrower re-enters the pool's deposit function
+4. The deposit function reads the pool's current balance (which still reflects the flash-loaned amounts as outstanding)
+5. The deposit calculation is based on this stale/manipulated state
+6. After the flash loan settles, the pool's accounting is inconsistent with its actual token balances
+
+The root cause was a missing reentrancy guard on the deposit function and the flash loan callback not properly locking the pool's state against concurrent modification.
+
+### ERC-3156 Flash Loan Standard
+
+DFX Finance implemented flash loans following a pattern similar to the ERC-3156 standard, where the pool transfers tokens to the borrower, calls a callback function, and then verifies that the tokens have been returned. The critical security requirement for flash loan implementations is that the pool's state must be consistent at every point where external code can execute — specifically, during the callback. If state reads during the callback reflect interim (incomplete) state, any function that reads that state is vulnerable to manipulation.
+
+## The Attack
+
+### Vulnerability: Missing Reentrancy Protection on Deposit
+
+The core vulnerability was that DFX Finance's pool deposit function lacked reentrancy protection (such as OpenZeppelin's `ReentrancyGuard` modifier or a manual mutex lock). The flash loan callback created an execution window where external code ran while the pool's token balances were temporarily altered (tokens had been sent out but not yet returned), and the deposit function could be called within this window.
+
+The deposit function calculated the number of LP tokens to mint based on the ratio of the depositor's contribution to the pool's current reserves. When called during a flash loan callback, the pool's reserves appeared smaller than their true value (because the flash-loaned tokens were temporarily absent), causing the deposit function to calculate an inflated LP token amount for the same deposit size.
+
+### Attack Execution
+
+The attack on November 11, 2022, was executed through a custom attacker contract that combined flash loans with reentrancy:
+
+**Step 1: Flash loan initiation.** The attacker's contract called the DFX pool's flash loan function, borrowing a large amount of one of the pool's stablecoins (e.g., USDC). This transferred the USDC from the pool to the attacker's contract and triggered the callback.
+
+**Step 2: Reentrancy during callback.** Inside the flash loan callback, the attacker's contract called the pool's deposit function. Because the pool's USDC balance had been temporarily reduced by the flash loan, the deposit function calculated LP token amounts based on the reduced reserve — meaning the attacker received more LP tokens per unit of deposit than they would under normal conditions.
+
+**Step 3: Flash loan repayment.** After the deposit, the attacker's contract returned the flash-loaned tokens to the pool, completing the flash loan. The pool's balance was restored, but the attacker now held LP tokens that represented a larger share of the pool than they should have received for their deposit amount.
+
+**Step 4: LP token redemption.** The attacker withdrew their LP tokens from the pool through the normal withdrawal mechanism. Because their LP tokens represented an inflated share, the withdrawal returned more stablecoins than the attacker had deposited, resulting in a net profit.
+
+**Step 5: Repetition across pools.** The attacker repeated this process across multiple DFX pools (CADC/USDC, EUROC/USDC, XSGD/USDC, and others), draining excess tokens from each pool.
+
+### Transaction Flow
+
+The entire attack could be executed in a single transaction per pool. Each transaction contained:
+1. Flash loan borrow from the DFX pool
+2. Callback execution containing a deposit to the same pool
+3. Flash loan repayment
+4. LP token withdrawal from the pool
+
+The net result of each transaction was that the attacker extracted more stablecoins from the pool than they deposited, with the difference representing the profit from the inflated LP token minting.
+
+## Impact
+
+### Financial Losses
+
+The total funds extracted were approximately $7.5 million across multiple DFX pools:
+- EUROC/USDC pool: ~$3.2 million
+- CADC/USDC pool: ~$2.1 million  
+- XSGD/USDC pool: ~$1.4 million
+- Other pools: ~$0.8 million
+
+The losses were absorbed by liquidity providers in each affected pool. After the exploit, remaining LP token holders could withdraw less than their original deposits because the pool reserves had been depleted by the attacker's inflated withdrawals.
+
+### Protocol Response
+
+DFX Finance responded by pausing all pool contracts to prevent further exploitation, publishing a detailed post-mortem analysis, engaging security researchers for incident response, and working on a remediation plan. The team also identified the attacker's on-chain activity and traced fund movements through various mixers and bridges.
+
+### Market Impact
+
+The exploit significantly impacted the non-USD stablecoin trading market on Ethereum. DFX Finance was one of the primary liquidity venues for CADC, EUROC, and other FX stablecoins. With pools drained and contracts paused, traders of these stablecoins lost a major liquidity source, temporarily widening spreads on alternative venues. The DFX token price declined sharply following the exploit as confidence in the protocol diminished.
+
+## Technical Analysis
+
+### Reentrancy in DeFi: A Persistent Threat
+
+Reentrancy vulnerabilities have been a persistent and recurring theme in DeFi exploits since the original DAO hack in 2016. Despite being one of the most well-known vulnerability classes in smart contract development, reentrancy continues to cause significant losses because:
+
+**New reentrancy patterns emerge**: While the classic "withdraw before update" reentrancy is well-understood, newer patterns like cross-function reentrancy, cross-contract reentrancy, and read-only reentrancy (exploited in the Curve/Vyper incident) continue to surprise developers. The DFX exploit was a cross-function reentrancy — the flash loan callback re-entered a different function (deposit) on the same contract.
+
+**Flash loans amplify reentrancy impact**: Flash loans provide attackers with unlimited capital within a single transaction, making even small per-call profits from reentrancy exploitable at scale. Without flash loans, the DFX attacker would have needed significant capital to deposit during the callback.
+
+**Custom code paths create audit blind spots**: DFX's custom bonding curve and flash loan implementations created unique code paths that may not have been covered by generic reentrancy analysis tools or auditor checklists designed for more standard AMM patterns.
+
+### The Check-Effects-Interactions Pattern
+
+The fundamental defense against reentrancy is the Checks-Effects-Interactions (CEI) pattern: perform all checks (require statements), update all state variables (effects), and only then make external calls (interactions). In DFX's case, the flash loan callback was an external call (interaction) that occurred before the pool's state was finalized, and the deposit function could read and modify state during this window.
+
+Applying CEI strictly would mean either: (a) completing all state updates before the flash loan callback, which would mean the pool's balances reflect the post-repayment state even though repayment hasn't occurred (requiring more complex accounting), or (b) locking the contract against state-modifying reentrancy during the callback.
+
+### Defense: ReentrancyGuard
+
+The most straightforward defense is OpenZeppelin's `ReentrancyGuard` modifier, which uses a mutex lock to prevent any function marked with the modifier from being called while another guarded function is executing. If DFX had applied `nonReentrant` to both the flash loan function and the deposit function, the deposit call during the callback would have reverted because the lock was already held by the flash loan execution.
+
+The cost of `ReentrancyGuard` is minimal (one storage read and write per function call, approximately 5,000-10,000 additional gas) relative to the protection it provides. For functions that handle significant value, this gas overhead is negligible.
+
+### Comparison with Similar Flash Loan Reentrancy Exploits
+
+The DFX exploit shares mechanistic similarities with several other incidents:
+
+**The DAO (June 2016, ~$60M equivalent)**: The original Ethereum reentrancy exploit. The DAO's withdrawal function sent ETH to the caller before updating the caller's balance, allowing recursive calls to drain the contract. While mechanistically simpler than DFX, the pattern is identical: external call before state finalization.
+
+**Cream Finance V2 (October 2021, ~$130M)**: A reentrancy vulnerability in flash loan logic allowed the attacker to manipulate lending protocol state during a callback. The cross-function reentrancy pattern (entering a different function during a callback) mirrors the DFX exploit.
+
+**Curve/Vyper Reentrancy (July 2023, ~$73M)**: A compiler-level reentrancy guard bypass in certain Vyper versions allowed reentrancy in Curve pools that were intended to be protected. While the root cause was different (compiler bug vs. missing guard), the exploitation pattern of re-entering a pool function during an external callback was similar.
+
+### Oracle Integration and Price Impact
+
+DFX's use of Chainlink oracles for FX rates was not directly implicated in the exploit, but it represents an additional complexity layer. During the reentrancy, the pool's bonding curve calculations used both the current reserve ratios (manipulated by the flash loan) and the oracle-provided FX rate (unchanged). This meant the attacker's profit was determined by the reserve manipulation rather than oracle manipulation, simplifying the attack compared to exploits that require both state manipulation and oracle control.
+
+### Why Flash Loans Make Reentrancy More Dangerous
+
+Flash loans transform reentrancy from a "requires capital" to a "requires no capital" attack:
+
+Without flash loans, exploiting the DFX reentrancy would require the attacker to have significant stablecoin holdings to deposit during the callback. The profit per attack iteration is proportional to the deposit size relative to the pool's reserves, so small deposits would yield small profits.
+
+With flash loans, the attacker can borrow the pool's entire reserve, creating maximum reserve manipulation during the callback. The flash-loaned amount temporarily removes most of the pool's reserves, making the attacker's deposit during the callback appear proportionally much larger than it actually is. The profit scales with the flash loan size, which is limited only by the pool's total reserves.
+
+This is why flash loan reentrancy is particularly dangerous: it removes the capital barrier that would otherwise limit the impact of reentrancy vulnerabilities. Any reentrancy vulnerability in a contract that supports flash loans (or interacts with contracts that do) should be considered critical regardless of the per-call profit margin.
+
+## Lessons Learned
+
+### Universal ReentrancyGuard Application
+
+Every public or external function in a DeFi contract that reads or modifies state should be protected by a reentrancy guard. This applies especially to: deposit/withdrawal functions, swap functions, flash loan functions and their callbacks, fee collection functions, and any function that triggers external calls (including token transfers with callback hooks). The gas cost of `ReentrancyGuard` is negligible compared to the catastrophic risk of reentrancy.
+
+### Flash Loan Security Requires State Isolation
+
+Flash loan implementations must ensure that no other state-modifying function can execute during the callback window. This can be achieved through explicit reentrancy guards on all functions, or through a contract-wide lock that prevents any state modification during flash loan execution except the repayment itself. The flash loan callback should be treated as untrusted external code with full adversarial capabilities.
+
+### Audit Focus on Cross-Function Reentrancy
+
+Security audits must specifically test for cross-function reentrancy — scenarios where re-entering a different function on the same contract during an external call produces inconsistent state. This requires analyzing all possible function call sequences that could occur during any external call, not just testing each function in isolation.
+
+### Invariant Checking After External Calls
+
+As a defense-in-depth measure, critical pool invariants (such as the relationship between LP token supply and pool reserves) should be verified after every external call returns. If a flash loan callback has somehow altered the pool's state in an unauthorized way, a post-callback invariant check would detect the inconsistency and revert the transaction before the attacker can profit.
+
+## Conclusion
+
+The DFX Finance exploit of November 11, 2022, extracted approximately $7.5 million in stablecoins through a reentrancy vulnerability in the protocol's flash loan callback mechanism. The attacker re-entered the pool's deposit function during a flash loan callback, exploiting the temporarily reduced pool reserves to receive inflated LP token allocations, then withdrew those LP tokens for more stablecoins than deposited. The exploit was enabled by the absence of reentrancy protection (such as OpenZeppelin's `ReentrancyGuard`) on the deposit function, combined with the flash loan's callback creating an execution window where external code could interact with the pool in a manipulated state. This incident reinforces that reentrancy remains one of DeFi's most persistent and dangerous vulnerability classes, and that flash loans amplify reentrancy impact by removing capital requirements. Universal application of reentrancy guards, flash loan state isolation, and post-callback invariant checks are essential defensive measures for any protocol that handles significant value.


### PR DESCRIPTION
Adds a comprehensive wiki article on the DFX Finance reentrancy exploit (November 2022, ~$7.5M). Covers flash loan callback reentrancy into the deposit function, LP token inflation mechanics, and cross-function reentrancy defense patterns.

Closes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new market-health research post analyzing a historical DeFi protocol security incident, covering attack mechanics, financial impact, market responses, and technical lessons learned around reentrancy protection and flash-loan considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->