### PR TITLE
Add Similarity Search batch processing

### DIFF
--- a/tools/similarity_search/README.md
+++ b/tools/similarity_search/README.md
@@ -1,11 +1,11 @@
-```
+```bash
 npm install
 npm run dev
 ```
 
 Single lookup:
 
-```
+```bash
 curl -X POST http://localhost:8787/ \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $API_KEY_TOKEN_CHECK" \
@@ -14,7 +14,7 @@ curl -X POST http://localhost:8787/ \
 
 Batch lookup:
 
-```
+```bash
 curl -X POST http://localhost:8787/batch \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $API_KEY_TOKEN_CHECK" \
@@ -23,6 +23,6 @@ curl -X POST http://localhost:8787/batch \
 
 The batch endpoint accepts 1 to 100 items, embeds all texts in one Workers AI request, and queries Vectorize in bounded parallel chunks.
 
-```
+```bash
 npm run deploy
 ```

--- a/tools/similarity_search/README.md
+++ b/tools/similarity_search/README.md
@@ -3,6 +3,26 @@ npm install
 npm run dev
 ```
 
+Single lookup:
+
+```
+curl -X POST http://localhost:8787/ \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY_TOKEN_CHECK" \
+  -d '{"text":"message to check","namespace":"articles"}'
+```
+
+Batch lookup:
+
+```
+curl -X POST http://localhost:8787/batch \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY_TOKEN_CHECK" \
+  -d '{"items":[{"text":"first message","namespace":"articles"},{"text":"second message","namespace":"articles"}]}'
+```
+
+The batch endpoint accepts 1 to 100 items, embeds all texts in one Workers AI request, and queries Vectorize in bounded parallel chunks.
+
 ```
 npm run deploy
 ```

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -49,6 +49,11 @@ function isValidTextEntry(value: unknown): value is TextEntry {
     && typeof entry.namespace === "string" && entry.namespace.length > 0
 }
 
+function isEmbeddingVector(value: unknown): value is number[] {
+  return Array.isArray(value)
+    && value.every((entry) => typeof entry === "number" && Number.isFinite(entry))
+}
+
 async function readJson<T>(request: Request): Promise<T | null> {
   try {
     return await request.json<T>()
@@ -65,7 +70,13 @@ async function embedTexts(ai: Ai, texts: string[]): Promise<number[][]> {
     throw new Error("Embedding response size did not match request size")
   }
 
-  return embeddings as number[][]
+  return embeddings.map((embedding, index) => {
+    if (!isEmbeddingVector(embedding)) {
+      throw new Error(`Embedding response contained invalid vector at index ${index}`)
+    }
+
+    return embedding
+  })
 }
 
 async function querySimilarity(env: Env, item: TextEntry, vector: number[]): Promise<BatchResult> {
@@ -100,10 +111,14 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const [vector] = await embedTexts(c.env.AI, [data.text])
-  const result = await querySimilarity(c.env, data, vector)
+  try {
+    const [vector] = await embedTexts(c.env.AI, [data.text])
+    const result = await querySimilarity(c.env, data, vector)
 
-  return c.json(result)
+    return c.json(result)
+  } catch (error) {
+    return c.text(error instanceof Error ? error.message : "Similarity lookup failed", 502)
+  }
 })
 
 app.post("/batch", async (c) => {

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,18 @@ type TextEntry = {
   namespace: string
 }
 
+type BatchRequest = {
+  items: TextEntry[]
+}
+
+type BatchResult = {
+  similarity_score: number
+}
+
+const MAX_BATCH_SIZE = 100
+const VECTORIZE_QUERY_CONCURRENCY = 10
+const EMBEDDING_MODEL = "@cf/baai/bge-base-en-v1.5"
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -27,25 +39,88 @@ app.use("*", async (c, next) => {
   return next()
 })
 
-app.post("/", async (c) => {
-  const data = await c.req.json<TextEntry>()
-  const { text, namespace } = data
-
-  if (typeof text !== "string" || typeof namespace !== "string") {
-    return c.text("Invalid JSON format", 400)
+function isValidTextEntry(value: unknown): value is TextEntry {
+  if (typeof value !== "object" || value === null) {
+    return false
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: [text]
-  })
-  const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
-    namespace,
+  const entry = value as Partial<TextEntry>
+  return typeof entry.text === "string" && entry.text.length > 0
+    && typeof entry.namespace === "string" && entry.namespace.length > 0
+}
+
+async function embedTexts(ai: Ai, texts: string[]): Promise<number[][]> {
+  const modelResp = await ai.run(EMBEDDING_MODEL, { text: texts }) as { data?: unknown }
+  const embeddings = modelResp.data
+
+  if (!Array.isArray(embeddings) || embeddings.length !== texts.length) {
+    throw new Error("Embedding response size did not match request size")
+  }
+
+  return embeddings as number[][]
+}
+
+async function querySimilarity(env: Env, item: TextEntry, vector: number[]): Promise<BatchResult> {
+  const searchResponse = await env.VECTORIZE_INDEX.query(vector, {
+    namespace: item.namespace,
     topK: 1
   })
   const similarityScore = searchResponse.matches[0]?.score || 0
 
-  return c.json({ similarity_score: similarityScore })
+  return { similarity_score: similarityScore }
+}
+
+async function querySimilarities(env: Env, items: TextEntry[], vectors: number[][]): Promise<BatchResult[]> {
+  const results: BatchResult[] = []
+
+  for (let i = 0; i < items.length; i += VECTORIZE_QUERY_CONCURRENCY) {
+    const itemChunk = items.slice(i, i + VECTORIZE_QUERY_CONCURRENCY)
+    const vectorChunk = vectors.slice(i, i + VECTORIZE_QUERY_CONCURRENCY)
+    const chunkResults = await Promise.all(
+      itemChunk.map((item, index) => querySimilarity(env, item, vectorChunk[index]))
+    )
+    results.push(...chunkResults)
+  }
+
+  return results
+}
+
+app.post("/", async (c) => {
+  const data = await c.req.json<TextEntry>()
+
+  if (!isValidTextEntry(data)) {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  const [vector] = await embedTexts(c.env.AI, [data.text])
+  const result = await querySimilarity(c.env, data, vector)
+
+  return c.json(result)
+})
+
+app.post("/batch", async (c) => {
+  const data = await c.req.json<Partial<BatchRequest>>()
+
+  if (typeof data !== "object" || data === null || !Array.isArray(data.items)) {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  if (data.items.length === 0 || data.items.length > MAX_BATCH_SIZE) {
+    return c.text(`Batch size must be between 1 and ${MAX_BATCH_SIZE}`, 400)
+  }
+
+  if (!data.items.every(isValidTextEntry)) {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  try {
+    const vectors = await embedTexts(c.env.AI, data.items.map((item) => item.text))
+    const results = await querySimilarities(c.env, data.items, vectors)
+
+    return c.json({ results })
+  } catch (error) {
+    return c.text(error instanceof Error ? error.message : "Batch processing failed", 502)
+  }
 })
 
 export default app

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -49,6 +49,14 @@ function isValidTextEntry(value: unknown): value is TextEntry {
     && typeof entry.namespace === "string" && entry.namespace.length > 0
 }
 
+async function readJson<T>(request: Request): Promise<T | null> {
+  try {
+    return await request.json<T>()
+  } catch {
+    return null
+  }
+}
+
 async function embedTexts(ai: Ai, texts: string[]): Promise<number[][]> {
   const modelResp = await ai.run(EMBEDDING_MODEL, { text: texts }) as { data?: unknown }
   const embeddings = modelResp.data
@@ -86,7 +94,7 @@ async function querySimilarities(env: Env, items: TextEntry[], vectors: number[]
 }
 
 app.post("/", async (c) => {
-  const data = await c.req.json<TextEntry>()
+  const data = await readJson<TextEntry>(c.req.raw)
 
   if (!isValidTextEntry(data)) {
     return c.text("Invalid JSON format", 400)
@@ -99,7 +107,7 @@ app.post("/", async (c) => {
 })
 
 app.post("/batch", async (c) => {
-  const data = await c.req.json<Partial<BatchRequest>>()
+  const data = await readJson<Partial<BatchRequest>>(c.req.raw)
 
   if (typeof data !== "object" || data === null || !Array.isArray(data.items)) {
     return c.text("Invalid JSON format", 400)

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -53,6 +53,23 @@ describe("Similarity search", () => {
     expect(await response.text()).toBe("Invalid JSON format")
   })
 
+  it("returns 502 when the single lookup embedding response is invalid", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        text: "invalid-embedding",
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Embedding response contained invalid vector at index 0")
+  })
+
   it("processes multiple text entries in request order", async () => {
     const response = await SELF.fetch("https://example.com/batch", {
       method: "POST",
@@ -87,6 +104,24 @@ describe("Similarity search", () => {
         "X-API-Key": "test-api-key"
       },
       body: JSON.stringify({ items: [] })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Batch size must be between 1 and 100")
+  })
+
+  it("rejects batch requests over the maximum size", async () => {
+    const items = Array.from({ length: 101 }, (_, index) => ({
+      text: `Text ${index}`,
+      namespace: "test-namespace"
+    }))
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({ items })
     })
 
     expect(response.status).toBe(400)

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -39,6 +39,20 @@ describe("Similarity search", () => {
     expect(await response.json()).toEqual({ similarity_score: 0.1 })
   })
 
+  it("rejects malformed single lookup JSON", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: "{"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
   it("processes multiple text entries in request order", async () => {
     const response = await SELF.fetch("https://example.com/batch", {
       method: "POST",
@@ -77,6 +91,20 @@ describe("Similarity search", () => {
 
     expect(response.status).toBe(400)
     expect(await response.text()).toBe("Batch size must be between 1 and 100")
+  })
+
+  it("rejects malformed batch JSON", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: "{"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
   })
 
   it("rejects invalid batch entries", async () => {

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -20,3 +20,81 @@ describe("Authentication", () => {
     expect(await response.text()).toBe("Unauthorized")
   })
 })
+
+describe("Similarity search", () => {
+  it("returns a similarity score for a single text entry", async () => {
+    const response = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        text: "Sample text",
+        namespace: "test-namespace"
+      })
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ similarity_score: 0.1 })
+  })
+
+  it("processes multiple text entries in request order", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        items: [
+          { text: "First text", namespace: "articles" },
+          { text: "Second text", namespace: "articles" },
+          { text: "Third text", namespace: "topics" }
+        ]
+      })
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      results: [
+        { similarity_score: 0.1 },
+        { similarity_score: 0.2 },
+        { similarity_score: 0.3 }
+      ]
+    })
+  })
+
+  it("rejects empty batch requests", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({ items: [] })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Batch size must be between 1 and 100")
+  })
+
+  it("rejects invalid batch entries", async () => {
+    const response = await SELF.fetch("https://example.com/batch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": "test-api-key"
+      },
+      body: JSON.stringify({
+        items: [
+          { text: "Valid text", namespace: "test-namespace" },
+          { text: "", namespace: "test-namespace" }
+        ]
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+})

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,9 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    return Promise.resolve({
+                      data: data.text.map((text, index) => [index + 1, text.length])
+                    });
                   }
                 };
               };`
@@ -37,7 +39,7 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   query: async (vectorData, options) => {
-                    const score = 0.5678;
+                    const score = vectorData[0] / 10;
                     return Promise.resolve({ matches: [{ score }] });
                   }
                 };

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -27,7 +27,9 @@ export default defineWorkersConfig({
                 return {
                   run: async (model, data) => {
                     return Promise.resolve({
-                      data: data.text.map((text, index) => [index + 1, text.length])
+                      data: data.text.map((text, index) =>
+                        text === "invalid-embedding" ? ["bad"] : [index + 1, text.length]
+                      )
                     });
                   }
                 };


### PR DESCRIPTION
## Summary

Adds batch message processing to the Similarity Search API while keeping the existing single-message endpoint compatible.

Changes:

- Adds `POST /batch` for 1 to 100 text and namespace entries.
- Uses one Workers AI embedding request for the full batch.
- Queries Vectorize in bounded parallel chunks to avoid unbounded load.
- Shares validation and query helpers between single and batch paths.
- Documents single and batch request examples.

## Validation

- `npm test -- --run`
- `npx --yes --package typescript tsc --noEmit -p test/tsconfig.json`
- `npx wrangler deploy --dry-run --outdir /tmp/similarity-search-dry-run`

Addresses #431


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added local usage instructions, npm run/install commands, and curl examples for single and batch lookup endpoints (headers and example bodies included).

* **New Features**
  * Added a batch endpoint that accepts 1–100 items, embeds texts in one request, and returns per-item similarity results with bounded parallel querying.

* **Improvements**
  * Stronger input validation and clearer error responses for single and batch requests.

* **Tests**
  * Expanded tests covering success, validation errors, embedding failures, and batch edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/935)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->