### PR TITLE
test: handle malformed similarity search payloads

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -28,8 +28,18 @@ app.use("*", async (c, next) => {
 })
 
 app.post("/", async (c) => {
-  const data = await c.req.json<TextEntry>()
-  const { text, namespace } = data
+  let data: unknown
+  try {
+    data = await c.req.json()
+  } catch {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return c.text("Invalid JSON format", 400)
+  }
+
+  const { text, namespace } = data as Record<string, unknown>
 
   if (typeof text !== "string" || typeof namespace !== "string") {
     return c.text("Invalid JSON format", 400)

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,6 +3,19 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const apiKey = "test-api-key"
+
+function postSimilaritySearch(body: string) {
+  return SELF.fetch("https://example.com/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": apiKey
+    },
+    body
+  })
+}
+
 describe("Authentication", () => {
   it("returns 401 Unauthorized when API key is missing or invalid", async () => {
     const response = await SELF.fetch("https://example.com/", {
@@ -18,5 +31,33 @@ describe("Authentication", () => {
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Request parsing", () => {
+  it("returns 400 when the request body is malformed JSON", async () => {
+    const response = await postSimilaritySearch("{")
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when the JSON body is null", async () => {
+    const response = await postSimilaritySearch("null")
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when the JSON body is an array", async () => {
+    const response = await postSimilaritySearch(JSON.stringify([
+      {
+        text: "Sample text",
+        namespace: "test-namespace"
+      }
+    ]))
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
   })
 })


### PR DESCRIPTION
Bounty issue: #430\n\n/claim #430\n\n## Summary\n- add full request-path integration tests for malformed JSON, JSON null, and JSON array payloads\n- return the existing 400 Invalid JSON format response instead of letting malformed/non-object request bodies throw before validation\n\n## Methodology\nThese tests use the existing Cloudflare Workers Vitest pool and SELF.fetch() path, so they exercise the deployed worker request parsing boundary rather than a helper or unit-level parser. The change is intentionally scoped to request parsing before the AI and Vectorize bindings are invoked.\n\n## Verification\n- npm test -- --run from tools/similarity_search: 4 tests passed\n\nReview request: @Lavriz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation on the similarity search API endpoint to reject malformed JSON and invalid request structures
  * Returns clearer 400 error responses for invalid requests

* **Tests**
  * Added comprehensive test coverage for request parsing scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/937)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->