### PR TITLE
Improve Market Health Reporter prompt structure

### DIFF
--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -1,82 +1,80 @@
-There are various indicators that are utilized to spot potential manipulative activities. These indicators, often rooted in statistical and economic theories, can be used individually or in combination to detect anomalies suggestive of market manipulation. Their importance lies in providing objective and quantifiable measures to assess market activities, which, when deviating from established norms, signal the need for closer scrutiny. 
-Here is some basic procedure of the market surveillance analysis:
+Analyze the supplied market-health data and write a publication-ready article. Use the example article only as a style and structure reference; do not copy facts from it unless they also appear in the supplied data.
 
-1. Start with key metrics such as volume distribution, first-digit distribution, correlation between volume and volatility, buy-sell ratio and time-of-trade. It is crucial to observe these metrics over time. 
-2. Identify anomalies using specific criteria, such as sudden spikes or significantly unusual trading volumes. The anomalous patterns and benchmarkes are provided below. Analyze metrics over time to identify trends and patterns. 
-3. Construct a coherent and convincing report, beginning with the metric that shows significant deviation and has a noticeable impact on other metrics. Ensure the report accurately captures market abnormalities that occurred concurrently. Include specific timestamps and quantitative values as evidence.
-4. If the data does not indicate any significant and clear anomalous patterns, avoid over-interpreting the datasets. If no signs of fraud or manipulation are evident, concisely report this absence and attach supporting evidence.
+Analysis workflow:
 
-- Volume-Volatility Correlation.
-    Description: It is a statistical measure that identifies the relationship between trading volume and market volatility in cryptocurrency exchanges. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `vvcorrelation`.
-    Anomalous Pattern: A consistently low correlation (significantly below 0.4) between volume and volatility over extended periods. This might suggest artificial trading volume, as real market trades typically correlate with price volatility.
-    Benchmark: A normal range might vary, but a correlation coefficient consistently below 0.4 can be considered suspicious.
+1. Establish scope first: identify the market venue, trading pair, analysis start/end dates, and the available metric keys.
+2. Build an evidence table internally before writing. For each available metric, note the strongest normal and anomalous observations, including timestamps, direction of change, and quantitative values when present.
+3. Prioritize cross-metric signals over isolated spikes. A single abnormal metric is weak evidence; multiple abnormal metrics over the same window are stronger evidence.
+4. Explicitly rule out weak signals. If a metric is missing, noisy, internally contradictory, or within normal range, say so briefly instead of stretching the conclusion.
+5. Write the report around the strongest supported narrative. If no clear manipulation signal exists, write a concise "no clear anomaly" report with supporting evidence.
 
-- First-Digit Distribution. 
-    Description: In the context of cryptocurrency trading, adherence of the first-digit distribution to Benford’s Law can be used to scrutinize trading data for inconsistencies or abnormalities. Non-conformity to the expected digit distribution could suggest manipulation, such as wash trading or massive sell-offs, warranting further investigation. 
-    Name of the metric: This value is stored in the key `firstdigitdist`.
-    Anomalous Pattern: Significant deviation from Benford's expected distribution in leading digits of trading data. For instance, if numbers begin disproportionately with higher digits (like 8 or 9) instead of lower digits (like 1, 2, or 3).
-    Benchmark: Normally, the empirical first-digit distribution converges with the Benford's Law.      
+Metric guide:
 
-- Kolmogorov-Smirnov (K-S) Test for the First-Digit Distribution.
-    Description: The Kolmogorov-Smirnov test is used to compare a sample with Benford's law. 
-    Name of the metrics: This value is stored in the key `benfordlawtest`.
-    Anomalous Pattern: A larger test value suggests a greater discrepancy between your dataset's distribution and Benford's Law.
-    Benchmark: The K-S test is sensitive to sample size. Sample size is stored in the key `tradecount`. It's necessary for the critical and the test values comparison.   
-    If test value > critical value, then you reject the null hypothesis. This suggests that your data does not conform to Benford's Law at the chosen significance level.
-    If test value ≤ critical value, then you do not reject the null hypothesis. This suggests that there is not enough evidence to conclude that your data deviates from Benford's Law at the chosen significance level.
-    The critical value is a ratio of 1.36 and a square root of `tradecount`. 
-    
-- Volume distribution. 
-    Description: Volume distribution is a graphical representation that shows how frequently different sizes of transactions occur within a time range. 
-    Name of the metric: This value is stored in the key `volumedist`.
-    Anomalous Pattern: A distribution that significantly deviates from the power law, such as an unusually high number of large (whale) trades or a lack of small/medium trades requires closer inspection.
-    Benchmark: The volume distribution is expected to follow the power law. The power law describes a phenomenon where a small number of items are concentrated at the top of a distribution. In simpler terms, this suggests that medium to small retail transactions are frequent, while large “whale” orders are rare.
-    The histogram of a power law distribution is not symmetric. It typically shows a steep drop-off at the beginning (for smaller values) and then a long tail that gradually descends but never really touches the x-axis.
+- Volume-volatility correlation
+  - Key: `vvcorrelation`.
+  - Suspicious when correlation stays materially below 0.4 across an extended period, especially while volume is elevated.
+  - Interpretation: real trading volume usually creates price movement; low correlation during high volume can indicate artificial volume or wash trading.
 
-- Time-of-trade.
-    Description: This metric is designed to analyze trading activity distribution within each minute of an hour/each second of a minute, irrespective of the day/hour/minute in which the trades occur. By focusing solely on the minute/second of trade execution (ranging from 0 to 59), it provides a unique perspective on trading patterns and frequencies that occur at specific minute/second intervals. This approach aggregates transaction data from various time periods into a consolidated array of 60 items, each representing a distinct minute/second within an hour.
-    Name of the metrics: This value is stored in the key `timeoftrade`.
-    Anomalous Pattern: The Time-of-Trade metric detects a two-sided pattern. This means it flags both a high frequency of trades executed at the same time (second or minute) and an almost even distribution of trade counts across seconds or minutes. Such patterns suggest the presence of bot activity or automated trading systems.
-    Benchmark: No specific benchmark exists for this metric. However, trading patterns that significantly deviate from typical human trading behaviors, such as consistent trade spikes every minute or second, or evenly distributed trading activity across seconds or minutes, are considered suspect.
-    
-- Buy/sell ratio.
-    Description: The proportion of buy to sell market orders in a given time period. It is crucial to observe this over time.
-    Name of the metric: This value is stored in the key `buysellratio` and `buysellratioabs`. 
-    Anomalous Pattern: Ratios that significantly deviate from the norm (0.4-0.6 range) or display unnatural steadiness during the periods of high volatility.
-    Benchmark: A balanced market should have a buy/sell ratio around 0.4-0.6. A buy/sell ratio significantly higher than 0.5 suggests a market bias towards buying. Such a scenario could lead to a price increase. A buy/sell ratio significantly lower than 0.5 indicates a market bias towards selling, possibly leading to a price decrease. 
-    
- 
-    Depending on the market context, both irregular and steady fluctuations in this ratio can be indicative of automated trading systems operating to influence the market. 
+- First-digit distribution
+  - Key: `firstdigitdist`.
+  - Suspicious when leading digits materially diverge from Benford's Law, particularly when higher digits such as 8 or 9 are overrepresented.
+  - Interpretation: use as a screening signal, not a standalone conclusion.
 
-- Volume Weighted Average Price (VWAP).
-    Description: A trading benchmark that calculates the average price of a cryptocurrency, weighted by its volume traded over a specific time period - more weight is given to the price levels where a lot of trading activity has occurred.
-    Name of the metric: This value is stored in the key `vwap`.
-    Anomalous Pattern: A significant and consistent difference between the VWAP and the actual trading price, particularly if the trading price is much higher or lower than the VWAP.
-    Benchmark: While there's no specific numerical benchmark, a deviation that's outside normal trading fluctuations could be a red flag.
+- Kolmogorov-Smirnov test for Benford conformity
+  - Key: `benfordlawtest`; sample size key: `tradecount`.
+  - Critical value: `1.36 / sqrt(tradecount)`.
+  - If test value > critical value, the sample does not conform to Benford's Law at the tested significance level.
+  - If test value <= critical value, do not claim Benford deviation.
 
-To enhance the analysis, here are some tips regarding simultaneous anomalous deviations of these metrics which can be indicative of market anomalies:
+- Volume distribution
+  - Key: `volumedist`.
+  - Suspicious when the distribution departs from the expected power-law shape: too many large trades, too few small or medium trades, repeated identical sizes, or a visibly distorted tail.
+  - Interpretation: pair this with volume-volatility correlation, trade count, or buy/sell behavior before inferring manipulation.
 
-Volume Distribution and Volume-Volatility Correlation: A volume distribution that deviates from the power law, especially with an unusual number of large trades, coupled with a low volume-volatility correlation, can suggest market manipulation. Large trades should typically introduce volatility, and a lack of this correlation might indicate that these large trades are not impacting the market as expected.
-Concurrent Irregularities in First-Digit Distribution and K-S Test: Significant deviations from Benford's Law in First-Digit Distribution, coupled with a K-S Test value greater than the critical value, strongly indicate data manipulation. This could be a sign of practices like wash trading, where large volumes of trades are artificially created to mislead the market.
-Inconsistencies in VWAP and Buy/Sell Ratio: A substantial difference between VWAP and market prices, along with abnormal Buy/Sell Ratios, could signify price manipulation. Traders might be attempting to influence the perceived average price through strategic buying or selling.
-Correlation between Time-of-Trade and Buy/Sell Ratio Anomalies: If the Time-of-Trade metric shows high frequency or evenly distributed trades, and the Buy/Sell Ratio deviates significantly from the 0.4-0.6 range, this might suggest automated trading systems are in play. This could be an attempt to influence market prices or create false market sentiment.
+- Time-of-trade
+  - Key: `timeoftrade`.
+  - Suspicious when trades cluster at exact seconds/minutes or appear unnaturally even across seconds/minutes.
+  - Interpretation: clustered or uniform timing can indicate automation, especially when paired with steady buy/sell ratios or repeated trade sizes.
 
-Create an article with the results of your analysis. The article should include:
-- Fields between --- and ---:
-    - 'date'
-        The content of this field must match the format YYYY-MM-DD — YYYY-MM-DD, where the first date is the start of the analysis period, and the second date is the end of the analysis period.
-        Example: '2023-10-02 — 2023-10-08'
-    - 'entities'
-        The content of this field should include entities implicated in wash trading. Example: 'Huobi, HT, TRX, DOGE'
-    - 'title'
-        The content of this field should include the title of the article. Example: 'Uncovering Wash Trading and Market Manipulation on Huobi'
+- Buy/sell ratio
+  - Keys: `buysellratio`, `buysellratioabs`.
+  - Normal range is roughly 0.4-0.6.
+  - Suspicious when the ratio stays outside that range, remains unnaturally stable during volatile periods, or moves in lockstep with other anomalies.
 
-Also, follow the example in the <example> </example> tags. Please, put into the article only the information from the data provided. 
-You can create placeholders for illustrations in the article, as in this example: `{{< figure src="volume_hist.png" alt="ht-usdt volume dist" caption="Volume distribution" loading="lazy" >}}`.
-Allowed names for illustrations:
-- volume_hist.png
-- crypto_metrics.png
-- benford_law.png
-- vv_correlation.png
-Place the article into the <article> </article> tags.
+- Volume weighted average price
+  - Key: `vwap`.
+  - Suspicious when VWAP diverges materially and persistently from the observed trading price.
+  - Interpretation: discuss only when the data includes enough price context to support the claim.
+
+Cross-metric patterns to look for:
+
+- Wash-trading / artificial volume: distorted volume distribution + low `vvcorrelation` + abnormal Benford or K-S results.
+- Bot-driven order printing: repeated or uniform `timeoftrade` patterns + stable `buysellratio` + repeated trade sizes or volume clusters.
+- Price-support behavior: abnormal `buysellratio` + VWAP divergence + concurrent volume spikes.
+- Weak or inconclusive signal: any isolated anomaly without supporting metrics, small samples, or missing timestamps.
+
+Article requirements:
+
+- Wrap the final answer in `<article>` and `</article>` tags only.
+- Start with valid YAML front matter between `---` markers:
+  - `title`: concise article title in quotes.
+  - `date`: quoted date range in the format `YYYY-MM-DD - YYYY-MM-DD`.
+  - `entities`: YAML list of the venue, pair, and assets implicated by the supplied data. If the data does not support an implication, include only the neutral venue/pair entities.
+- Follow the example article's structure, but keep the generated article concise:
+  - `## Summary`: 3-5 numbered bullets with the strongest findings.
+  - `## Metrics used`: explain the relevant metrics in the order they support the conclusion.
+  - `## Evidence and interpretation`: connect timestamps and values across metrics.
+  - `## Conclusion`: state whether the evidence is strong, moderate, weak, or inconclusive.
+- Use cautious language. Prefer "is consistent with", "suggests", or "does not provide enough evidence" over unsupported accusations.
+- Include concrete values and timestamps from the supplied data wherever possible.
+- Do not invent exchanges, assets, values, causes, outside events, links, or citations.
+- Do not mention unavailable metrics.
+
+Allowed figure placeholders:
+
+- `{{< figure src="volume_hist.png" alt="volume distribution" caption="Volume distribution" loading="lazy" >}}`
+- `{{< figure src="crypto_metrics.png" alt="market health metrics" caption="Market health metrics over time" loading="lazy" >}}`
+- `{{< figure src="benford_law.png" alt="Benford law comparison" caption="First-digit distribution versus Benford's Law" loading="lazy" >}}`
+- `{{< figure src="vv_correlation.png" alt="volume volatility correlation" caption="Volume-volatility correlation" loading="lazy" >}}`
+
+Use a figure only when the corresponding metric is discussed in the article.

--- a/tools/market_health_reporter/doc/prompts/prompt1.txt
+++ b/tools/market_health_reporter/doc/prompts/prompt1.txt
@@ -22,6 +22,7 @@ Metric guide:
 
 - Kolmogorov-Smirnov test for Benford conformity
   - Key: `benfordlawtest`; sample size key: `tradecount`.
+  - If `tradecount` is unavailable, zero, or negative, state "Benford K-S inconclusive due to unavailable or non-positive tradecount"; do not compute the critical value or infer deviation.
   - Critical value: `1.36 / sqrt(tradecount)`.
   - If test value > critical value, the sample does not conform to Benford's Law at the tested significance level.
   - If test value <= critical value, do not claim Benford deviation.

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,1 +1,5 @@
-You are a cryptocurrency market analyst with a focus on the market manipulations and anomalous trade activity detection. Conduct a thorough analysis of the data, using the instructions provided to you.
+You are a cryptocurrency market surveillance analyst specializing in wash-trading, bot activity, and anomalous trade-pattern detection.
+
+Use only the supplied market-health data and the supplied example article. Separate evidence from interpretation, cite concrete metric keys, timestamps, values, and trend direction whenever the data supports them, and avoid implying fraud when the evidence is weak or contradictory.
+
+Write for readers who understand cryptocurrency markets but need a concise, auditable explanation of what the metrics show. Prefer clear claims, quantified support, and explicit uncertainty over dramatic language.

--- a/tools/market_health_reporter/doc/prompts/system_prompt.txt
+++ b/tools/market_health_reporter/doc/prompts/system_prompt.txt
@@ -1,5 +1,5 @@
 You are a cryptocurrency market surveillance analyst specializing in wash-trading, bot activity, and anomalous trade-pattern detection.
 
-Use only the supplied market-health data and the supplied example article. Separate evidence from interpretation, cite concrete metric keys, timestamps, values, and trend direction whenever the data supports them, and avoid implying fraud when the evidence is weak or contradictory.
+Use only the supplied market-health data for factual claims; treat the supplied example article as a style and structure template only. Separate evidence from interpretation, cite concrete metric keys, timestamps, values, and trend direction whenever the data supports them, never import or repeat factual content from the example article, and avoid implying fraud when the evidence is weak or contradictory.
 
 Write for readers who understand cryptocurrency markets but need a concise, auditable explanation of what the metrics show. Prefer clear claims, quantified support, and explicit uncertainty over dramatic language.

--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -190,3 +190,4 @@ def main():
 
     except Exception as e:
         print(f"Error occurred: {e}")
+        raise

--- a/tools/market_health_reporter/market_health_reporter.py
+++ b/tools/market_health_reporter/market_health_reporter.py
@@ -13,8 +13,8 @@ from tools.python_modules.report_graphics_tool import Visualization
 REPO_NAME = "1712n/dn-institute"
 SYSTEM_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/system_prompt.txt'
 HUMAN_PROMPT_FILE = 'tools/market_health_reporter/doc/prompts/prompt1.txt'
-ARTICLE_EXAMPLE_FILE = 'content/market-health/posts/2023-08-14-huobi/index.md'
-OUTPUT_DIR = 'content/market-health/posts/'
+ARTICLE_EXAMPLE_FILE = 'content/research/market-health/posts/2023-08-14-huobi/index.md'
+OUTPUT_DIR = 'content/research/market-health/posts/'
 DATA_DIR = 'tools/market_health_reporter/doc/data/'
 MAX_TOKENS = 125000
 


### PR DESCRIPTION
## Summary
- Refactors the Market Health Reporter prompts around an evidence-first surveillance workflow, metric-by-metric interpretation rules, cross-metric signal patterns, and cautious conclusion language.
- Tightens the generated article requirements so outputs better match the existing Market Health article style, Hugo front matter, and contribution expectations.
- Fixes reporter content paths that had drifted after Market Health posts moved under `content/research/market-health/posts`.

## Methodology
I treated the prompts as the reporter core analysis contract: first separate evidence from interpretation, then give the model a concrete metric guide, then require cross-metric reasoning before drafting article prose. The updated prompt asks the model to preserve uncertainty, avoid unsupported claims, cite concrete values/timestamps when available, and only use figure placeholders from the supplied artifact list.

## Verification
- `python3 -m py_compile tools/market_health_reporter/market_health_reporter.py`
- `git diff --check`
- Verified that the updated example article path and output directory exist locally.

Refs #427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced market health reporting with stricter analysis guidelines for detecting wash trading, bot activity, and anomalous trade patterns.
  * Improved article generation with clearer evidence requirements, citation standards, and uncertainty handling for more consistent, auditable reports.
  * Updated analysis workflow to include metric-specific suspicion criteria and cross-metric pattern detection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/938)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->