### PR TITLE
Improve article checker diff selection

### DIFF
--- a/tests/test_article_checker_claude.py
+++ b/tests/test_article_checker_claude.py
@@ -10,8 +10,7 @@ sys.modules.setdefault("github", github_module)
 llm_utils_module = types.ModuleType("tools.python_modules.llm_utils")
 llm_utils_module.remove_plus = lambda text: "\n".join(
     line[1:] if line.startswith("+") else line
-    for line in text.splitlines()
-    if line.startswith("+") and not line.startswith("+++")
+    for line in text.split("\n")
 )
 sys.modules.setdefault("tools.python_modules.llm_utils", llm_utils_module)
 
@@ -65,6 +64,44 @@ class ArticleReviewTextTests(unittest.TestCase):
         ]
 
         self.assertEqual(build_article_review_text(diff), "")
+
+    def test_handles_attack_article_in_subdirectory(self):
+        diff = [
+            {
+                "header": "a/content/attacks/subdir/example.md b/content/attacks/subdir/example.md\n+++ b/content/attacks/subdir/example.md\n",
+                "body": [{"body": "+Nested article text\n"}],
+            }
+        ]
+
+        review_text = build_article_review_text(diff)
+
+        self.assertIn("File: content/attacks/subdir/example.md", review_text)
+        self.assertIn("Nested article text", review_text)
+
+    def test_ignores_deleted_only_attack_article(self):
+        diff = [
+            {
+                "header": "a/content/attacks/example.md b/content/attacks/example.md\n+++ b/content/attacks/example.md\n",
+                "body": [{"body": "-Deleted claim\n context\n"}],
+            }
+        ]
+
+        self.assertEqual(build_article_review_text(diff), "")
+
+    def test_handles_empty_diff(self):
+        self.assertEqual(build_article_review_text([]), "")
+
+    def test_preserves_literal_leading_plus_in_added_line(self):
+        diff = [
+            {
+                "header": "a/content/attacks/example.md b/content/attacks/example.md\n+++ b/content/attacks/example.md\n",
+                "body": [{"body": "++C compiler note\n"}],
+            }
+        ]
+
+        review_text = build_article_review_text(diff)
+
+        self.assertIn("+C compiler note", review_text)
 
 
 if __name__ == "__main__":

--- a/tests/test_article_checker_claude.py
+++ b/tests/test_article_checker_claude.py
@@ -1,0 +1,71 @@
+import sys
+import types
+import unittest
+
+
+github_module = types.ModuleType("github")
+github_module.Github = object
+sys.modules.setdefault("github", github_module)
+
+llm_utils_module = types.ModuleType("tools.python_modules.llm_utils")
+llm_utils_module.remove_plus = lambda text: "\n".join(
+    line[1:] if line.startswith("+") else line
+    for line in text.splitlines()
+    if line.startswith("+") and not line.startswith("+++")
+)
+sys.modules.setdefault("tools.python_modules.llm_utils", llm_utils_module)
+
+retriever_module = types.ModuleType("tools.article_checker.claude_retriever")
+retriever_module.ClientWithRetrieval = object
+sys.modules.setdefault("tools.article_checker.claude_retriever", retriever_module)
+
+websearch_module = types.ModuleType(
+    "tools.article_checker.claude_retriever.searcher.searchtools.websearch"
+)
+websearch_module.BraveSearchTool = object
+sys.modules.setdefault(
+    "tools.article_checker.claude_retriever.searcher.searchtools.websearch",
+    websearch_module,
+)
+
+from tools.article_checker.article_checker_claude import build_article_review_text
+
+
+class ArticleReviewTextTests(unittest.TestCase):
+    def test_builds_text_from_attack_article_markdown_only(self):
+        diff = [
+            {
+                "header": "a/content/attacks/example.md b/content/attacks/example.md\n+++ b/content/attacks/example.md\n",
+                "body": [
+                    {"body": "+# Example\n+Added claim\n-context\n"},
+                    {"body": "+Second addition\n"},
+                ],
+            },
+            {
+                "header": "a/tools/script.py b/tools/script.py\n+++ b/tools/script.py\n",
+                "body": [{"body": "+print('skip')\n"}],
+            },
+        ]
+
+        review_text = build_article_review_text(diff)
+
+        self.assertIn("File: content/attacks/example.md", review_text)
+        self.assertIn("# Example", review_text)
+        self.assertIn("Added claim", review_text)
+        self.assertIn("Second addition", review_text)
+        self.assertNotIn("script.py", review_text)
+        self.assertNotIn("print('skip')", review_text)
+
+    def test_returns_empty_text_when_no_attack_articles_changed(self):
+        diff = [
+            {
+                "header": "a/README.md b/README.md\n+++ b/README.md\n",
+                "body": [{"body": "+Unrelated docs\n"}],
+            }
+        ]
+
+        self.assertEqual(build_article_review_text(diff), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_article_checker_claude.py
+++ b/tests/test_article_checker_claude.py
@@ -103,6 +103,18 @@ class ArticleReviewTextTests(unittest.TestCase):
 
         self.assertIn("+C compiler note", review_text)
 
+    def test_preserves_added_markdown_line_starting_with_plus_markers(self):
+        diff = [
+            {
+                "header": "a/content/attacks/example.md b/content/attacks/example.md\n+++ b/content/attacks/example.md\n",
+                "body": [{"body": "++++ front matter delimiter example\n"}],
+            }
+        ]
+
+        review_text = build_article_review_text(diff)
+
+        self.assertIn("+++ front matter delimiter example", review_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/article_checker/article_checker_claude.py
+++ b/tools/article_checker/article_checker_claude.py
@@ -100,7 +100,7 @@ def build_article_review_text(diff: list[dict]) -> str:
         for segment in file_diff.get("body", []):
             added = "\n".join(
                 line for line in segment.get("body", "").splitlines()
-                if line.startswith("+") and not line.startswith("+++")
+                if line.startswith("+") and line != "+++"
             )
             if added:
                 added_lines.append(remove_plus(added))

--- a/tools/article_checker/article_checker_claude.py
+++ b/tools/article_checker/article_checker_claude.py
@@ -15,6 +15,8 @@ from tools.python_modules.llm_utils import remove_plus
 import tools.article_checker.claude_retriever
 from tools.article_checker.claude_retriever.searcher.searchtools.websearch import BraveSearchTool
 
+ARTICLE_PATH_PREFIX = "content/attacks/"
+
 
 def parse_cli_args():
     """
@@ -69,6 +71,42 @@ def create_comment_on_pr(pull_request, answer):
         print(f"Error creating a comment on PR: {e}")
 
 
+def _path_from_diff_header(header: str) -> str:
+    """
+    Extract the new-side file path from a parsed unified diff file header.
+    """
+    for line in header.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:].strip()
+            return path[2:] if path.startswith("b/") else path
+    return ""
+
+
+def _is_attack_article_markdown(path: str) -> bool:
+    return path.startswith(ARTICLE_PATH_PREFIX) and path.endswith(".md")
+
+
+def build_article_review_text(diff: list[dict]) -> str:
+    """
+    Build review input from changed attack article Markdown files only.
+    """
+    review_chunks = []
+    for file_diff in diff:
+        path = _path_from_diff_header(file_diff.get("header", ""))
+        if not _is_attack_article_markdown(path):
+            continue
+
+        added_lines = []
+        for segment in file_diff.get("body", []):
+            added_lines.append(remove_plus(segment.get("body", "")))
+
+        file_text = "\n".join(part for part in added_lines if part.strip())
+        if file_text.strip():
+            review_chunks.append(f"File: {path}\n{file_text}")
+
+    return "\n\n".join(review_chunks)
+
+
 def main():
     args = parse_cli_args()
     with open('tools/article_checker/config.json', 'r') as config_file:
@@ -92,7 +130,14 @@ def main():
     print(diff)
     print('-' * 50)
 
-    text = remove_plus(diff[0]['header'] + diff[0]['body'][0]['body'])
+    text = build_article_review_text(diff)
+    if not text:
+        create_comment_on_pr(
+            pr,
+            "Article check skipped: this pull request does not change any attack article Markdown files under `content/attacks/`."
+        )
+        return
+
     answer = api_call(text, client, model, max_tokens, temperature)
     print('-' * 50)
     print('This is an answer', answer)

--- a/tools/article_checker/article_checker_claude.py
+++ b/tools/article_checker/article_checker_claude.py
@@ -98,7 +98,12 @@ def build_article_review_text(diff: list[dict]) -> str:
 
         added_lines = []
         for segment in file_diff.get("body", []):
-            added_lines.append(remove_plus(segment.get("body", "")))
+            added = "\n".join(
+                line for line in segment.get("body", "").splitlines()
+                if line.startswith("+") and not line.startswith("+++")
+            )
+            if added:
+                added_lines.append(remove_plus(added))
 
         file_text = "\n".join(part for part in added_lines if part.strip())
         if file_text.strip():
@@ -139,6 +144,8 @@ def main():
         return
 
     answer = api_call(text, client, model, max_tokens, temperature)
+    if answer is None:
+        answer = "Article check failed: unable to complete the review due to an API error. Please check the workflow logs."
     print('-' * 50)
     print('This is an answer', answer)
     print('-' * 50)

--- a/tools/python_modules/llm_utils.py
+++ b/tools/python_modules/llm_utils.py
@@ -18,7 +18,7 @@ def extract_json(text):
 
 
 def remove_plus(text):
-    return '\n'.join(line.lstrip('+') for line in text.split('\n'))
+    return '\n'.join(line[1:] if line.startswith('+') else line for line in text.split('\n'))
 
 
 def count_tokens(text):


### PR DESCRIPTION
## Summary
- Filter the Claude article-check input to changed Markdown files under `content/attacks/` instead of blindly reviewing the first parsed diff hunk.
- Skip unrelated PRs with a clear comment before making the Claude/search call.
- Add focused unit coverage for selecting article Markdown and ignoring unrelated files.

## Why this helps
The workflow is triggered from an issue comment, so it can be run on PRs that touch tooling, docs, or other non-article files. Filtering the diff first reduces wasted API/search calls and keeps the QA bot focused on attack article submissions.

## Verification
- `python -m unittest tests.test_article_checker_claude`
- `python -m compileall tools\article_checker\article_checker_claude.py tests\test_article_checker_claude.py`
- `git diff --check`

Related to #408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite covering multiple scenarios for generating article review text (new/removed/empty diffs, subdirectories, and preservation of literal leading "+" in added lines).

* **Improvements**
  * Review now targets only newly added attack-article Markdown changes and aggregates added lines for review.
  * PR comment workflow skips posting when no relevant attack-article changes are present.
  * Adjusted handling to remove only a single leading "+" from added lines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/940)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->