### PR TITLE
test: cover Similarity Search upstream failures

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -11,6 +11,10 @@ type TextEntry = {
   namespace: string
 }
 
+type EmbeddingResponse = {
+  data?: unknown[]
+}
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -35,14 +39,30 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: [text]
-  })
-  const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
-    namespace,
-    topK: 1
-  })
+  let modelResp: EmbeddingResponse
+  try {
+    const response = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+      text: [text]
+    })
+    modelResp = response as unknown as EmbeddingResponse
+  } catch {
+    return c.text("Embedding generation failed", 502)
+  }
+
+  const vector = modelResp.data?.[0]
+  if (!Array.isArray(vector) || vector.length === 0) {
+    return c.text("Embedding generation failed", 502)
+  }
+
+  let searchResponse: Awaited<ReturnType<Env["VECTORIZE_INDEX"]["query"]>>
+  try {
+    searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
+      namespace,
+      topK: 1
+    })
+  } catch {
+    return c.text("Similarity search failed", 502)
+  }
   const similarityScore = searchResponse.matches[0]?.score || 0
 
   return c.json({ similarity_score: similarityScore })

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -15,6 +15,11 @@ type EmbeddingResponse = {
   data?: unknown[]
 }
 
+const isEmbeddingVector = (value: unknown): value is number[] =>
+  Array.isArray(value) &&
+  value.length > 0 &&
+  value.every((item) => typeof item === "number" && Number.isFinite(item))
+
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
@@ -50,7 +55,7 @@ app.post("/", async (c) => {
   }
 
   const vector = modelResp.data?.[0]
-  if (!Array.isArray(vector) || vector.length === 0) {
+  if (!isEmbeddingVector(vector)) {
     return c.text("Embedding generation failed", 502)
   }
 

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,6 +3,16 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const postSearch = (body: Record<string, unknown>) =>
+  SELF.fetch("https://example.com/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": "test-api-key"
+    },
+    body: JSON.stringify(body)
+  })
+
 describe("Authentication", () => {
   it("returns 401 Unauthorized when API key is missing or invalid", async () => {
     const response = await SELF.fetch("https://example.com/", {
@@ -18,5 +28,69 @@ describe("Authentication", () => {
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Similarity search integration", () => {
+  it("returns the Vectorize similarity score for a valid search request", async () => {
+    const response = await postSearch({
+      text: "Sample text",
+      namespace: "test-namespace"
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ similarity_score: 0.5678 })
+  })
+
+  it("returns 0 when Vectorize returns no matches", async () => {
+    const response = await postSearch({
+      text: "Sample text",
+      namespace: "no-match"
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ similarity_score: 0 })
+  })
+})
+
+describe("Upstream dependency failures", () => {
+  it("returns 502 when Workers AI cannot generate an embedding", async () => {
+    const response = await postSearch({
+      text: "trigger-ai-error",
+      namespace: "test-namespace"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Embedding generation failed")
+  })
+
+  it("returns 502 when Workers AI returns no embedding vector", async () => {
+    const response = await postSearch({
+      text: "empty-embedding",
+      namespace: "test-namespace"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Embedding generation failed")
+  })
+
+  it("returns 502 when Workers AI returns a malformed embedding vector", async () => {
+    const response = await postSearch({
+      text: "invalid-embedding",
+      namespace: "test-namespace"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Embedding generation failed")
+  })
+
+  it("returns 502 when Vectorize cannot complete the similarity lookup", async () => {
+    const response = await postSearch({
+      text: "Sample text",
+      namespace: "trigger-vectorize-error"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Similarity search failed")
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -34,7 +34,7 @@ export default defineWorkersConfig({
                       return Promise.resolve({ data: [] });
                     }
                     if (text === "invalid-embedding") {
-                      return Promise.resolve({ data: [null] });
+                      return Promise.resolve({ data: [[0.1, "not-a-number", 0.3]] });
                     }
                     return Promise.resolve({ data: [[0.1, 0.2, 0.3]] });
                   }

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,17 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    const text = data.text?.[0];
+                    if (text === "trigger-ai-error") {
+                      throw new Error("AI binding unavailable");
+                    }
+                    if (text === "empty-embedding") {
+                      return Promise.resolve({ data: [] });
+                    }
+                    if (text === "invalid-embedding") {
+                      return Promise.resolve({ data: [null] });
+                    }
+                    return Promise.resolve({ data: [[0.1, 0.2, 0.3]] });
                   }
                 };
               };`
@@ -37,6 +47,15 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   query: async (vectorData, options) => {
+                    if (options.namespace === "trigger-vectorize-error") {
+                      throw new Error("Vectorize query failed");
+                    }
+                    if (!Array.isArray(vectorData)) {
+                      throw new Error("Expected embedding vector");
+                    }
+                    if (options.namespace === "no-match") {
+                      return Promise.resolve({ matches: [] });
+                    }
                     const score = 0.5678;
                     return Promise.resolve({ matches: [{ score }] });
                   }


### PR DESCRIPTION
Bounty issue: #430

/claim #430

## Summary
- add explicit 502 handling when Workers AI fails, returns no embedding, or returns a malformed embedding
- add explicit 502 handling when Vectorize query fails
- expand Workers Vitest integration coverage through SELF.fetch() for valid search, empty matches, and upstream dependency failures

## Methodology
These tests keep the worker exercised through the Cloudflare Workers Vitest pool and deterministic wrapped service bindings. The new scenarios focus on the AI and Vectorize trust boundary, which is separate from the auth/request parsing coverage in the existing open PRs.

## Verification
- npm test -- --run from tools/similarity_search passed in /tmp/dn-institute-copy because the Cloudflare/Vitest runner cannot resolve modules when the checkout path contains spaces
- git diff --check

Review request: @Lavriz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation for embedding generation and similarity lookups; returns clear 502 responses when embedding or index queries fail.
  * Ensures embeddings are validated before querying to prevent malformed-vector errors.

* **Tests**
  * Expanded integration tests to cover successful search results, no-match behavior, and upstream failure scenarios (embedding and index errors).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/943)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->