### PR TITLE
test: add Similarity Search integration coverage

### DIFF
--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -56,7 +56,16 @@ describe("Similarity Search integration", () => {
     })
   })
 
-  it("rejects requests that do not include string text and namespace fields", async () => {
+  it("rejects requests missing the text field", async () => {
+    const response = await postSimilarity({
+      namespace: "known-namespace"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("rejects requests missing the namespace field", async () => {
     const response = await postSimilarity({
       text: "Missing namespace"
     })

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,65 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const similaritySearchUrl = "https://example.com/"
+const validHeaders = {
+  "Content-Type": "application/json",
+  "X-API-Key": "test-api-key"
+}
+
+function postSimilarity(body: unknown, headers: Record<string, string> = validHeaders) {
+  return SELF.fetch(similaritySearchUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body)
+  })
+}
+
 describe("Authentication", () => {
   it("returns 401 Unauthorized when API key is missing or invalid", async () => {
-    const response = await SELF.fetch("https://example.com/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
+    const response = await postSimilarity({
+      text: "Sample text",
+      namespace: "known-namespace"
+    }, {
+      "Content-Type": "application/json"
     })
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Similarity Search integration", () => {
+  it("returns the top Vectorize similarity score for a valid request", async () => {
+    const response = await postSimilarity({
+      text: "Near duplicate claim text",
+      namespace: "known-namespace"
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      similarity_score: 0.8765
+    })
+  })
+
+  it("returns zero when Vectorize has no matches", async () => {
+    const response = await postSimilarity({
+      text: "Completely new claim text",
+      namespace: "empty-namespace"
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      similarity_score: 0
+    })
+  })
+
+  it("rejects requests that do not include string text and namespace fields", async () => {
+    const response = await postSimilarity({
+      text: "Missing namespace"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -43,7 +43,13 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   query: async (vectorData, options) => {
-                    if (JSON.stringify(vectorData) !== JSON.stringify([0.12, 0.34, 0.56])) {
+                    const expectedVector = [0.12, 0.34, 0.56];
+                    const epsilon = 1e-6;
+                    if (
+                      !Array.isArray(vectorData) ||
+                      vectorData.length !== expectedVector.length ||
+                      !vectorData.every((value, index) => Math.abs(value - expectedVector[index]) <= epsilon)
+                    ) {
                       throw new Error("Unexpected vector payload");
                     }
                     if (options?.topK !== 1) {

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,13 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    if (model !== "@cf/baai/bge-base-en-v1.5") {
+                      throw new Error("Unexpected model: " + model);
+                    }
+                    if (!Array.isArray(data?.text) || typeof data.text[0] !== "string") {
+                      throw new Error("AI text payload must be a string array");
+                    }
+                    return Promise.resolve({ data: [[0.12, 0.34, 0.56]] });
                   }
                 };
               };`
@@ -37,8 +43,19 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   query: async (vectorData, options) => {
-                    const score = 0.5678;
-                    return Promise.resolve({ matches: [{ score }] });
+                    if (JSON.stringify(vectorData) !== JSON.stringify([0.12, 0.34, 0.56])) {
+                      throw new Error("Unexpected vector payload");
+                    }
+                    if (options?.topK !== 1) {
+                      throw new Error("Expected topK=1");
+                    }
+                    if (options?.namespace === "empty-namespace") {
+                      return Promise.resolve({ matches: [] });
+                    }
+                    if (options?.namespace !== "known-namespace") {
+                      throw new Error("Unexpected namespace: " + options?.namespace);
+                    }
+                    return Promise.resolve({ matches: [{ score: 0.8765 }] });
                   }
                 };
               };`


### PR DESCRIPTION
## Summary
- expand the Similarity Search worker integration tests from auth-only coverage to four SELF.fetch() scenarios
- verify successful lookup, empty Vectorize match fallback, schema validation, and unauthorized requests
- tighten the Workers Vitest mocks so they assert the AI model payload, embedding vector, namespace, and topK wiring

## Methodology
The tests keep the request path at the worker boundary via `SELF.fetch()` and use deterministic Worker bindings for Workers AI and Vectorize. The mock bindings now fail fast if the worker changes the model name, embedding payload shape, namespace, or Vectorize query options unexpectedly.

This is intentionally scoped to integration coverage for #430 rather than changing runtime behavior.

## Verification
- `npm test -- --run`
- `git diff --check`
- `npm run deploy -- --dry-run`

Review request: @Lavriz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Significantly expanded similarity search test suite with comprehensive integration testing across multiple scenarios including authentication validation.
  * Added validation tests to ensure required input fields are properly checked with appropriate error responses.
  * Improved test infrastructure with enhanced mock behavior, stricter payload verification, and more robust assertion logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/944)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->