### PR TITLE
test(similarity_search): expand integration tests from 1 to 31

### DIFF
--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -5,11 +5,11 @@ import "../src/index"
 
 const API_KEY = "test-api-key"
 
-function postJson(body: unknown, apiKey = API_KEY) {
+function postJson(body: unknown, apiKey: string | undefined = API_KEY) {
   const headers: Record<string, string> = {
     "Content-Type": "application/json"
   }
-  if (apiKey) headers["X-API-Key"] = apiKey
+  if (apiKey !== undefined) headers["X-API-Key"] = apiKey
 
   return SELF.fetch("https://example.com/", {
     method: "POST",
@@ -47,20 +47,10 @@ describe("Authentication", () => {
     expect(res.status).toBe(200)
   })
 
-  it("is case-sensitive on API key header", async () => {
-    // lowercase header should not match
-    const res = await SELF.fetch("https://example.com/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": API_KEY // lowercase
-      },
-      body: JSON.stringify({ text: "hello", namespace: "ns" })
-    })
-    // Hono normalizes header names to lowercase, so lowercase x-api-key
-    // may actually match. Either 200 or 401 is acceptable depending on
-    // the runtime; we just verify the request doesn't crash.
-    expect([200, 401]).toContain(res.status)
+  it("rejects API key with wrong value casing", async () => {
+    const res = await postJson({ text: "hello", namespace: "ns" }, API_KEY.toUpperCase())
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
   })
 })
 
@@ -203,7 +193,8 @@ describe("HTTP Methods", () => {
       headers: { "X-API-Key": API_KEY }
     })
     // Hono returns 404 for unmatched routes with GET
-    expect(res.status).not.toBe(200)
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
   })
 
   it("rejects PUT requests", async () => {
@@ -215,7 +206,8 @@ describe("HTTP Methods", () => {
       },
       body: JSON.stringify({ text: "hello", namespace: "ns" })
     })
-    expect(res.status).not.toBe(200)
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
   })
 
   it("rejects DELETE requests", async () => {
@@ -223,7 +215,8 @@ describe("HTTP Methods", () => {
       method: "DELETE",
       headers: { "X-API-Key": API_KEY }
     })
-    expect(res.status).not.toBe(200)
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
   })
 
   it("rejects PATCH requests", async () => {
@@ -235,7 +228,8 @@ describe("HTTP Methods", () => {
       },
       body: JSON.stringify({ text: "hello", namespace: "ns" })
     })
-    expect(res.status).not.toBe(200)
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
   })
 })
 
@@ -267,7 +261,7 @@ describe("Edge Cases", () => {
     expect(res.status).toBeGreaterThanOrEqual(400)
   })
 
-  it("returns 400 when extra unexpected fields are present", async () => {
+  it("accepts extra unexpected fields", async () => {
     const res = await postJson({
       text: "hello",
       namespace: "ns",

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,20 +3,294 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const API_KEY = "test-api-key"
+
+function postJson(body: unknown, apiKey = API_KEY) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json"
+  }
+  if (apiKey) headers["X-API-Key"] = apiKey
+
+  return SELF.fetch("https://example.com/", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body)
+  })
+}
+
+// ── Authentication ──────────────────────────────────────────────
+
 describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
-    const response = await SELF.fetch("https://example.com/", {
+  it("returns 401 when X-API-Key header is missing", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello", namespace: "ns" })
+    })
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 when X-API-Key is wrong", async () => {
+    const res = await postJson({ text: "hello", namespace: "ns" }, "wrong-key")
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 when X-API-Key is empty string", async () => {
+    const res = await postJson({ text: "hello", namespace: "ns" }, "")
+    expect(res.status).toBe(401)
+  })
+
+  it("passes authentication with correct API key", async () => {
+    const res = await postJson({ text: "hello", namespace: "ns" })
+    expect(res.status).toBe(200)
+  })
+
+  it("is case-sensitive on API key header", async () => {
+    // lowercase header should not match
+    const res = await SELF.fetch("https://example.com/", {
       method: "POST",
       headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY // lowercase
+      },
+      body: JSON.stringify({ text: "hello", namespace: "ns" })
+    })
+    // Hono normalizes header names to lowercase, so lowercase x-api-key
+    // may actually match. Either 200 or 401 is acceptable depending on
+    // the runtime; we just verify the request doesn't crash.
+    expect([200, 401]).toContain(res.status)
+  })
+})
+
+// ── Input Validation ────────────────────────────────────────────
+
+describe("Input Validation", () => {
+  it("returns 400 when text field is missing", async () => {
+    const res = await postJson({ namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace field is missing", async () => {
+    const res = await postJson({ text: "hello" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when both fields are missing", async () => {
+    const res = await postJson({})
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when text is a number", async () => {
+    const res = await postJson({ text: 123, namespace: "ns" })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is a number", async () => {
+    const res = await postJson({ text: "hello", namespace: 456 })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when text is null", async () => {
+    const res = await postJson({ text: null, namespace: "ns" })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when namespace is null", async () => {
+    const res = await postJson({ text: "hello", namespace: null })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when text is an array", async () => {
+    const res = await postJson({ text: ["a", "b"], namespace: "ns" })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when text is an object", async () => {
+    const res = await postJson({ text: { foo: "bar" }, namespace: "ns" })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when text is boolean", async () => {
+    const res = await postJson({ text: true, namespace: "ns" })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when namespace is boolean", async () => {
+    const res = await postJson({ text: "hello", namespace: false })
+    expect(res.status).toBe(400)
+  })
+
+  it("accepts empty strings for text and namespace", async () => {
+    const res = await postJson({ text: "", namespace: "" })
+    // empty strings are still typeof "string", so validation passes
+    expect(res.status).toBe(200)
+  })
+})
+
+// ── Similarity Search Response ──────────────────────────────────
+
+describe("Similarity Search", () => {
+  it("returns JSON with similarity_score for valid request", async () => {
+    const res = await postJson({ text: "bitcoin price", namespace: "crypto" })
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("application/json")
+
+    const body = await res.json()
+    expect(body).toHaveProperty("similarity_score")
+    expect(typeof body.similarity_score).toBe("number")
+  })
+
+  it("returns a numeric score between 0 and 1", async () => {
+    const res = await postJson({ text: "test query", namespace: "default" })
+    const body = await res.json()
+    expect(body.similarity_score).toBeGreaterThanOrEqual(0)
+    expect(body.similarity_score).toBeLessThanOrEqual(1)
+  })
+
+  it("handles different namespaces independently", async () => {
+    const res1 = await postJson({ text: "hello", namespace: "ns-a" })
+    const res2 = await postJson({ text: "hello", namespace: "ns-b" })
+
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+
+    const body1 = await res1.json()
+    const body2 = await res2.json()
+    expect(body1).toHaveProperty("similarity_score")
+    expect(body2).toHaveProperty("similarity_score")
+  })
+
+  it("handles special characters in text", async () => {
+    const res = await postJson({
+      text: "What's the price of BTC/USD? @#$%^&*()",
+      namespace: "test"
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty("similarity_score")
+  })
+
+  it("handles unicode text", async () => {
+    const res = await postJson({
+      text: "比特币价格 比特幣價格",
+      namespace: "crypto"
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty("similarity_score")
+  })
+
+  it("handles long text input", async () => {
+    const longText = "word ".repeat(500).trim()
+    const res = await postJson({ text: longText, namespace: "test" })
+    expect(res.status).toBe(200)
+  })
+})
+
+// ── HTTP Method Restrictions ────────────────────────────────────
+
+describe("HTTP Methods", () => {
+  it("rejects GET requests", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "GET",
+      headers: { "X-API-Key": API_KEY }
+    })
+    // Hono returns 404 for unmatched routes with GET
+    expect(res.status).not.toBe(200)
+  })
+
+  it("rejects PUT requests", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "PUT",
+      headers: {
+        "X-API-Key": API_KEY,
         "Content-Type": "application/json"
       },
-      body: JSON.stringify({
-        text: "Sample text",
-        namespace: "test-namespace"
-      })
+      body: JSON.stringify({ text: "hello", namespace: "ns" })
     })
+    expect(res.status).not.toBe(200)
+  })
 
-    expect(response.status).toBe(401)
-    expect(await response.text()).toBe("Unauthorized")
+  it("rejects DELETE requests", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "DELETE",
+      headers: { "X-API-Key": API_KEY }
+    })
+    expect(res.status).not.toBe(200)
+  })
+
+  it("rejects PATCH requests", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "PATCH",
+      headers: {
+        "X-API-Key": API_KEY,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ text: "hello", namespace: "ns" })
+    })
+    expect(res.status).not.toBe(200)
+  })
+})
+
+// ── Edge Cases ──────────────────────────────────────────────────
+
+describe("Edge Cases", () => {
+  it("returns 400 when body is not valid JSON", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "X-API-Key": API_KEY,
+        "Content-Type": "application/json"
+      },
+      body: "not-json"
+    })
+    // Hono will throw when parsing invalid JSON
+    expect(res.status).toBeGreaterThanOrEqual(400)
+  })
+
+  it("returns 400 when body is empty", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "X-API-Key": API_KEY,
+        "Content-Type": "application/json"
+      },
+      body: ""
+    })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+  })
+
+  it("returns 400 when extra unexpected fields are present", async () => {
+    const res = await postJson({
+      text: "hello",
+      namespace: "ns",
+      extra: "field",
+      count: 42
+    })
+    // endpoint should still work with extra fields
+    expect(res.status).toBe(200)
+  })
+
+  it("does not leak server errors on malformed requests", async () => {
+    const res = await SELF.fetch("https://example.com/", {
+      method: "POST",
+      headers: {
+        "X-API-Key": API_KEY,
+        "Content-Type": "application/json"
+      },
+      body: '{"text": "hello"' // truncated JSON
+    })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    // should not return stack traces
+    const text = await res.text()
+    expect(text).not.toContain("SyntaxError")
+    expect(text).not.toContain("at ")
   })
 })


### PR DESCRIPTION
Expands the Similarity Search API integration test suite from **1 test** to **31 tests**, covering 5 categories using `@cloudflare/vitest-pool-workers` and `SELF.fetch()`.

## Test Categories

| Category | Tests | What it covers |
|----------|-------|----------------|
| Authentication | 5 | Missing/wrong/empty/correct API key, case sensitivity |
| Input Validation | 12 | Missing fields, type checking (number/null/array/object/boolean), empty strings |
| Similarity Search | 6 | Response format, score range, namespace isolation, unicode, special chars, long text |
| HTTP Methods | 4 | GET/PUT/DELETE/PATCH all rejected |
| Edge Cases | 4 | Invalid JSON, empty body, extra fields, no stack trace leakage |

## Approach

- **No source code changes** — purely testing improvements
- Uses `SELF.fetch()` for higher-level integration testing as recommended by Cloudflare
- Added a reusable `postJson()` helper to reduce test boilerplate
- All 31 tests pass locally

Closes #430

@christina-tkach requesting review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the similarity search API, including authentication validation, input validation, response format verification, HTTP method restrictions, and edge case handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/952)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->