### PR TITLE
Improve article QA bot preflight review

### DIFF
--- a/tools/article_checker/article_checker_claude.py
+++ b/tools/article_checker/article_checker_claude.py
@@ -8,12 +8,32 @@ import argparse
 import os
 import sys
 import json
+import re
 from github import Github
 from tools.python_modules.git import get_pull_request, get_diff_by_url, parse_diff
 from tools.python_modules.utils import logging_decorator
-from tools.python_modules.llm_utils import remove_plus
 import tools.article_checker.claude_retriever
 from tools.article_checker.claude_retriever.searcher.searchtools.websearch import BraveSearchTool
+
+ARTICLE_PATH_PREFIXES = (
+    "content/attacks/",
+    "content/research/cyberattacks/incidents/",
+)
+ALLOWED_METADATA_HEADERS = {
+    "date",
+    "target-entities",
+    "entity-types",
+    "attack-types",
+    "title",
+    "loss",
+}
+REQUIRED_SECTION_HEADERS = {
+    "## Summary",
+    "## Attackers",
+    "## Losses",
+    "## Timeline",
+    "## Security Failure Causes",
+}
 
 
 def parse_cli_args():
@@ -44,14 +64,208 @@ def api_call(query, client, model, max_tokens, temperature):
         return client.completion_with_retrieval(
             query=query,
             model=model,
-            n_search_results_to_use=1,
-            max_searches_to_try=5,
+            n_search_results_to_use=3,
+            max_searches_to_try=8,
             max_tokens=max_tokens,
             temperature=temperature
         )
     except Exception as e:
         print(f"Error in API call: {e}")
         return None
+
+
+def extract_file_path(diff_header: str) -> str:
+    """
+    Extract the new file path from a unified diff file header.
+    """
+    for line in diff_header.splitlines():
+        if line.startswith("+++ b/"):
+            return line.removeprefix("+++ b/").strip()
+        if line.startswith("+++ "):
+            return line.removeprefix("+++ ").strip()
+    match = re.search(r" b/([^\s]+)", diff_header)
+    return match.group(1) if match else ""
+
+
+def is_article_path(path: str) -> bool:
+    """
+    Check whether a file path is a Markdown article managed by the QA bot.
+    """
+    return path.endswith(".md") and any(
+        path.startswith(prefix) for prefix in ARTICLE_PATH_PREFIXES
+    )
+
+
+def is_new_file_diff(diff_header: str) -> bool:
+    """
+    Check whether a diff header represents a newly added file.
+    """
+    return "new file mode" in diff_header or "--- /dev/null" in diff_header
+
+
+def extract_added_lines(hunk_body: str) -> list[str]:
+    """
+    Return only added content lines from a diff hunk, excluding diff metadata.
+    """
+    return [
+        line[1:]
+        for line in hunk_body.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+
+
+def collect_changed_articles(diff: list[dict]) -> list[dict]:
+    """
+    Collect all changed article Markdown files from a parsed PR diff.
+    """
+    articles = []
+    for file_diff in diff:
+        path = extract_file_path(file_diff["header"])
+        if not is_article_path(path):
+            continue
+
+        added_lines = []
+        for hunk in file_diff["body"]:
+            added_lines.extend(extract_added_lines(hunk["body"]))
+
+        if added_lines:
+            articles.append({
+                "path": path,
+                "text": "\n".join(added_lines),
+                "is_new_file": is_new_file_diff(file_diff["header"]),
+            })
+    return articles
+
+
+def parse_front_matter(text: str) -> dict[str, str]:
+    """
+    Parse simple Hugo YAML front matter keys without adding a YAML dependency.
+    """
+    if not text.startswith("---"):
+        return {}
+
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+
+    front_matter = {}
+    for raw_line in parts[1].splitlines():
+        if ":" not in raw_line:
+            continue
+        key, value = raw_line.split(":", 1)
+        front_matter[key.strip()] = value.strip()
+    return front_matter
+
+
+def extract_markdown_headers(text: str) -> list[str]:
+    """
+    Extract level-two-or-deeper Markdown headers from an article body.
+    """
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.startswith("##")
+    ]
+
+
+def analyze_article_structure(path: str, text: str, is_new_file: bool = True) -> str:
+    """
+    Produce deterministic review notes before the LLM fact-checking pass.
+    """
+    notes = [f"### Preflight: `{path}`"]
+    file_name = os.path.basename(path)
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}-.+\.md", file_name):
+        notes.append("- Filename shape: pass")
+    else:
+        notes.append(
+            "- Filename shape: fail. Expected `YYYY-MM-DD-entity-that-was-hacked.md`."
+        )
+
+    headers = extract_markdown_headers(text)
+    if is_new_file:
+        metadata = parse_front_matter(text)
+        metadata_keys = set(metadata.keys())
+        missing_keys = sorted(ALLOWED_METADATA_HEADERS - metadata_keys)
+        extra_keys = sorted(metadata_keys - ALLOWED_METADATA_HEADERS)
+        if not metadata:
+            notes.append("- Front matter: fail. Missing opening and closing `---` block.")
+        elif missing_keys or extra_keys:
+            notes.append(
+                "- Front matter keys: warning. "
+                f"Missing: {missing_keys or 'none'}; unexpected: {extra_keys or 'none'}."
+            )
+        else:
+            notes.append("- Front matter keys: pass")
+
+        header_set = set(headers)
+        missing_headers = sorted(REQUIRED_SECTION_HEADERS - header_set)
+        extra_headers = sorted(header_set - REQUIRED_SECTION_HEADERS)
+        if missing_headers or extra_headers:
+            notes.append(
+                "- Section headers: warning. "
+                f"Missing: {missing_headers or 'none'}; unexpected: {extra_headers or 'none'}."
+            )
+        else:
+            notes.append("- Section headers: pass")
+    else:
+        added_unexpected_headers = sorted(
+            set(headers) - REQUIRED_SECTION_HEADERS
+        )
+        if added_unexpected_headers:
+            notes.append(
+                "- Added section headers: warning. "
+                f"Unexpected headers in changed lines: {added_unexpected_headers}."
+            )
+        else:
+            notes.append(
+                "- Full-article structure checks: skipped because this is an edit to an existing article diff, not a full new-file diff."
+            )
+
+    if len(text.strip()) < 500:
+        notes.append("- Article length: warning. Added article text is very short.")
+    else:
+        notes.append("- Article length: pass")
+
+    return "\n".join(notes)
+
+
+def build_review_input(diff: list[dict]) -> tuple[str, list[str]]:
+    """
+    Build the LLM input from every changed article file, not just the first diff.
+    """
+    articles = collect_changed_articles(diff)
+    if not articles:
+        return (
+            "No changed attack article Markdown files were found in this pull request.",
+            [],
+        )
+
+    preflight_blocks = []
+    article_blocks = []
+    for article in articles:
+        preflight_blocks.append(
+            analyze_article_structure(
+                article["path"],
+                article["text"],
+                is_new_file=article["is_new_file"],
+            )
+        )
+        article_blocks.append(
+            f"<article_file path=\"{article['path']}\">\n{article['text']}\n</article_file>"
+        )
+
+    prompt = "\n\n".join(
+        [
+            "Review every changed attack article below. Start with the deterministic preflight notes, then perform fact-checking, source review, style review, Hugo formatting checks, and submission-guideline checks.",
+            "<deterministic_preflight>",
+            "\n\n".join(preflight_blocks),
+            "</deterministic_preflight>",
+            "<changed_articles>",
+            "\n\n".join(article_blocks),
+            "</changed_articles>",
+        ]
+    )
+    return prompt, [article["path"] for article in articles]
 
 
 @logging_decorator("Comment on PR")
@@ -92,8 +306,23 @@ def main():
     print(diff)
     print('-' * 50)
 
-    text = remove_plus(diff[0]['header'] + diff[0]['body'][0]['body'])
-    answer = api_call(text, client, model, max_tokens, temperature)
+    text, article_paths = build_review_input(diff)
+    if not article_paths:
+        answer = (
+            "## Article Check\n\n"
+            "No changed attack article Markdown files were found in this pull request. "
+            "Expected a Markdown file under `content/attacks/` or "
+            "`content/research/cyberattacks/incidents/`."
+        )
+    else:
+        answer = api_call(text, client, model, max_tokens, temperature)
+        if answer is None:
+            answer = (
+                "## Article Check\n\n"
+                "The deterministic preflight ran, but the Claude retrieval pass failed. "
+                "Please rerun `/articlecheck` or inspect the action logs.\n\n"
+                f"{text}"
+            )
     print('-' * 50)
     print('This is an answer', answer)
     print('-' * 50)

--- a/tools/article_checker/claude_retriever/client.py
+++ b/tools/article_checker/claude_retriever/client.py
@@ -3,7 +3,7 @@ import anthropic
 from .searcher.types import SearchTool, SearchResult, Tool
 import logging
 import re
-from utils import format_results_full
+from .utils import format_results_full
 import json
 from datetime import datetime
 

--- a/tools/article_checker/claude_retriever/searcher/types.py
+++ b/tools/article_checker/claude_retriever/searcher/types.py
@@ -51,7 +51,7 @@ class SearchTool(Tool):
         raise NotImplementedError()
     
     def search(self, query: str, n_search_results_to_use: int) -> str:
-        from utils import format_results_full # Avoids circular import
+        from tools.article_checker.claude_retriever.utils import format_results_full # Avoids circular import
 
         raw_search_results = self.raw_search(query, n_search_results_to_use)
         processed_search_results = self.process_raw_search_results(raw_search_results)

--- a/tools/article_checker/tests/test_article_checker_claude.py
+++ b/tools/article_checker/tests/test_article_checker_claude.py
@@ -1,0 +1,102 @@
+import unittest
+
+from tools.article_checker.article_checker_claude import (
+    analyze_article_structure,
+    build_review_input,
+    collect_changed_articles,
+    extract_added_lines,
+    extract_file_path,
+    is_new_file_diff,
+)
+
+
+class ArticleCheckerClaudeTest(unittest.TestCase):
+    def test_extract_file_path_prefers_new_diff_path(self):
+        header = "a/old.md b/content/research/cyberattacks/incidents/2024-01-02-Test.md\n--- a/old.md\n+++ b/content/research/cyberattacks/incidents/2024-01-02-Test.md"
+
+        self.assertEqual(
+            extract_file_path(header),
+            "content/research/cyberattacks/incidents/2024-01-02-Test.md",
+        )
+
+    def test_extract_added_lines_skips_removed_and_metadata_lines(self):
+        hunk = "@@ -1,2 +1,2 @@\n-old\n+new\n+++ b/file.md\n context"
+
+        self.assertEqual(extract_added_lines(hunk), ["new"])
+
+    def test_is_new_file_diff_detects_new_file_headers(self):
+        self.assertTrue(is_new_file_diff("new file mode 100644\n--- /dev/null"))
+        self.assertFalse(is_new_file_diff("--- a/file.md\n+++ b/file.md"))
+
+    def test_collect_changed_articles_ignores_non_article_markdown(self):
+        diff = [
+            {
+                "header": "a/README.md b/README.md\n--- a/README.md\n+++ b/README.md",
+                "body": [{"body": "+Readme"}],
+            },
+            {
+                "header": "a/content/research/cyberattacks/incidents/2024-01-02-Test.md b/content/research/cyberattacks/incidents/2024-01-02-Test.md\n--- a/content/research/cyberattacks/incidents/2024-01-02-Test.md\n+++ b/content/research/cyberattacks/incidents/2024-01-02-Test.md",
+                "body": [{"body": "+## Summary\n+Test body"}],
+            },
+        ]
+
+        articles = collect_changed_articles(diff)
+
+        self.assertEqual(len(articles), 1)
+        self.assertEqual(
+            articles[0]["path"],
+            "content/research/cyberattacks/incidents/2024-01-02-Test.md",
+        )
+
+    def test_analyze_article_structure_reports_missing_headers(self):
+        text = """---
+date: 2024-01-02
+target-entities: Example
+entity-types: exchange
+attack-types: exploit
+title: Example Hack
+loss: $100
+---
+
+## Summary
+Short text.
+"""
+
+        report = analyze_article_structure(
+            "content/research/cyberattacks/incidents/example.md", text
+        )
+
+        self.assertIn("Filename shape: fail", report)
+        self.assertIn("Section headers: warning", report)
+
+    def test_existing_article_edits_do_not_require_full_front_matter(self):
+        report = analyze_article_structure(
+            "content/research/cyberattacks/incidents/2024-01-02-Example.md",
+            "## Summary\nA changed sentence.",
+            is_new_file=False,
+        )
+
+        self.assertIn("Full-article structure checks: skipped", report)
+        self.assertNotIn("Front matter: fail", report)
+
+    def test_build_review_input_includes_all_article_files(self):
+        diff = [
+            {
+                "header": "a/content/research/cyberattacks/incidents/2024-01-02-First.md b/content/research/cyberattacks/incidents/2024-01-02-First.md\n--- a/content/research/cyberattacks/incidents/2024-01-02-First.md\n+++ b/content/research/cyberattacks/incidents/2024-01-02-First.md",
+                "body": [{"body": "+## Summary\n+First"}],
+            },
+            {
+                "header": "a/content/research/cyberattacks/incidents/2024-01-03-Second.md b/content/research/cyberattacks/incidents/2024-01-03-Second.md\n--- a/content/research/cyberattacks/incidents/2024-01-03-Second.md\n+++ b/content/research/cyberattacks/incidents/2024-01-03-Second.md",
+                "body": [{"body": "+## Summary\n+Second"}],
+            },
+        ]
+
+        prompt, paths = build_review_input(diff)
+
+        self.assertEqual(len(paths), 2)
+        self.assertIn("2024-01-02-First.md", prompt)
+        self.assertIn("2024-01-03-Second.md", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Improves the Claude article QA bot for #408 by adding a deterministic preflight review before the retrieval/fact-checking pass.

Changes:

- Reviews every changed attack article Markdown file instead of only the first parsed diff file.
- Filters review input to article paths under `content/attacks/` and `content/research/cyberattacks/incidents/`.
- Adds deterministic checks for filename shape, Hugo front matter keys, required section headers, unexpected added headers, and very short article diffs.
- Avoids false structural failures for edits to existing articles where the PR diff does not include the full front matter.
- Returns a clear action comment when `/articlecheck` is run on a PR without changed attack articles.
- Fixes package-relative `format_results_full` imports in the Claude retriever path.
- Adds unit coverage for diff parsing, article filtering, new-file detection, structure preflight, and multi-article PR input.

## Methodology

The previous bot passed `diff[0]` into Claude, which meant multi-file PRs and non-article-first diffs could be reviewed incorrectly. This patch separates cheap deterministic checks from Claude's judgment layer: Python validates the submission structure first, then Claude receives a cleaner prompt containing preflight notes plus the changed article text.

## Verification

```text
python -m unittest discover -s tools\article_checker\tests
python -m py_compile tools\article_checker\article_checker_claude.py tools\article_checker\claude_retriever\client.py tools\article_checker\claude_retriever\searcher\types.py tools\article_checker\tests\test_article_checker_claude.py
git diff --check
```

Addresses #408.