### PR TITLE
Add 2026 market-maker wash trading case study

### DIFF
--- a/content/research/market-health/posts/2026-03-30-market-maker-wash-trading-indictments/index.md
+++ b/content/research/market-health/posts/2026-03-30-market-maker-wash-trading-indictments/index.md
@@ -1,0 +1,88 @@
+---
+title: "2026 Market-Maker Indictments: Vortex, Contrarian, Antier, and Gotbit Wash-Trading Network"
+date: 2026-03-30
+description: "DOJ and IRS-CI announced charges against ten foreign nationals tied to Gotbit, Vortex, Contrarian, and Antier, alleging market-maker wash trading and pump-and-dump schemes exposed through an FBI and IRS undercover operation."
+entities:
+  - Gotbit
+  - Vortex
+  - Contrarian
+  - Antier Solutions
+  - FBI
+  - IRS Criminal Investigation
+---
+
+## Summary
+
+1. On March 30, 2026, the U.S. Attorney's Office for the Northern District of California and IRS Criminal Investigation announced charges against ten executives and employees linked to four crypto market-making firms: Gotbit, Vortex, Contrarian, and Antier.
+2. The indictments alleged a common pattern: market makers used coordinated wash trading to inflate token volume and price, then profited by selling tokens into the artificial demand.
+3. DOJ said three defendants, including two chief executives, had been extradited from Singapore for initial court appearances in Oakland. Two other defendants had already pleaded guilty and been sentenced.
+4. The investigation used undercover FBI-created tokens, giving law enforcement a controlled way to observe how manipulation services were pitched and executed.
+5. For market-health monitoring, the case is a reminder that "market maker" labels can hide two very different behaviors: legitimate spread-tightening liquidity provision, or artificial volume generation designed to mislead buyers.
+
+## Why This Case Matters
+
+Market makers are supposed to improve liquidity by quoting both sides of a market and absorbing temporary order-flow imbalances. In thin crypto markets, however, the same operational tools can be misused to manufacture the appearance of activity. The 2026 DOJ announcement describes that second pattern: coordinated trades that make a token look more actively traded than it is, paired with a plan to sell into the inflated market.
+
+This case is also important because it extends beyond one token issuer or one venue. DOJ described multiple firms, multiple indictments, cross-border arrests, guilty pleas, and more than $1 million in cryptocurrency seized. That scale makes the case useful for market-health taxonomy: the risk is not only a rogue token project, but a service layer that can sell manipulation as an outsourced market-making package.
+
+## Alleged Manipulation Pattern
+
+The filings and agency releases describe a repeatable market-maker abuse pattern:
+
+| Stage             | Legitimate market making                            | Alleged abusive variant                                                                |
+| ----------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Client engagement | Provide liquidity and reduce bid-ask spreads.       | Offer volume and price support that creates misleading demand.                         |
+| Trading activity  | Quote independently and manage inventory risk.      | Coordinate buys and sells among controlled or aligned accounts.                        |
+| Market signal     | Genuine trades reveal actual supply and demand.     | Wash trades make activity look organic when it is not.                                 |
+| Exit              | Earn fees or spread revenue for liquidity services. | Sell token holdings after artificial price and volume support attracts outside buyers. |
+| Investor effect   | Lower execution friction for real participants.     | Buyers rely on fabricated volume, price momentum, or liquidity depth.                  |
+
+DOJ's announcement defined wash trading in functional terms: the same trader, or coordinated traders, act on both sides of transactions. The market-health harm is that dashboards, exchange rankings, and retail buyers see volume without seeing the common control or coordination behind it.
+
+## Firm-Level Timeline
+
+The supporting dataset is available in [market-maker-indictments-summary.csv](market-maker-indictments-summary.csv).
+
+| Firm or group         | Indictment date   | Named roles from DOJ/IRS releases                                                                                                                                                                                                               | Alleged pattern                                                                                           |
+| --------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Gotbit                | March 25, 2025    | Antoine Tsao, business development manager; Ian Sofronov, sales manager; Nemanja Popov, account manager.                                                                                                                                        | Artificially inflate a cryptocurrency token's price through wire-fraud and wire-fraud-conspiracy conduct. |
+| Vortex                | August 28, 2025   | Gleb Gora, chief executive officer; Sergei Ryzhkov, chief financial officer; Michael Vogel, business development manager.                                                                                                                       | Inflate token price while planning to liquidate holdings once the token reached a high trading price.     |
+| Contrarian and Antier | September 4, 2025 | Manu Singh, Contrarian chief executive officer; Kushagra Srivastava, Contrarian chief financial officer; Vasu Sharma, Contrarian business development associate; Sabby Singh, business development manager at Antier Solutions Private Limited. | Pump token price and dump holdings after the market reached the targeted price level.                     |
+
+The March 2026 announcement was therefore not just a single-day charge. It consolidated a sequence of indictments, arrests, extraditions, guilty pleas, and sentencing events that unfolded across 2025 and early 2026.
+
+## Undercover Tokens As Controlled Market-Health Tests
+
+The most useful investigative feature is that the FBI created several cryptocurrency tokens as part of the undercover operation. From a market-health perspective, an undercover token is a controlled experiment:
+
+1. **Known starting conditions:** The token has no organic trading history that must be disentangled from manipulation.
+2. **Known counterparties:** Investigators can track who was approached, what service was offered, and what accounts traded.
+3. **Known intent evidence:** Communications about volume support, price targets, and sell plans can be tied to observed trades.
+4. **Known event windows:** Trading activity can be compared against the exact time when manipulation services begin.
+
+This is stronger than passive anomaly detection. A high-volume token can be suspicious for many reasons. A controlled token lets investigators compare promised manipulation services with the resulting trade pattern.
+
+## Detection Indicators
+
+Market operators and researchers can convert the case into surveillance rules:
+
+1. **Counterparty overlap:** Identify accounts that repeatedly appear on both the buy and sell side of the same token within short intervals.
+2. **Volume without depth:** Flag tokens where reported volume rises sharply while usable order-book depth and independent market-maker diversity remain thin.
+3. **Launch-period volume ladders:** Look for volume patterns that ramp in prearranged steps rather than responding to external news or user adoption.
+4. **Price-target conversations:** Treat client communications promising price levels, ranking boosts, or volume guarantees as high-risk compliance evidence.
+5. **Market-maker inventory exits:** Monitor whether liquidity providers sell meaningful token inventory shortly after artificial volume campaigns.
+6. **Multi-account coordination:** Cluster exchange accounts, deposit wallets, withdrawal wallets, and trading intervals to detect common control.
+7. **Cross-token repetition:** Escalate firms whose trading pattern repeats across many low-liquidity tokens.
+
+The most important signal is not any single trade. It is the link between a service promise, coordinated trading, and a profitable exit into outside demand.
+
+## Market-Health Takeaways
+
+This case separates real liquidity from theatrical liquidity. Real liquidity lets outside traders transact with lower slippage. Theatrical liquidity creates charts, rankings, and apparent activity that can persuade outsiders to buy at prices set by insiders.
+
+For exchanges, the implication is that market-maker onboarding should include surveillance obligations, beneficial ownership checks, and restrictions on profit-sharing arrangements that reward price pumps. For token issuers, the case shows that hiring a market maker to create fake volume can turn a marketing shortcut into a criminal exposure. For researchers, it provides a concrete pattern to test: coordinated same-token trades, short-interval buy-sell loops, and post-campaign inventory liquidation.
+
+## References
+
+- [DOJ Northern District of California press release, March 30, 2026](https://www.justice.gov/usao-ndca/pr/ten-foreign-nationals-charged-international-operation-targeting-cryptocurrency-market)
+- [IRS Criminal Investigation release, March 30, 2026](https://www.irs.gov/compliance/criminal-investigation/ten-foreign-nationals-charged-in-an-international-operation-targeting-cryptocurrency-market-manipulation)

--- a/content/research/market-health/posts/2026-03-30-market-maker-wash-trading-indictments/market-maker-indictments-summary.csv
+++ b/content/research/market-health/posts/2026-03-30-market-maker-wash-trading-indictments/market-maker-indictments-summary.csv
@@ -1,0 +1,9 @@
+category,firm_or_group,date,people_or_roles,event_or_allegation,source
+announcement,Gotbit/Vortex/Contrarian/Antier,2026-03-30,"Ten executives and employees across four firms","DOJ and IRS-CI announced charges tied to alleged wash trading and pump-and-dump schemes; more than $1 million in cryptocurrency had been seized","DOJ NDCA and IRS-CI releases"
+undercover_operation,FBI and IRS-CI,2025-2026,"FBI-created cryptocurrency tokens","Undercover operation targeted illicit wash trading in the crypto industry using several created tokens","DOJ NDCA and IRS-CI releases"
+indictment,Gotbit,2025-03-25,"Antoine Tsao, Ian Sofronov, Nemanja Popov","Charged with wire fraud conspiracy and wire fraud for allegedly inflating the price of a cryptocurrency token","DOJ NDCA and IRS-CI releases"
+case_status,Gotbit,2025-06-02/2026-02-10,"Antoine Tsao and Nemanja Popov","DOJ said Tsao pleaded guilty and was sentenced on June 2, 2025; Popov pleaded guilty and was sentenced on February 10, 2026","DOJ NDCA release"
+indictment,Vortex,2025-08-28,"Gleb Gora, Sergei Ryzhkov, Michael Vogel","Charged with wire fraud conspiracy and wire fraud for allegedly inflating token price while planning to liquidate holdings at a high price","DOJ NDCA and IRS-CI releases"
+case_status,Vortex,2025-10-02/2026-03-30,"Gleb Gora","DOJ said Gora was arrested in Singapore on October 2, 2025 and appeared in Oakland after extradition on March 30, 2026","DOJ NDCA release"
+indictment,Contrarian/Antier,2025-09-04,"Manu Singh, Kushagra Srivastava, Vasu Sharma, Sabby Singh","Charged with wire fraud and wire fraud conspiracy for allegedly pumping token price and planning to dump holdings at a high trading price","DOJ NDCA and IRS-CI releases"
+case_status,Contrarian,2025-10-02/2026-03-30,"Manu Singh and Vasu Sharma","DOJ said Singh and Sharma were arrested in Singapore and appeared in Oakland after extradition on March 30, 2026","DOJ NDCA release"


### PR DESCRIPTION
## Summary

Adds a Market Health article documenting the March 30, 2026 DOJ/IRS-CI announcement covering alleged wash-trading and pump-and-dump schemes involving Gotbit, Vortex, Contrarian, and Antier.

The article covers:
- firm-level timeline for the 2025 indictments and 2026 extradition/case-status announcement
- the alleged market-maker abuse pattern: coordinated wash trading, artificial volume/price, and inventory liquidation
- why FBI-created undercover tokens are useful controlled tests for market-health investigations
- detection indicators for separating legitimate liquidity provision from theatrical liquidity
- a companion CSV summarizing the firm-level indictment and status facts

## Validation

- `npx prettier@2.7.1 --check content/research/market-health/posts/2026-03-30-market-maker-wash-trading-indictments/index.md`
- `git diff --check -- content/research/market-health/posts/2026-03-30-market-maker-wash-trading-indictments`

Addresses #277.
