### PR TITLE
Add Synthetix sKRW oracle market health case

### DIFF
--- a/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md
+++ b/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md
@@ -19,7 +19,7 @@ The abnormal signal was not wash trading in the usual sense of one party trading
 
 This makes the incident useful for market-health monitoring because it shows how a venue can display apparently valid executed trades even when the tradeable price is detached from the underlying reference asset. In a synthetic-asset exchange, the oracle price is the order book's economic anchor. When that anchor fails, automated arbitrage can convert an oracle-data anomaly into distorted volume, artificial profit, and debt-pool losses for other participants.
 
-| Indicator                       | Observed value                                  | Market-health interpretation                                                               |
+| Indicator                       | Reported value                                  | Market-health interpretation                                                               |
 | ------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | Reference price deviation       | KRW feed reported about 1000x the correct rate  | Synthetic asset price was detached from its underlying fiat market                         |
 | Exploit window                  | Less than one hour, according to Synthetix      | Automated strategies can monetize bad oracle states faster than manual operators can react |
@@ -52,9 +52,9 @@ For synthetic assets and derivatives venues, useful monitoring should include:
 
 The incident also shows why social reversibility is not a complete control. Synthetix was able to contact the bot owner and negotiate a reversal, but a market-health framework should treat that as mitigation after failure, not as proof that the market remained healthy.
 
-## Source dataset
+## Source timeline
 
-The supporting event timeline is included in `timeline.csv`. It records the incident date, reported metrics, and public source links used for the analysis.
+The supporting event timeline is included in `timeline.csv`. It is a citation log of narrative events and secondary-source reported values, not a primary on-chain dataset or time-series of measured trade metrics. Treat the CSV as provenance for the public reports cited here, not as independent statistical evidence of block-level balances, transaction flows, or oracle-rate movement.
 
 ## References
 

--- a/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md
+++ b/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md
@@ -1,0 +1,63 @@
+---
+title: "Synthetix sKRW Oracle Error and Automated Arbitrage"
+date: "2019-06-25"
+description: "A faulty Korean won price feed created an artificial sKRW market on Synthetix, allowing an automated trading bot to convert the mispriced asset into sETH before trades were reversed."
+entities:
+  - Synthetix
+  - sKRW
+  - sETH
+  - KRW
+---
+
+On June 25, 2019, Synthetix disclosed an oracle incident in which its Korean won price feed reported KRW at roughly 1000 times the correct rate. The error did not require an attacker to compromise Synthetix contracts or manipulate the external data provider directly. Instead, an automated trading bot detected the mispriced synthetic asset and traded through it while Synthetix.exchange was still accepting the rate.
+
+The result was a short-lived but extreme market-health failure: Synthetix reported several trades with 1000x profits and more than $1 billion in apparent profit in less than one hour. The Block separately reported that the bot accumulated more than 37 million sETH, while noting that the true dollar impact was hard to value because sETH liquidity was limited. Synthetix later said the bot owner agreed to reverse the trades in exchange for a bug bounty.
+
+## Manipulation signal
+
+The abnormal signal was not wash trading in the usual sense of one party trading with itself to inflate volume. It was a price-integrity failure that created an executable false market. The sKRW venue briefly priced a synthetic fiat asset as though KRW had moved by orders of magnitude, while other markets and real-world FX rates had not.
+
+This makes the incident useful for market-health monitoring because it shows how a venue can display apparently valid executed trades even when the tradeable price is detached from the underlying reference asset. In a synthetic-asset exchange, the oracle price is the order book's economic anchor. When that anchor fails, automated arbitrage can convert an oracle-data anomaly into distorted volume, artificial profit, and debt-pool losses for other participants.
+
+| Indicator                       | Observed value                                  | Market-health interpretation                                                               |
+| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Reference price deviation       | KRW feed reported about 1000x the correct rate  | Synthetic asset price was detached from its underlying fiat market                         |
+| Exploit window                  | Less than one hour, according to Synthetix      | Automated strategies can monetize bad oracle states faster than manual operators can react |
+| Apparent profit                 | More than $1 billion reported by Synthetix      | Reported venue PnL and volume became economically meaningless during the bad-price window  |
+| Exposed synthetic asset balance | More than 37 million sETH reported by The Block | A single price-feed failure could spill into another synthetic asset market                |
+| Resolution                      | Trades reversed after contact with bot owner    | Final loss was mitigated socially, not by a purely market-native control                   |
+
+## Failure chain
+
+Synthetix said it used multiple commercial APIs for FX, commodities, and crypto price feeds. One API began intermittently reporting KRW at roughly 1000 times the current rate. Synthetix also said the outlier filter should have absorbed the error, but the KRW feed was only being served by two APIs because of an unrelated earlier outage. With fewer inputs available, the oracle averaged the two remaining prices and sent the bad KRW rate to the exchange-rates contract.
+
+That failure chain left the trading system with two important weaknesses:
+
+1. The venue accepted a large isolated price move in one synthetic fiat market.
+2. Trades using the bad sKRW price were still composable with other synth markets, including sETH.
+
+The bot did not need to create false public demand for sKRW. It only needed to recognize that Synthetix.exchange had published an economically impossible conversion rate. By moving into and out of sKRW while the bad feed was live, the bot transformed an oracle input error into a market event visible as outsized executed trades and synthetic profit.
+
+## Why this matters for market health
+
+Market-health analysis usually focuses on executed order feeds, trade-size distributions, wash-trading clusters, and venue-level volume. The Synthetix incident shows that those metrics also depend on reference-data integrity. If a venue's price source is corrupted, the downstream trade feed can look active and profitable while measuring a broken market state.
+
+For synthetic assets and derivatives venues, useful monitoring should include:
+
+- deviation checks between the venue's executable price and independent reference prices;
+- stale-feed checks before a synthetic asset can be used in cross-asset exchange paths;
+- circuit breakers that halt a market when an underlying reference asset moves beyond plausible bounds;
+- cross-market impact analysis when one mispriced asset can be converted into another synthetic asset;
+- post-incident labeling so suspicious volume from bad oracle windows is not treated as organic demand.
+
+The incident also shows why social reversibility is not a complete control. Synthetix was able to contact the bot owner and negotiate a reversal, but a market-health framework should treat that as mitigation after failure, not as proof that the market remained healthy.
+
+## Source dataset
+
+The supporting event timeline is included in `timeline.csv`. It records the incident date, reported metrics, and public source links used for the analysis.
+
+## References
+
+- [Synthetix response to oracle incident](https://blog.synthetix.io/response-to-oracle-incident/)
+- [The Block report on the sKRW oracle incident](https://www.theblock.co/post/28748/synthetix-suffers-oracle-attack-potentially-looting-37-million-synthetic-ether)
+- [CoinDesk report on the trade reversal](https://www.coindesk.com/markets/2019/06/25/synthetix-trader-rolls-back-broken-trades-that-netted-1-billion-profit)

--- a/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md
+++ b/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md
@@ -11,7 +11,7 @@ entities:
 
 On June 25, 2019, Synthetix disclosed an oracle incident in which its Korean won price feed reported KRW at roughly 1000 times the correct rate. The error did not require an attacker to compromise Synthetix contracts or manipulate the external data provider directly. Instead, an automated trading bot detected the mispriced synthetic asset and traded through it while Synthetix.exchange was still accepting the rate.
 
-The result was a short-lived but extreme market-health failure: Synthetix reported several trades with 1000x profits and more than $1 billion in apparent profit in less than one hour. The Block separately reported that the bot accumulated more than 37 million sETH, while noting that the true dollar impact was hard to value because sETH liquidity was limited. Synthetix later said the bot owner agreed to reverse the trades in exchange for a bug bounty.
+The result was a short-lived but extreme market-health failure: Synthetix reported several trades with 1000x profits and more than $1 billion in apparent profit in less than one hour. The Block separately reported that the bot accumulated more than 37 million sETH, while noting that the true dollar impact was hard to value because sETH liquidity was limited. These figures are treated here as incident-report evidence rather than independently reconstructed measurements. Synthetix later said the bot owner agreed to reverse the trades in exchange for a bug bounty.
 
 ## Manipulation signal
 
@@ -51,6 +51,10 @@ For synthetic assets and derivatives venues, useful monitoring should include:
 - post-incident labeling so suspicious volume from bad oracle windows is not treated as organic demand.
 
 The incident also shows why social reversibility is not a complete control. Synthetix was able to contact the bot owner and negotiate a reversal, but a market-health framework should treat that as mitigation after failure, not as proof that the market remained healthy.
+
+## Evidence limits
+
+This post does not reconstruct the Ethereum transaction sequence, oracle updates, or sETH balances at block level. It therefore should not be read as a statistical trade-size, balance-flow, or oracle-rate study. Its contribution is narrower: it records a documented oracle failure mode and maps the reported incident facts to market-health controls that would need primary on-chain and reference-price data for quantitative validation.
 
 ## Source timeline
 

--- a/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/timeline.csv
+++ b/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/timeline.csv
@@ -2,5 +2,6 @@ date,event,reported_metric,source
 2019-06-25,Synthetix disclosed that a commercial KRW feed intermittently reported a price about 1000 times higher than the correct rate,1000x KRW price-feed error,https://blog.synthetix.io/response-to-oracle-incident/
 2019-06-25,An automated trading bot traded into and out of sKRW while the bad feed was live,1000x trade profits and more than $1B apparent profit in less than one hour,https://blog.synthetix.io/response-to-oracle-incident/
 2019-06-25,Synthetix stopped the oracle service from sending rates to contracts and halted transfers and trading,Transfers and trading halted,https://blog.synthetix.io/response-to-oracle-incident/
-2019-06-24,The Block reported that the incident exposed more than 37 million sETH,More than 37 million sETH,https://www.theblock.co/post/28748/synthetix-suffers-oracle-attack-potentially-looting-37-million-synthetic-ether
+2019-06-25,The Block reported that the incident exposed more than 37 million sETH,More than 37 million sETH,https://www.theblock.co/post/28748/synthetix-suffers-oracle-attack-potentially-looting-37-million-synthetic-ether
+2019-06-25,CoinDesk reported that the trader rolled back the broken trades after the incident,Trades reversed after contact with trader,https://www.coindesk.com/markets/2019/06/25/synthetix-trader-rolls-back-broken-trades-that-netted-1-billion-profit
 2019-06-25,Synthetix said the bot owner agreed to reverse the trades in exchange for a bug bounty,Trades reversed after bounty negotiation,https://blog.synthetix.io/response-to-oracle-incident/

--- a/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/timeline.csv
+++ b/content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/timeline.csv
@@ -1,0 +1,6 @@
+date,event,reported_metric,source
+2019-06-25,Synthetix disclosed that a commercial KRW feed intermittently reported a price about 1000 times higher than the correct rate,1000x KRW price-feed error,https://blog.synthetix.io/response-to-oracle-incident/
+2019-06-25,An automated trading bot traded into and out of sKRW while the bad feed was live,1000x trade profits and more than $1B apparent profit in less than one hour,https://blog.synthetix.io/response-to-oracle-incident/
+2019-06-25,Synthetix stopped the oracle service from sending rates to contracts and halted transfers and trading,Transfers and trading halted,https://blog.synthetix.io/response-to-oracle-incident/
+2019-06-24,The Block reported that the incident exposed more than 37 million sETH,More than 37 million sETH,https://www.theblock.co/post/28748/synthetix-suffers-oracle-attack-potentially-looting-37-million-synthetic-ether
+2019-06-25,Synthetix said the bot owner agreed to reverse the trades in exchange for a bug bounty,Trades reversed after bounty negotiation,https://blog.synthetix.io/response-to-oracle-incident/


### PR DESCRIPTION
## Summary

- Adds a Market Health article about the Synthetix sKRW oracle incident and automated arbitrage.
- Adds `timeline.csv` with source-backed incident facts and public references.
- Frames the incident as a reference-data integrity failure that created a temporary false market in a synthetic asset venue.

## Verification

- `npx prettier --check content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/index.md content/research/market-health/posts/2019-06-25-synthetix-skrw-oracle/timeline.csv --ignore-unknown`
- `git diff --cached --check`

Hugo build was not run locally because Hugo is not installed in this environment.

References #277


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit (updated)

* **Documentation**
  * Added a new article documenting the June 25, 2019 Synthetix sKRW oracle incident, describing market-health anomalies, manipulation-signal indicators, a failure-chain analysis, monitoring best practices, and references. The post explicitly includes an "Evidence limits" section stating it does not reconstruct Ethereum transaction sequences, oracle updates, or block-level sETH balances.

* **Data / dataset**
  * Added timeline.csv as a supporting citation log. The CSV lists six narrative events (all dated 2019-06-25) with secondary-source links (Synthetix blog, The Block, CoinDesk). It remains a provenance/citation log rather than a primary on-chain dataset or sub-day numeric time series.

* **Reviewer findings / concerns**
  * Reviewer concluded the submission is a readable narrative but does not meet the repository's dataset standards for primary, block-level evidence or statistical time-series:
    - No on-chain transaction details (block numbers, tx hashes, wallet addresses, per-transaction sETH transfers) or reconstructed trade-level data are provided.
    - No sub-day time series of oracle-reported KRW vs independent FX or block-level sETH balance accumulation.
    - Manipulation-signal "Observed value" entries and headline figures (e.g., "1000x", "> $1B", "37 million sETH") are drawn from Synthetix and a few secondary articles rather than independent measurement.
  * Reviewer recommended either:
    1. Add primary on-chain reconstruction (bot wallet txs, block numbers, tx hashes, per-transaction sETH flows) and time-series comparison of oracle KRW vs external FX, plus block-level balance accumulation; or
    2. If on-chain reconstruction is out of scope, retain timeline.csv as an explicit citation log (which the post now does) and avoid implying it contains source-backed metric data.

* **Commits**
  * Single commit message: "Clarify Synthetix evidence limits" — updates the post to clarify limits of available evidence but does not add primary on-chain datasets or statistical analyses.

* **Actionable next steps (author-facing)**
  - If the goal is to meet repository dataset standards: provide on-chain transaction and block-level reconstructions and a measured time series of oracle vs external FX during the incident window, and add trade/balance analyses.
  - If keeping the submission as a narrative/citation piece: ensure timeline.csv remains labeled and documented as a citation log (not a numeric dataset), remove any language implying primary measurement, and consider a brief note in the post about why on-chain reconstruction was not performed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->