### PR TITLE
Add EminiFX robo-advisor return case study

### DIFF
--- a/content/research/market-health/posts/2023-07-18-eminifx-robo-advisor-weekly-returns/eminifx-summary.csv
+++ b/content/research/market-health/posts/2023-07-18-eminifx-robo-advisor-weekly-returns/eminifx-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2021-09-20,EminiFX incorporated,EminiFX; Eddy Alexandre,EminiFX incorporated in New York according to the CFTC complaint,New platform required custody and registration checks,CFTC complaint
+2021-09-21,EminiFX business bank account opened,EminiFX; Eddy Alexandre,Alexandre was sole signatory on initial EminiFX account according to the CFTC complaint,Centralized account control shaped cash-flow risk,CFTC complaint
+2021-10,Investment club solicitation begins,EminiFX; Eddy Alexandre,Participants were solicited for a purported investment club to trade commodity interests,Investor deposits were represented as trading capital,CFTC complaint
+2021-2022,Robo-advisor and automated trading claims,EminiFX; Robo-Advisor Assisted Account,Platform represented crypto and forex automated trading through a robo-advisor account,Secret automation claims require venue and execution proof,CFTC complaint
+2021-2022,Weekly account gains displayed,EminiFX,Customer accounts allegedly showed 5 percent to 9.99 percent weekly increases,Displayed returns required reconciliation to realized P&L,CFTC complaint
+2022-04-27,Limited traded funds show losses,EminiFX; Eddy Alexandre,Complaint alleged about 9 million USD sent to trading account and about 6.2 million USD lost,Trading losses contradicted weekly positive balance displays,CFTC complaint
+2022-05-12,DOJ announces charges,DOJ; EminiFX; Eddy Alexandre,DOJ announced charges tied to more than 59 million USD in investments from hundreds of investors,Early enforcement record challenged trading and return representations,DOJ charging release
+2023-07-18,DOJ announces sentence and restitution,DOJ; Eddy Alexandre,DOJ reported more than 248 million USD from over 25000 investors and restitution of 213639133.53 USD,Later criminal resolution confirmed large investor-harm scale,DOJ sentencing release

--- a/content/research/market-health/posts/2023-07-18-eminifx-robo-advisor-weekly-returns/index.md
+++ b/content/research/market-health/posts/2023-07-18-eminifx-robo-advisor-weekly-returns/index.md
@@ -1,0 +1,92 @@
+---
+title: "EminiFX Robo-Advisor Weekly Return Claims"
+date: 2023-07-18
+entities:
+  - EminiFX
+  - Eddy Alexandre
+  - Robo-Advisor Assisted Account
+---
+
+## Summary
+
+This case study analyzes EminiFX as a market-health warning about automated trading claims that transform customer account dashboards into apparent market evidence. EminiFX marketed a purported cryptocurrency and forex investment platform built around a "Robo-Advisor Assisted account" and reported weekly account gains of 5 percent to 9.99 percent. The CFTC complaint and DOJ sentencing release show a different pattern: investor money was not substantially routed into crypto or forex trading, the limited traded funds generated large losses, and customer balances still appeared to grow.
+
+The market-health problem was not simply a failed strategy. It was a signal-fabrication loop. Customers saw platform balances and weekly return postings that looked like trading performance, while the public enforcement record describes a cash-flow mismatch between investor deposits, actual trading-account transfers, losses, and personal use of funds. That mismatch is directly relevant to crypto venues and pooled trading products because similar dashboard-based returns can be used to imply liquidity, execution skill, or profitable automated strategies without venue-level proof.
+
+The supporting dataset is available in [eminifx-summary.csv](eminifx-summary.csv).
+
+## Trading Narrative
+
+The EminiFX claim can be tested with a three-part reconciliation model: deposits should flow to a live venue, trading records should match the represented asset class, and customer dashboards should reconcile to realized P&L. The CFTC complaint alleged that defendants accepted at least $59 million during the initial relevant period and that only about $9 million was sent to a futures commission merchant for trading. That implies roughly 15.3 percent of the funds identified in the complaint reached the trading account, before considering that the traded account was not used for the represented crypto or forex strategy.
+
+The second break was execution quality. The complaint alleged that funds moved to the trading account were used for securities futures, options, and stock index futures rather than the advertised crypto and forex strategy, and that the account had lost nearly 70 percent, about $6.2 million, by April 27, 2022. A platform cannot convert those facts into weekly 5 percent to 9.99 percent gains without an independent source of profit. In market-health terms, the account dashboard became a synthetic performance feed.
+
+The later criminal case widened the scale. DOJ said Alexandre defrauded more than 25,000 investors of more than $248 million, and the July 18, 2023 sentencing release reported forfeiture of $248.8 million and restitution of $213.6 million. The useful analytical lesson is that a claimed automated trading product should be evaluated from the bottom up: cash movement, venue statements, order records, realized gains and losses, and then customer-facing performance displays. If the order is reversed, the dashboard can become the proof instead of the object being tested.
+
+## False Market Signals
+
+### Secret robo-advisor technology
+
+The "Robo-Advisor Assisted account" label converted an undisclosed process into an authority signal. A secret strategy can be commercially confidential while still producing auditable venue records. The absence of disclosed mechanics increases the burden for independent execution, custody, and P&L proof.
+
+### Weekly return postings
+
+The CFTC complaint alleged that funded accounts showed weekly balance increases between 5 percent and 9.99 percent. Stable positive returns at that frequency should trigger a variance test: compare the displayed return stream with actual trades, open risk, drawdowns, fees, and cash withdrawals.
+
+### Trading-account flow mismatch
+
+The complaint's $59 million deposit figure and approximately $9 million trading-account transfer figure create a deposit-to-trading-account ratio of about 15.3 percent. The remaining gap is a market-health signal because displayed returns cannot be treated as trading performance unless customer capital can be traced into accounts that generated those returns.
+
+### Strategy mismatch
+
+The platform was marketed around crypto and forex trading. The complaint alleged the limited traded funds were used for securities futures, options, and stock index futures, not crypto or forex as represented. Product-level performance claims need asset-class reconciliation, not only account-balance screenshots.
+
+### Loss concealment
+
+The complaint alleged the limited trading account lost about $6.2 million while customer balances continued to show weekly increases. That creates a direct contradiction between realized venue outcomes and customer-facing performance.
+
+## Event Timeline
+
+| Date or period      | Event                                                                                  | Market-health signal                                                       |
+| ------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| September 20, 2021  | EminiFX was incorporated in New York, according to the CFTC complaint.                 | New platform structure required custody and registration checks.           |
+| September 21, 2021  | Alexandre opened an EminiFX business account, according to the complaint.              | Centralized bank-account control became the cash-flow starting point.      |
+| October 2021 onward | EminiFX solicited funds for a purported trading investment club.                       | Investor deposits were represented as trading capital.                     |
+| 2021 to 2022        | The platform promoted automated crypto and forex trading through a robo-advisor label. | Technology branding substituted for verifiable execution records.          |
+| 2021 to 2022        | Customer accounts allegedly showed 5 percent to 9.99 percent weekly gains.             | Dashboard returns required reconciliation to actual venue P&L.             |
+| April 27, 2022      | The CFTC complaint alleged the limited traded funds had lost nearly 70 percent.        | Realized trading outcomes contradicted weekly positive return displays.    |
+| May 12, 2022        | DOJ announced charges involving more than $59 million in alleged investments.          | Enforcement record challenged the platform's trading and return narrative. |
+| July 18, 2023       | DOJ announced a nine-year sentence and restitution of about $213.6 million.            | Criminal resolution confirmed the investor-harm scale reported by DOJ.     |
+
+## Reconciliation Metrics
+
+| Metric                         | Enforcement-record figure                                       | Market-health interpretation                                     |
+| ------------------------------ | --------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Initial funds accepted         | At least $59 million in the CFTC complaint and 2022 DOJ release | Baseline for deposit-to-trading-account reconciliation.          |
+| Funds sent to trading account  | About $9 million in the CFTC complaint                          | Roughly 15.3 percent of identified funds reached the account.    |
+| Trading account loss           | About $6.2 million by April 27, 2022                            | Roughly 68.9 percent loss on the limited traded amount.          |
+| Weekly displayed account gains | 5 percent to 9.99 percent alleged in the CFTC complaint         | Performance stream conflicted with recorded trading losses.      |
+| Later criminal scale           | More than $248 million from more than 25,000 investors          | Early cash-flow controls did not scale with solicitation growth. |
+
+## Detection Checklist
+
+1. Reconcile deposits to live venue accounts before accepting any dashboard return as market evidence.
+2. Require asset-class matching: a crypto and forex strategy should reconcile to crypto or forex venue records, not unrelated futures or options activity.
+3. Treat secret automated technology as unaudited until it produces strategy logs, order routing records, fills, balances, fees, and realized P&L.
+4. Compare weekly return stability against actual risk. A 5 percent to 9.99 percent weekly account increase with hidden losses is a no-reliance signal.
+5. Check whether platform balances are operator-controlled displays or records generated by independent custodians and brokers.
+6. Trace return payments and withdrawals to realized gains, not later deposits or commingled operating accounts.
+7. Check CFTC registration status when a platform pools participant funds for forex, futures, or commodity-interest trading.
+8. Preserve legal posture: this article relies on DOJ statements and public CFTC complaint allegations.
+
+## Market-Health Lessons
+
+EminiFX shows how an automated-trading label can make a platform dashboard look like a market data feed. The control is to separate presentation from execution. Customer-facing returns are claims, not measurements, until they are tied to deposits, venue confirmations, order histories, and realized P&L.
+
+The most useful metric is the reconciliation gap. In the initial CFTC complaint, the gap between at least $59 million accepted and about $9 million sent to a trading account was large enough to invalidate the platform's performance story without needing to model every customer account. For market-health reviewers, that means deposit-to-trading-account ratios, asset-class matching, and loss-disclosure checks can surface synthetic performance narratives early.
+
+## References
+
+- [DOJ sentencing release, July 18, 2023](https://www.justice.gov/usao-sdny/pr/ceo-cryptocurrency-and-forex-trading-platform-sentenced-nine-years-prison-240-million)
+- [DOJ charging release, May 12, 2022](https://www.justice.gov/usao-sdny/pr/ceo-cryptocurrency-and-forex-trading-platform-charged-fraudulent-scheme-involving-over)
+- [CFTC complaint against EminiFX and Eddy Alexandre](https://www.cftc.gov/media/7246/enfeminifxcomplaint051122/download)


### PR DESCRIPTION
## Summary
- Adds a Market Health case study on EminiFX, robo-advisor trading claims, weekly dashboard returns, and the deposit-to-trading-account reconciliation gap.
- Includes a supporting CSV dataset covering event dates, reported metrics, sources, and market-health signals.

## Validation
- `npx prettier --write --ignore-unknown content/research/market-health/posts/2023-07-18-eminifx-robo-advisor-weekly-returns/index.md content/research/market-health/posts/2023-07-18-eminifx-robo-advisor-weekly-returns/eminifx-summary.csv`
- `git diff --cached --check`
- CSV parsed successfully: 8 rows, 6 columns

Relates to #277

/claim #277