### PR TITLE
Add PGI bitcoin daily-return case study

### DIFF
--- a/content/research/market-health/posts/2026-02-12-pgi-bitcoin-daily-return-portal/index.md
+++ b/content/research/market-health/posts/2026-02-12-pgi-bitcoin-daily-return-portal/index.md
@@ -1,0 +1,98 @@
+---
+title: "PGI Bitcoin Daily Return Portal Claims"
+date: 2026-02-12
+entities:
+  - Praetorian Group International
+  - PGI
+  - Ramil Ventura Palafox
+  - Bitcoin
+---
+
+## Summary
+
+This case study analyzes Praetorian Group International (PGI) as a market-health warning about bitcoin trading claims that rely on daily return promises and platform-reported performance. On February 12, 2026, DOJ announced that PGI CEO Ramil Ventura Palafox was sentenced to 20 years in prison after conviction on wire fraud and money laundering charges for operating a bitcoin Ponzi scheme.
+
+DOJ said PGI was a multi-level marketing and bitcoin trading firm that defrauded more than 90,000 investors worldwide. From December 2019 to October 2021, investors put more than $201 million into PGI, including about $30.3 million in fiat currency and 8,198 bitcoin worth about $171.5 million. DOJ said investors suffered losses of at least $62.7 million. The SEC's 2025 litigation release separately described PGI Global as a crypto asset and foreign exchange trading company claim that raised approximately $198 million and involved more than $57 million in alleged misappropriation.
+
+The market-health signal was the gap between a 0.5 percent to 3 percent daily return promise, limited bitcoin trading capacity, and an online portal that showed investments gaining value.
+
+The supporting dataset is available in [pgi-summary.csv](pgi-summary.csv).
+
+## Trading Narrative
+
+PGI can be tested with a trading-capacity model. A bitcoin trading firm promising daily returns should be able to show the capital actually deployed, venue accounts, order history, realized P&L, fees, drawdowns, wallet movements, and withdrawal records. DOJ said Palafox falsely claimed PGI was engaged in bitcoin trading and promised daily returns of 0.5 percent to 3 percent. DOJ also said PGI was not trading bitcoin at a scale capable of producing the promised returns and that investor repayments came from investor money.
+
+The scale of the inflows makes the reconciliation gap concrete. DOJ reported more than $201 million invested by at least 90,000 people, including 8,198 bitcoin. At that size, a real strategy should leave a substantial venue and wallet trail. Instead, DOJ described platform performance reporting that misled investors into believing their investments were profitable and secure from 2020 through 2021.
+
+The spending record is also a market-health signal because it shows an alternative destination for investor funds. DOJ said Palafox spent about $3 million on 20 luxury vehicles, about $329,000 on luxury hotel penthouse suites, more than $6 million on four homes, another $3 million on luxury goods and furnishings, and transferred at least $800,000 plus 100 bitcoin to a family member. For market reviewers, those cash-flow destinations should be tested against any claimed trading returns before treating portal balances as market evidence.
+
+## False Market Signals
+
+### Daily return promise
+
+The promised 0.5 percent to 3 percent daily return range transformed bitcoin trading into a stable-yield narrative. Real trading strategies have capacity limits, drawdowns, fees, and losing periods. A daily return range this smooth requires direct venue-level evidence.
+
+### Online performance portal
+
+DOJ said Palafox created a PGI website where investors could review purported investment performance and that, from 2020 through 2021, the portal misrepresented that investments were gaining value. A dashboard can report account status, but it is not proof of trading without independent reconciliation.
+
+### Bitcoin inflow scale
+
+The 8,198 bitcoin figure created an audit baseline. A legitimate bitcoin trading operation should be able to connect those inflows to wallets, exchange deposits, orders, realized gains, withdrawals, and remaining balances.
+
+### MLM growth signal
+
+PGI was described as a multi-level marketing firm. MLM growth can increase deposits and social proof, but it does not prove trading skill. Deposit inflow has to be separated from market-generated profit.
+
+### Lifestyle and promotional spending
+
+Luxury purchases and promotional spending can create credibility signals while also draining funds away from trading. The correct test is whether spending, withdrawals, and repayments reconcile to realized trading gains rather than new investor deposits.
+
+## Event Timeline
+
+| Date or period             | Event                                                                                                | Market-health signal                                                     |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| December 2019 onward       | DOJ said investors began putting funds into PGI.                                                     | Investor inflows created a trading-capacity reconciliation baseline.     |
+| 2020-2021                  | DOJ said PGI's portal misrepresented that investments were gaining value.                            | Dashboard performance needed independent trading and wallet proof.       |
+| December 2019-October 2021 | DOJ said more than 90,000 investors placed more than $201 million into PGI.                          | Large scale required robust custody, execution, and redemption controls. |
+| December 2019-October 2021 | DOJ said investments included about $30.3 million fiat and 8,198 bitcoin worth about $171.5 million. | Fiat and BTC flows needed separate reconciliation paths.                 |
+| 2020-2021                  | DOJ said Palafox promised daily returns of 0.5 percent to 3 percent.                                 | Smooth daily yields conflicted with normal bitcoin-trading variability.  |
+| 2020-2021                  | DOJ described luxury and personal spending from investor funds.                                      | Spending destinations competed with claimed trading capital.             |
+| October 2021               | DOJ's investment period ended.                                                                       | End of inflow period defined the reconciliation window.                  |
+| February 12, 2026          | DOJ announced Palafox's 20-year sentence.                                                            | Criminal outcome confirmed the bitcoin Ponzi finding.                    |
+
+## Reconciliation Metrics
+
+| Metric                  | Enforcement-record figure                               | Market-health interpretation                                          |
+| ----------------------- | ------------------------------------------------------- | --------------------------------------------------------------------- |
+| Total investor count    | More than 90,000 investors worldwide                    | Strategy scale required institutional-grade reconciliation.           |
+| Total invested          | More than $201 million                                  | Claimed returns needed proof across fiat and BTC channels.            |
+| Fiat invested           | At least $30,295,289                                    | Fiat banking flows had to connect to trading or redemptions.          |
+| Bitcoin invested        | 8,198 BTC worth about $171,498,528                      | BTC wallet flows should reconcile to exchange deposits and balances.  |
+| Investor losses         | At least $62,692,007                                    | Losses contradicted a secure daily-return story.                      |
+| Promised daily return   | 0.5 percent to 3 percent                                | Smooth daily yield required venue-level P&L support.                  |
+| Luxury vehicle spending | About $3 million for 20 vehicles                        | Investor funds were diverted from claimed trading use.                |
+| Family-member transfer  | At least $800,000 plus 100 BTC worth about $3.3 million | Large off-platform transfers required source-of-funds reconciliation. |
+
+## Detection Checklist
+
+1. Reconcile fiat deposits and bitcoin deposits separately to trading venues, wallets, orders, fees, and balances.
+2. Compare promised daily returns against actual bitcoin price volatility, strategy capacity, and drawdown history.
+3. Treat platform-reported gains as unverified until matched to independent exchange statements and wallet flows.
+4. Separate MLM deposit growth from trading profits.
+5. Test whether investor repayments come from realized trading gains or later investor funds.
+6. Review promotional and lifestyle spending as possible leakage from claimed trading capital.
+7. Require a redemption test: displayed value should map to successful withdrawals.
+8. Preserve legal posture: this article relies on DOJ statements, court-document summaries, and conviction/sentencing reporting.
+
+## Market-Health Lessons
+
+PGI shows how daily-return promises can turn bitcoin volatility into a false stability signal. The most important metric is not the displayed return percentage, but the reconciliation path from investor funds to trading activity and back to withdrawable balances.
+
+The case also shows why fiat and BTC flows should be audited separately. A platform may receive both banked fiat and on-chain bitcoin, but each channel has different evidence. Market-health reviewers should require bank records, wallet analysis, exchange records, and withdrawal histories to agree before accepting any dashboard as a source of performance data.
+
+## References
+
+- [DOJ PGI sentencing release, February 12, 2026](https://www.justice.gov/usao-edva/pr/praetorian-group-international-ceo-sentenced-20-years-prison-200m-bitcoin-ponzi-scheme)
+- [IRS-CI PGI plea release, September 17, 2025](https://www.irs.gov/compliance/criminal-investigation/praetorian-group-international-ceo-pleads-guilty-to-200m-bitcoin-ponzi-scheme)
+- [SEC litigation release 26295, April 29, 2025](https://www.sec.gov/enforcement-litigation/litigation-releases/lr-26295)

--- a/content/research/market-health/posts/2026-02-12-pgi-bitcoin-daily-return-portal/pgi-summary.csv
+++ b/content/research/market-health/posts/2026-02-12-pgi-bitcoin-daily-return-portal/pgi-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2019-12,PGI investment period begins,PGI; Ramil Ventura Palafox,DOJ said investors placed funds into PGI from December 2019 to October 2021,Investor inflows created a trading-capacity reconciliation baseline,DOJ sentencing release
+2020-2021,Daily bitcoin trading returns promised,PGI; Palafox,DOJ said Palafox promised daily returns of 0.5 percent to 3 percent,Smooth daily yields required venue-level P&L proof,DOJ sentencing release
+2020-2021,Online portal showed purported gains,PGI,DOJ said the online portal misrepresented that investments were gaining value,Dashboard returns required independent trading and wallet proof,DOJ sentencing release
+2019-12 to 2021-10,Investor scale reported,PGI; investors,More than 90000 investors worldwide invested more than 201 million USD,Large scale required robust custody execution and redemption controls,DOJ sentencing release
+2019-12 to 2021-10,Fiat and bitcoin investment mix,PGI,Investments included 30295289 USD fiat and 8198 BTC worth 171498528 USD,Fiat and BTC flows needed separate reconciliation paths,DOJ sentencing release
+2021-10,Investor loss figure,PGI; investors,DOJ said investor losses totaled at least 62692007 USD,Losses contradicted profitable and secure daily-return claims,DOJ sentencing release
+2020-2021,Personal and promotional spending,PGI; Palafox,DOJ described millions spent on vehicles homes luxury suites goods and transfers,Spending destinations competed with claimed trading capital,DOJ sentencing release
+2026-02-12,Palafox sentenced,Ramil Ventura Palafox,DOJ announced a 20-year prison sentence after conviction on wire fraud and money laundering charges,Criminal outcome confirmed the bitcoin Ponzi finding,DOJ sentencing release


### PR DESCRIPTION
## Summary
- Adds a Market Health case study on PGI bitcoin daily-return claims, portal-reported gains, fiat/BTC inflow reconciliation, and DOJ/SEC/IRS enforcement metrics.
- Includes a supporting CSV dataset covering event dates, reported metrics, sources, and market-health signals.

## Validation
- `npx prettier --write --ignore-unknown content/research/market-health/posts/2026-02-12-pgi-bitcoin-daily-return-portal/index.md content/research/market-health/posts/2026-02-12-pgi-bitcoin-daily-return-portal/pgi-summary.csv`
- `git diff --cached --check`
- CSV parsed successfully: 8 rows, 6 columns

Relates to #277

/claim #277