### PR TITLE
[codex] Add OmegaPro forex return market-health article

### DIFF
--- a/content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/index.md
+++ b/content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/index.md
@@ -1,0 +1,110 @@
+---
+title: "OmegaPro Forex Return and Broker Group Withdrawal Claims"
+date: 2025-07-08
+entities:
+  - OmegaPro
+  - Broker Group
+  - Michael Shannon Sims
+  - Juan Carlos Reynoso
+---
+
+## Summary
+
+This case study analyzes OmegaPro as a market-health warning about crypto-funded foreign exchange investment packages that use fixed high-return claims, luxury-event credibility, and platform migration narratives. On July 8, 2025, DOJ announced that an indictment had been unsealed in the District of Puerto Rico charging Michael Shannon Sims and Juan Carlos Reynoso for alleged roles in operating and promoting OmegaPro, an international investment scheme that defrauded investors of more than $650 million.
+
+DOJ said Sims was a founder, strategic consultant, and promoter of OmegaPro, and that Reynoso led OmegaPro operations in Latin America and parts of the United States, including Puerto Rico. According to DOJ, OmegaPro operated as a multi-level marketing scheme in which investors purchased investment packages using virtual currency. The packages were allegedly promoted as generating 300 percent returns over 16 months through foreign exchange trading by elite traders.
+
+The market-health problem was a return-certificate and migration loop. OmegaPro allegedly represented that virtual-currency-funded packages would be safely traded by elite forex traders, then used lavish global events and social media wealth displays to reinforce legitimacy. After OmegaPro announced a network hack, investors were allegedly told in January 2023 that their investments were secure and being transferred to another platform called Broker Group. DOJ said victims were unable to withdraw money from either OmegaPro or Broker Group accounts.
+
+The supporting dataset is available in [omegapro-summary.csv](omegapro-summary.csv).
+
+## Trading Narrative
+
+OmegaPro can be tested with a package-to-trading reconciliation. If an investment package promises 300 percent returns over 16 months from elite forex trading, reviewers should be able to trace each package purchase from virtual currency deposit to custody wallet, trading venue, position history, realized P&L, fees, promoter compensation, and withdrawal settlement.
+
+The DOJ release describes the opposite control environment. Investors were instructed to buy packages using virtual currency, and the indictment allegedly traced more than $650 million in victim funds first to wallet addresses controlled by OmegaPro executives. DOJ then said those funds were transferred to insiders and high-ranking promoters to disperse funds and obscure origins. That flow is a market-health signal because investor deposits moved first through operator-controlled wallets rather than through an independently verifiable trading chain.
+
+The return promise itself required scrutiny. A 300 percent return over 16 months is not a normal forex benchmark; it implies either extreme leverage, exceptional directional accuracy, or a non-market source of payouts. A real strategy with that profile should produce drawdowns, volatility, margin history, risk controls, counterparty statements, and losing periods. DOJ said Sims allegedly vouched for OmegaPro's trading performance and trader skill while falsely advertising safety.
+
+The event marketing amplified the trading claim. DOJ said Sims, Reynoso, and co-conspirators hosted lavish promotional events and trainings around the world, including projecting the OmegaPro logo onto the Burj Khalifa in Dubai, and used social media to show expensive vacations, cars, designer clothes, and watches. Those signals can make a platform look successful, but they do not verify exchange accounts, executed trades, or net returns.
+
+The final warning was the Broker Group migration. DOJ said that after OmegaPro announced a network hack, Reynoso and others told victims around January 2023 that their investments were secure and being moved to Broker Group. Victims were then unable to withdraw from either platform. In market-health terms, a migration during withdrawal stress should be treated as a liquidity-substitution event: the new platform must prove assets, custody, and redemption ability before investors accept it as continuity.
+
+## False Market Signals
+
+### Three-hundred-percent package return
+
+A fixed 300 percent return over 16 months implies unusually high repeatable market performance. The claim should be tested against venue statements, order records, leverage, drawdowns, counterparty risk, and actual realized P&L.
+
+### Elite-trader authority
+
+Elite-trader language can turn undisclosed people and methods into a credibility signal. It does not substitute for named counterparties, account statements, complete strategy history, and risk reports.
+
+### Virtual-currency funding
+
+Investor package purchases were allegedly made in virtual currency. Crypto funding can be legitimate, but it also raises tracing and custody questions: which wallets received funds, who controlled them, and whether funds moved to trading venues or insiders.
+
+### Luxury-event proof
+
+Global promotional events, Burj Khalifa branding, and luxury lifestyle posts can imply success without proving market activity. Reviewers should treat them as marketing expenses until tied to trading revenue.
+
+### License ambiguity
+
+DOJ said Reynoso allegedly represented both that OmegaPro had a legitimate license and that OmegaPro was not subject to any country's legal rules. Conflicting regulatory claims are a market-health warning because they obscure which supervisor, venue, or custody rules apply.
+
+### Broker Group migration
+
+A platform migration after a claimed hack can become a way to reset balances and delay withdrawals. The new platform should be independently tested for asset custody, liabilities, wallet control, and actual withdrawal settlement.
+
+## Event Timeline
+
+| Date or period | Event                                                                                        | Market-health signal                                                         |
+| -------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| January 2019   | DOJ said Sims and co-conspirators established OmegaPro in or about January 2019.             | New platform required custody, trading, and registration checks.             |
+| April 2019     | DOJ said Reynoso joined OmegaPro in or about April 2019.                                     | Regional operations expanded solicitation reach.                             |
+| 2019 onward    | Investors bought investment packages using virtual currency.                                 | Crypto deposits needed wallet-to-trading reconciliation.                     |
+| 2019 onward    | OmegaPro allegedly promised 300 percent returns over 16 months through elite forex trading.  | Fixed high returns required independent trading and risk proof.              |
+| 2019 to 2023   | DOJ said promotional events and trainings were hosted around the world.                      | Luxury-event credibility did not verify market performance.                  |
+| January 2023   | DOJ said victims were told investments were secure and moving to Broker Group after a hack.  | Platform migration appeared during withdrawal stress.                        |
+| January 2023   | Victims allegedly could not withdraw from OmegaPro or Broker Group accounts.                 | Account balances failed the redemption test.                                 |
+| June 25, 2025  | Public court records identified the indictment filing date in the Puerto Rico criminal case. | Criminal allegations formalized the fraud and money-laundering theory.       |
+| July 8, 2025   | DOJ announced the unsealed indictment against Sims and Reynoso.                              | Public enforcement record quantified more than $650 million in alleged harm. |
+
+## Reconciliation Metrics
+
+| Metric                   | Enforcement-record figure                                       | Market-health interpretation                                         |
+| ------------------------ | --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Alleged investor harm    | More than $650 million                                          | Scale required institutional-grade custody and trading evidence.     |
+| Return promise           | 300 percent over 16 months                                      | Fixed high return needed venue-level P&L support.                    |
+| Claimed source of return | Foreign exchange trading by elite traders                       | Needed counterparties, account statements, orders, and risk history. |
+| Funding method           | Investment packages purchased with virtual currency             | Wallet control and routing were central reconciliation points.       |
+| Initial fund routing     | Wallet addresses allegedly controlled by OmegaPro executives    | Deposits first entered operator-controlled addresses.                |
+| Later fund routing       | Transfers allegedly went to insiders and high-ranking promoters | Cash flow did not map cleanly to independent trading venues.         |
+| Migration platform       | Broker Group                                                    | New platform required proof of assets, liabilities, and withdrawals. |
+| Withdrawal outcome       | Victims unable to withdraw from either platform                 | Displayed balances did not equal redeemable value.                   |
+| Criminal charges         | Wire-fraud conspiracy and money-laundering conspiracy           | Enforcement theory targeted both deception and fund movement.        |
+
+## Detection Checklist
+
+1. Reconcile every virtual-currency package purchase to custody wallets, trading venues, executed trades, fees, and withdrawals.
+2. Treat fixed high-return forex packages as unsupported until complete P&L, leverage, drawdown, and counterparty records are available.
+3. Separate luxury-event and social-media credibility from evidence of market performance.
+4. Verify claimed licenses and regulatory status in each jurisdiction where investors are solicited.
+5. Map promoter payments and insider transfers separately from trading gains.
+6. Treat a platform migration after a claimed hack as a liquidity-substitution event until assets and liabilities are independently verified.
+7. Test whether investors can withdraw to external wallets or bank accounts before accepting portal balances as value.
+8. Preserve legal posture: this article relies on DOJ allegations and public court-record descriptions.
+
+## Market-Health Lessons
+
+OmegaPro shows how a fixed forex-return package can use crypto deposits to bypass ordinary investor checks. The first control is wallet and venue reconciliation. If funds move from investor wallets to operator-controlled wallets and then to insiders or promoters, the return stream should not be treated as market-generated without contrary evidence from trading venues.
+
+The second lesson is that prestige marketing is not liquidity. Large events, recognizable landmarks, and luxury imagery can create confidence while providing no information about positions, margin calls, realized P&L, or withdrawal reserves. Analysts should classify those signals as promotion, not performance.
+
+The Broker Group episode adds a migration rule. When a platform announces a hack and shifts investors to another platform, the market-health review should restart from zero: wallet control, asset coverage, liabilities, access rules, and withdrawal completion. A balance transferred on-screen is not a settled market asset.
+
+## References
+
+- [DOJ press release 25-703, July 8, 2025](https://www.justice.gov/opa/pr/omegapro-founder-and-promoter-charged-running-global-650m-foreign-exchange-and-crypto)
+- [ICE HSI release, July 14, 2025](https://www.ice.gov/news/releases/omegapro-founder-promoter-charged-running-global-650-million-foreign-exchange-and)
+- [GovInfo docket PDF, United States v. Reynoso](https://www.govinfo.gov/content/pkg/USCOURTS-prd-3_25-cr-00284/pdf/USCOURTS-prd-3_25-cr-00284-0.pdf)

--- a/content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/omegapro-summary.csv
+++ b/content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/omegapro-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2019-01,OmegaPro established,OmegaPro; Michael Shannon Sims,DOJ said Sims and co-conspirators established OmegaPro in or about January 2019,New platform required custody trading and registration checks,DOJ press release
+2019-04,Reynoso joins OmegaPro,OmegaPro; Juan Carlos Reynoso,DOJ said Reynoso joined OmegaPro in or about April 2019,Regional operations expanded solicitation reach,DOJ press release
+2019,Virtual-currency investment packages sold,OmegaPro,Investors were instructed to purchase investment packages using virtual currency,Crypto deposits required wallet-to-trading reconciliation,DOJ press release
+2019,Return promise promoted,OmegaPro; Michael Shannon Sims; Juan Carlos Reynoso,DOJ said packages were falsely promised to generate 300 percent returns over 16 months through forex trading by elite traders,Fixed high returns required independent P&L support,DOJ press release
+2019-2023,Global promotional events hosted,OmegaPro; promoters,DOJ said promotional events and trainings were hosted around the world including Burj Khalifa branding,Luxury-event credibility did not verify market performance,DOJ press release
+2023-01,Broker Group migration represented,OmegaPro; Broker Group; Juan Carlos Reynoso,DOJ said victims were told investments were secure and transferring to Broker Group after a hack,Platform migration appeared during withdrawal stress,DOJ press release
+2023-01,Withdrawals fail,OmegaPro; Broker Group,DOJ said victims could not withdraw from OmegaPro or Broker Group accounts,Displayed balances failed the redemption test,DOJ press release
+2025-07-08,Indictment announced,DOJ; Michael Shannon Sims; Juan Carlos Reynoso,DOJ announced charges tied to more than 650 million USD raised from thousands of investors,Public enforcement quantified alleged harm and fund-movement theory,DOJ press release


### PR DESCRIPTION
## Summary

/claim #277

Adds a focused Market Health case study on OmegaPro forex-return and Broker Group withdrawal claims, including:

- DOJ/ICE timeline for the alleged $650M scheme
- 300% over 16 months forex-return package analysis
- crypto wallet routing, luxury-event credibility, license ambiguity, and migration/withdrawal signals
- supporting CSV dataset for the event timeline and market-health signals

@marina-chibizova could you review when convenient?

## Validation

- `npx prettier --write --ignore-unknown content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/index.md content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/omegapro-summary.csv`
- `npx prettier --check --ignore-unknown content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/index.md content/research/market-health/posts/2025-07-08-omegapro-forex-return-claims/omegapro-summary.csv`
- CSV column-count parse: 8 data rows, 6 columns
- `git diff --cached --check`