### PR TITLE
[codex] Add Debiex fake trading platform case study

### DIFF
--- a/content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/debiex-summary.csv
+++ b/content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/debiex-summary.csv
@@ -1,0 +1,10 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2022-03-12,Debiex domains created,Debiex,CFTC said debiex.com and/or debiex.net were created around March 12 2022,New domains required registration and custody checks,CFTC press release 8850-24
+2022-03,Customer solicitation begins,Debiex,CFTC alleged solicitors contacted customers through social media and pretended to befriend or romance them,Relationship trust replaced platform verification,CFTC press release 8850-24
+2022-03,Trading accounts serviced,Debiex,CFTC alleged customer service purported to set up and service Debiex accounts,Support interactions created apparent operational legitimacy,CFTC press release 8850-24
+2022-03,Money mule wallets used,Debiex; Zhang Cheng Yang,CFTC alleged Zhang's wallet was used to misappropriate at least one customer's funds,Wallet-control evidence challenged the trading-account story,CFTC press release 8850-24
+2024-01-17,CFTC complaint filed,CFTC; Debiex,CFTC said it filed a complaint against Debiex in the District of Arizona,Regulatory action challenged the platform and trading claims,CFTC press release 9058-25
+2024-01-19,CFTC announces action,CFTC; Debiex,CFTC alleged about 2.3 million USD was misappropriated from about five customers,Customer assets allegedly failed to reach real trading activity,CFTC press release 8850-24
+2025-03-12,Wallet recovery order entered,Zhang Cheng Yang,The court ordered remaining digital assets worth about 120000 USD before fees returned to a customer,Specific wallet tracing supported partial recovery,CFTC press release 9058-25
+2025-03-13,Default judgment issued,Debiex,The court found Debiex liable for fraud and misappropriating over 2 million USD in customer funds,Liability finding confirmed fake-platform risk,CFTC press release 9058-25
+2025-03-21,CFTC announces restitution and penalty,CFTC; Debiex,CFTC announced more than 2.2 million USD restitution and a 221466 USD civil monetary penalty,Remedies followed the no-actual-trading finding,CFTC press release 9058-25

--- a/content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/index.md
+++ b/content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/index.md
@@ -1,0 +1,106 @@
+---
+title: "Debiex Romance Scam and Live Trading Platform Ruse"
+date: 2025-03-21
+entities:
+  - Debiex
+  - Zhang Cheng Yang
+---
+
+## Summary
+
+This case study analyzes Debiex as a market-health warning about fake digital asset trading platforms that mimic live trading interfaces while routing customer assets to misappropriation wallets. On January 19, 2024, the CFTC announced a civil enforcement action against Debiex alleging a romance-scam scheme that misappropriated approximately $2.3 million from about five customers who intended to fund digital asset commodity trading accounts.
+
+On March 21, 2025, the CFTC announced that the U.S. District Court for the District of Arizona had issued a default judgment against Debiex. The order found Debiex liable for fraud in connection with digital asset commodity trading and misappropriating more than $2 million in customer funds. It required more than $2.2 million in restitution and a $221,466 civil monetary penalty.
+
+The market-health problem was a live-platform ruse. The CFTC alleged that Debiex websites mimicked the features of a legitimate live trading platform, while the trading accounts shown on the websites were a complete ruse and no actual digital asset trading took place for customers. That makes Debiex useful for market-health analysis because the false signal was not only a return promise; it was an entire trading-account interface.
+
+The supporting dataset is available in [debiex-summary.csv](debiex-summary.csv).
+
+## Trading Narrative
+
+Debiex can be tested with a website-to-wallet reconciliation. A legitimate digital asset trading platform should map customer deposits to segregated accounts or wallets, trading venue activity, order history, realized P&L, fees, and withdrawals. Debiex allegedly produced the appearance of trading while routing customer assets through wallets used to accept or misappropriate funds.
+
+The CFTC described three functional groups in the alleged scheme. Solicitors contacted customers through at least one U.S.-based social media platform and pretended to befriend or romance them. Customer service personnel purported to set up and service Debiex trading accounts. Money mules, including relief defendant Zhang Cheng Yang, allegedly provided digital asset wallets used by Debiex to accept or misappropriate customer funds.
+
+That role split is a market-health signal. The social relationship created trust, customer service created platform legitimacy, and wallet routing moved assets. A reviewer should not treat any one part as proof of trading. The key check is whether customer assets moved from deposit wallets into actual trading infrastructure and whether account screens matched independent records.
+
+The CFTC's March 2025 release confirmed the most important issue: no actual trading took place on customers' behalf, according to the allegations described in the case background. The default judgment and restitution order do not by themselves recover every customer dollar, but they provide a public regulatory record that the platform-display evidence failed.
+
+## False Market Signals
+
+### Live trading interface
+
+Debiex allegedly operated websites that mimicked legitimate live trading platform features. A live interface is not proof of live markets unless prices, trades, balances, and fills reconcile to independent market venues and wallets.
+
+### Romance-based confidence
+
+Solicitors allegedly cultivated friendly or romantic relationships before customers funded accounts. Relationship trust can make platform due diligence feel unnecessary, but it provides no information about registration, custody, or execution.
+
+### Customer-service onboarding
+
+Customer service allegedly set up and serviced trading accounts. Support responsiveness can create operational credibility while still leaving deposits outside any real trading path.
+
+### Money-mule wallet routing
+
+The CFTC named Zhang as a relief defendant because Debiex allegedly used his digital asset wallet to misappropriate at least one customer's funds. Wallet ownership and control should be traced before accepting that a deposit reached a trading platform.
+
+### Registration gap
+
+The CFTC urged the public to verify registration before committing funds. For market-health review, unverified or missing registration is not only a compliance issue; it is a signal that no regulated intermediary may be supervising customer funds or market activity.
+
+### Restitution uncertainty
+
+The CFTC cautioned that repayment orders may not result in recovered money if wrongdoers lack sufficient assets. A court order can establish liability, but the market-health lesson remains deposit prevention and early wallet tracing.
+
+## Event Timeline
+
+| Date or period        | Event                                                                                    | Market-health signal                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Around March 12, 2022 | CFTC said Debiex domains were created and accessible to U.S. customers.                  | New digital asset domains required registration and custody checks.       |
+| March 2022 onward     | CFTC alleged Debiex accepted and misappropriated customer funds.                         | Deposit wallets needed tracing before account screens were trusted.       |
+| March 2022 onward     | Solicitors allegedly befriended or romanced customers through social media.              | Relationship trust replaced platform verification.                        |
+| March 2022 onward     | Customer service allegedly set up and serviced Debiex accounts.                          | Operational support created apparent platform legitimacy.                 |
+| March 2022 onward     | Money-mule wallets allegedly accepted or misappropriated customer funds.                 | Wallet-control evidence challenged the trading-account story.             |
+| January 17, 2024      | CFTC filed its complaint against Debiex.                                                 | Regulator intervention challenged the platform and trading claims.        |
+| January 19, 2024      | CFTC announced the civil enforcement action.                                             | Public release identified about $2.3 million in alleged misappropriation. |
+| March 12, 2025        | Court ordered remaining assets in Zhang's wallet returned to a customer.                 | Specific wallet assets were tied to victim recovery.                      |
+| March 13, 2025        | Court issued a default judgment against Debiex, according to the CFTC.                   | Liability finding confirmed the regulatory theory.                        |
+| March 21, 2025        | CFTC announced more than $2.2 million restitution and a $221,466 civil monetary penalty. | Restitution and penalty followed the fake-platform finding.               |
+
+## Reconciliation Metrics
+
+| Metric                  | Enforcement-record figure                            | Market-health interpretation                                        |
+| ----------------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
+| Alleged customer loss   | Approximately $2.3 million from about five customers | Small victim count still produced large platform-risk exposure.     |
+| Judgment restitution    | More than $2.2 million                               | Recovery order quantified customer harm.                            |
+| Civil monetary penalty  | $221,466                                             | Court remedy followed fraud liability.                              |
+| Wallet recovery order   | Approximately $120,000 before transfer fees          | Wallet tracing supported partial customer recovery.                 |
+| Claimed activity        | Digital asset commodity trading                      | Needed actual trading records and wallet-to-venue routing.          |
+| CFTC-described reality  | No actual digital asset trading for customers        | Website balances and accounts were not market evidence.             |
+| Functional scheme roles | Solicitors, customer service, and money mules        | Social, operational, and wallet layers should be tested separately. |
+| Public domains          | debiex.com and/or debiex.net identified by CFTC      | Domains required entity, registration, and custody verification.    |
+
+## Detection Checklist
+
+1. Verify platform registration, legal entity, domain ownership, and operating jurisdiction before sending digital assets.
+2. Trace deposit wallet control and movement before accepting a trading-account screen as evidence.
+3. Reconcile live-interface prices and balances to independent trading venues and transaction records.
+4. Treat romance or friendship-based investment invitations as unverified until independently validated.
+5. Separate customer-service responsiveness from evidence of custody, segregation, and execution.
+6. Preserve wallet addresses, transaction hashes, screenshots, and chat records if a platform requests deposits or blocks withdrawals.
+7. Treat money-mule wallet patterns as evidence that funds may be bypassing trading infrastructure.
+8. Preserve legal posture: this article relies on CFTC allegations, court orders, and public regulatory releases.
+
+## Market-Health Lessons
+
+Debiex shows that fake platforms can reproduce the user experience of trading without any trading behind it. The control is to anchor every screen to external evidence: wallet movements, venue statements, order records, and withdrawals. If those records are absent, the platform is presenting claims, not market data.
+
+The case also shows why role mapping matters. A romance solicitor, customer-service operator, and wallet holder can each make the platform feel real while hiding the absence of actual market activity. Reviewers should test the cash path rather than the story path.
+
+Finally, Debiex underlines the value of early wallet preservation. The March 2025 order returning remaining assets from Zhang's wallet shows that specific wallet evidence can matter for recovery. Market-health workflows should capture wallet addresses and transaction hashes as soon as deposits are requested.
+
+## References
+
+- [CFTC press release 8850-24, January 19, 2024](https://www.cftc.gov/PressRoom/PressReleases/8850-24)
+- [CFTC press release 9058-25, March 21, 2025](https://www.cftc.gov/PressRoom/PressReleases/9058-25)
+- [Statement of Commissioner Kristin N. Johnson, January 19, 2024](https://www.cftc.gov/PressRoom/SpeechesTestimony/johnsonstatement011924)


### PR DESCRIPTION
## Summary

/claim #277

Adds a focused Market Health case study on Debiex as a fake digital asset trading platform ruse, including:

- CFTC 2024 complaint and 2025 default-judgment timeline
- live trading interface, romance-solicitor, customer-service, and money-mule wallet signals
- reconciliation metrics for the approximately $2.3M alleged misappropriation and restitution order
- supporting CSV dataset for events and market-health indicators

@marina-chibizova could you review when convenient?

## Validation

- `npx prettier --write --ignore-unknown content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/index.md content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/debiex-summary.csv`
- `npx prettier --check --ignore-unknown content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/index.md content/research/market-health/posts/2025-03-21-debiex-romance-platform-ruse/debiex-summary.csv`
- CSV column-count parse: 9 data rows, 6 columns
- `git diff --cached --check`