### PR TITLE
[codex] Add Blessings Thru Crypto pool case study

### DIFF
--- a/content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/blessings-thru-crypto-summary.csv
+++ b/content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/blessings-thru-crypto-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2022-07,Pool scheme begins,Michael Griffis; Amanda Griffis; Blessings Thru Crypto,CFTC said the pool scheme operated from about July 2022 through January 2023,Pool formation required registration and custody checks,CFTC press release 8757-23
+2022-2023,Participant funds solicited,Blessings Thru Crypto; Blessings of God Thru Crypto,CFTC said over 100 people sent more than 6 million USD to participate,Deposits needed pool-to-platform reconciliation,CFTC press release 8757-23
+2022-2023,Apex trading story promoted,Apex Trading Platform; Coach Wendy,Participants were told funds would trade crypto futures on Apex Trading Platform with Coach Wendy advice,Platform name and adviser required independent proof,CFTC press release 8757-23
+2022-2023,Apex-route funds lost,Apex Trading Platform,CFTC said over 4 million USD purportedly sent to Apex moved to wallets outside defendants control and beyond recovery,Fund flow contradicted represented trading path,CFTC press release 8757-23
+2022-2023,Personal-expense diversion,Michael Griffis; Amanda Griffis,CFTC said about 1 million USD was misappropriated for debts jewelry and an all-terrain vehicle,Personal leakage undermined pool-performance claims,CFTC press release 8757-23
+2022-2023,Ponzi-like payments,Blessings Thru Crypto,CFTC said remaining funds were used for Ponzi-like payments,Payouts needed tracing to realized gains,CFTC press release 8757-23
+2023-07-25,CFTC charges announced,CFTC; Michael Griffis; Amanda Griffis,CFTC charged fraud and failure to register in connection with the commodity pool,Public enforcement challenged safety and trading claims,CFTC press release 8757-23
+2025-09-25,CFTC announces consent order,CFTC; Michael Griffis; Amanda Griffis,CFTC announced 5.528121 million USD restitution and 1.355232 million USD civil monetary penalty,Final relief quantified victim harm and penalties,CFTC press release 9133-25

--- a/content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/index.md
+++ b/content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/index.md
@@ -1,0 +1,108 @@
+---
+title: "Blessings Thru Crypto Pool and Apex Trading Platform Claims"
+date: 2025-09-25
+entities:
+  - Blessings Thru Crypto
+  - Blessings of God Thru Crypto
+  - Apex Trading Platform
+  - Michael Griffis
+  - Amanda Griffis
+---
+
+## Summary
+
+This case study analyzes the Blessings Thru Crypto commodity pool as a market-health warning about relationship-based crypto futures pools that route investor funds away from the represented trading venue. On July 25, 2023, the CFTC charged Tennessee residents Michael and Amanda Griffis with defrauding over 100 people and failing to register with the CFTC in connection with a multi-million dollar commodity pool.
+
+On September 25, 2025, the CFTC announced a consent order against the Griffises. The order required $5,528,121 in restitution and a $1,355,232 civil monetary penalty, totaling more than $6.8 million in monetary relief, and permanently banned the defendants from CFTC-regulated markets and registration.
+
+The market-health problem was a trusted-relationship pool and platform-transfer loop. The CFTC said the Griffises used real estate connections, including clients, to solicit funds for a pool called Blessings Thru Crypto or Blessings of God Thru Crypto. Participants were allegedly told their funds would be safe and used to trade crypto futures on Apex Trading Platform with advice from a person identified as Coach Wendy. Instead, the CFTC said funds purportedly sent to Apex were transferred to wallets outside the Griffises' control and became unrecoverable, while other funds were used for personal expenses and Ponzi-like payments.
+
+The supporting dataset is available in [blessings-thru-crypto-summary.csv](blessings-thru-crypto-summary.csv).
+
+## Trading Narrative
+
+Blessings Thru Crypto can be evaluated with a pool-to-platform reconciliation. A commodity pool that claims to trade digital asset futures should connect participant deposits to pool accounts, registered operators, futures commission merchant records, exchange positions, margin, realized P&L, fees, withdrawals, and custody controls. A named trading platform and a coach are not enough.
+
+The CFTC's July 2023 release said the Griffises had no trading or other relevant experience but convinced over 100 people to send more than $6 million to the pool. The solicitation relied on personal and professional relationships developed through their real estate business. That relationship channel is a market-health issue because trust in the solicitor can substitute for proof of trading skill, registration, and custody.
+
+The represented trading path centered on crypto futures through Apex Trading Platform. The CFTC said over $4 million in pool funds purportedly sent to Apex were instead quickly transferred to digital wallets outside the Griffises' control and were beyond recovery. That is the core reconciliation failure: the platform name did not prove the funds were held, margined, or traded for participants.
+
+The remaining fund use also contradicted market-generated performance. The CFTC said the Griffises misappropriated approximately $1 million to pay debts and buy items including jewelry and an all-terrain vehicle, and used the remainder for Ponzi-like payments to keep the scheme going. That means participant distributions could not be presumed to come from crypto futures gains.
+
+## False Market Signals
+
+### Safe crypto futures pool
+
+Participants were allegedly told pool funds would be safe. Digital asset futures trading involves leverage, margin, volatility, liquidation risk, and operational risk. Safety claims require custody proof, risk limits, registration checks, and loss disclosure.
+
+### Trusted real estate network
+
+The Griffises allegedly used client and colleague relationships from their real estate business. A trusted local business relationship does not verify commodity pool registration, trading experience, or exchange custody.
+
+### Apex Trading Platform routing
+
+Funds were allegedly represented as going to Apex Trading Platform for crypto futures trading. A platform name should be verified through account statements, exchange records, wallet flows, and who controls the destination wallets.
+
+### Coach Wendy authority
+
+The advice of an unnamed coach was allegedly used to support the trading story. Anonymous or partially identified advisers cannot replace verifiable trading credentials, account control, and risk records.
+
+### Ponzi-like payments
+
+The CFTC said remaining funds were used for Ponzi-like payments. Payouts can make a pool look profitable while hiding the absence of realized market gains.
+
+### Personal-expense leakage
+
+The alleged use of approximately $1 million for debts, jewelry, and an all-terrain vehicle is a fund-use signal. Pool expenses and personal expenses must be separated from trading P&L.
+
+## Event Timeline
+
+| Date or period            | Event                                                                             | Market-health signal                                                    |
+| ------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| July 2022                 | CFTC said the commodity pool scheme began around July 2022.                       | Pool formation required registration and custody checks.                |
+| July 2022 to January 2023 | Participants sent funds to Blessings Thru Crypto or Blessings of God Thru Crypto. | Deposits needed pool-to-platform reconciliation.                        |
+| July 2022 to January 2023 | Participants were told funds would trade crypto futures on Apex Trading Platform. | Platform name needed independent account and trading proof.             |
+| July 2022 to January 2023 | Over $4 million was allegedly transferred to wallets outside defendants' control. | Fund flow contradicted the represented trading path.                    |
+| July 2022 to January 2023 | About $1 million was allegedly used for debts and personal purchases.             | Personal leakage undermined pool-performance claims.                    |
+| July 25, 2023             | CFTC announced charges against Michael and Amanda Griffis.                        | Public enforcement challenged safety, trading, and registration claims. |
+| September 22, 2025        | Court entered the consent order, according to the CFTC order PDF date.            | Resolution imposed restitution, penalty, and market bans.               |
+| September 25, 2025        | CFTC announced over $5.5 million restitution and $1.35 million civil penalty.     | Final monetary relief quantified victim harm.                           |
+
+## Reconciliation Metrics
+
+| Metric                       | Enforcement-record figure                                          | Market-health interpretation                                            |
+| ---------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Initial alleged pool scale   | Over $6 million from over 100 people                               | Large trusted-network pool required formal controls.                    |
+| Consent-order restitution    | $5,528,121                                                         | Victim harm remained after enforcement resolution.                      |
+| Civil monetary penalty       | $1,355,232                                                         | Monetary relief exceeded $6.8 million in total.                         |
+| Funds allegedly sent to Apex | Over $4 million                                                    | Platform routing needed wallet and account proof.                       |
+| Apex-route outcome           | Funds moved to wallets outside defendants' control and unrecovered | Named platform did not equal recoverable trading custody.               |
+| Personal-expense diversion   | Approximately $1 million                                           | Pool funds were not confined to trading use.                            |
+| Participant payout source    | Ponzi-like payments alleged                                        | Payouts needed tracing to realized gains rather than participant funds. |
+| Registration finding         | CFTC alleged failure to register                                   | Pool operation lacked the represented regulatory controls.              |
+
+## Detection Checklist
+
+1. Verify commodity pool operator, commodity trading advisor, and intermediary registration before pooling funds for crypto futures.
+2. Reconcile participant deposits to pool accounts, futures commission merchant records, exchange positions, margin, fees, and realized P&L.
+3. Confirm who controls every wallet or account presented as the trading-platform destination.
+4. Separate distributions from realized trading gains; do not infer profitability from payouts alone.
+5. Treat unnamed coaches or advisers as unverified until identity, authority, and track record are documented.
+6. Review personal and business relationships as potential trust channels, not as trading evidence.
+7. Compare pool expenses with disclosed operating terms and prohibit personal-expense leakage.
+8. Preserve legal posture: this article relies on CFTC allegations, consent-order descriptions, and public enforcement releases.
+
+## Market-Health Lessons
+
+Blessings Thru Crypto shows how a trusted local network can make a crypto futures pool look safer than its trading and custody controls justify. The first market-health control is not return analysis; it is fund-path analysis. Deposits should reconcile to controlled pool accounts and regulated trading records before any performance claim is credited.
+
+The Apex Trading Platform story is the central warning. A named platform can sound concrete while still failing the wallet-control test. If funds move to wallets outside the pool operators' control and become unrecoverable, platform branding is not evidence of custody or trading.
+
+The case also shows why payouts are weak proof. Ponzi-like payments can mimic trading returns until new inflows slow or asset recovery fails. Pool reviewers should test the source of each distribution and match it to realized crypto futures gains, not participant capital.
+
+## References
+
+- [CFTC press release 8757-23, July 25, 2023](https://www.cftc.gov/PressRoom/PressReleases/8757-23)
+- [CFTC press release 9133-25, September 25, 2025](https://www.cftc.gov/PressRoom/PressReleases/9133-25)
+- [CFTC complaint against Michael and Amanda Griffis](https://www.cftc.gov/media/8996/enfmichaelgriffiscomplaint072423/download)
+- [CFTC consent order against Michael and Amanda Griffis](https://www.cftc.gov/media/12721/enfGriffisConsentOrder092225/download)


### PR DESCRIPTION
## Summary

/claim #277

Adds a focused Market Health case study on the Blessings Thru Crypto / Blessings of God Thru Crypto commodity pool, including:

- CFTC July 2023 charge and September 2025 consent-order timeline
- Apex Trading Platform routing, Coach Wendy authority, trusted-network solicitation, personal-expense diversion, and Ponzi-like payout signals
- reconciliation metrics for over $6M solicited, over $4M allegedly routed away, $5.5M restitution, and $1.35M penalty
- supporting CSV dataset for events and market-health indicators

@marina-chibizova could you review when convenient?

## Validation

- `npx prettier --write --ignore-unknown content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/index.md content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/blessings-thru-crypto-summary.csv`
- `npx prettier --check --ignore-unknown content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/index.md content/research/market-health/posts/2025-09-25-blessings-thru-crypto-pool/blessings-thru-crypto-summary.csv`
- CSV column-count parse: 8 data rows, 6 columns
- `git diff --cached --check`