### PR TITLE
[codex] Add Vista robot traders digital asset article

### DIFF
--- a/content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/index.md
+++ b/content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/index.md
@@ -1,0 +1,112 @@
+---
+title: "Vista Robot Traders Digital Asset Return Claims"
+date: 2023-02-16
+entities:
+  - Vista Network Technologies
+  - Vista
+  - Armen Temurian
+  - Bitcoin
+  - Ether
+---
+
+## Summary
+
+This case study analyzes Vista Network Technologies as a market-health warning about digital-asset platforms that market automated trading systems without a matching execution record. On February 16, 2023, the CFTC announced charges against Vista, a California-based company, and its CEO, Armen Temurian, for fraudulent solicitation and misappropriation of customers' digital asset commodities. The CFTC said the complaint alleged more than $7 million worth of bitcoin and ether was solicited from customers and that a portion of those assets was misappropriated in a Ponzi-like scheme.
+
+The central market claim was simple: Vista allegedly told retail investors that it would trade their bitcoin and ether with automated "Robot Traders" and generate a daily return. The CFTC complaint alleged that Vista never traded customer assets and did not have any trading program capable of generating the promised returns. Commissioner Kristin Johnson's public statement said investors transferred more than 750 bitcoin and 2,000 ether, worth more than $7 million at the time, and that the defendants never traded a single entrusted digital asset.
+
+For market-health review, Vista is useful because the alleged scheme can be tested with standard controls: wallet inflows, wallet outflows, claimed algorithmic strategy, realized trading records, and investor-payout timing. If an automated trading platform is real, deposits should move into trading venues or custody arrangements that can be reconciled to trades. If assets instead move to earlier investors or unrelated wallets, the return story is not market performance.
+
+The supporting dataset is available in [vista-summary.csv](vista-summary.csv).
+
+## Trading Narrative
+
+The CFTC complaint said Vista launched a website in August 2017 and used a downloadable PowerPoint in multiple languages to describe the opportunity. The materials allegedly promoted doubling bitcoin and ether within 80 days, a 2.5 percent daily return, and automated trading that would share earnings with investors' wallets. The same complaint said Temurian personally marketed Vista to investors in the United States and abroad, including at Vista's Glendale, California offices.
+
+Vista's trading narrative depended on three linked assertions: customer bitcoin and ether would be transferred to Vista-controlled wallets, automated systems would trade those assets, and profits would be returned to customers on a fixed daily schedule. Each assertion creates a testable market-health requirement. The platform should be able to identify trading venues, strategy capacity, realized P&L, fees, loss days, wallet custody, and customer-level allocation logic.
+
+The CFTC alleged the opposite. Vista and Temurian allegedly collected more than 750 bitcoin and more than 2,000 ether from investors during the September 2017 to January 2018 period, including assets from hundreds of U.S.-based investors. The complaint said Vista's transaction records and public blockchain information showed characteristics of a Ponzi scheme: new investor assets were used to make payments to earlier investors, while many later investors did not receive their promised gains or full principal.
+
+The follow-on mini-miner offer is also relevant. The complaint said that in early 2018, after some investors questioned why promised returns were not appearing, Vista offered a product that supposedly could mine digital assets from users' homes. The complaint alleged this too was false. For market-health review, this is a common pivot: when a trading story cannot be reconciled, the operator introduces a new technical product to keep customers engaged.
+
+## False Market Signals
+
+### Automated trading claim
+
+Automated trading language can make a return promise sound like technology rather than investment risk. Reviewers should require evidence of the trading program, venue connectivity, order logs, fills, wallet transfers into venues, and realized P&L.
+
+### Fixed daily return
+
+A daily return schedule is not proof of trading. It should be compared with daily market volatility, strategy drawdown, trade logs, and the timing of new investor deposits.
+
+### Wallet inflow scale
+
+The complaint alleged more than 750 bitcoin and 2,000 ether entered Vista-controlled wallets. Large wallet inflows make blockchain tracing possible, but they do not prove trading unless outflows connect to venues, custodians, or audited accounts.
+
+### Network marketing distribution
+
+The complaint described individual marketers using Vista materials to recruit investors. Network marketing can expand deposit inflows quickly while separating customers from direct operational proof.
+
+### Reworded return language
+
+The complaint said Temurian later discussed moving away from fixed-return language and making daily benefits variable. Changing terminology does not repair a missing execution record.
+
+### Mini-miner pivot
+
+When promised trading returns were challenged, Vista allegedly introduced a mini-miner product. A new product claim should be tested separately rather than treated as a recovery path for earlier losses.
+
+## Event Timeline
+
+| Date or period      | Event                                                                                      | Market-health signal                                             |
+| ------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Mid-2017            | Temurian co-founded Vista, according to the CFTC complaint.                                | Founder and entity controls needed registration review.          |
+| August 2017         | Vista launched `vista.network`, according to the CFTC complaint.                           | Website claims became the primary solicitation surface.          |
+| September 2017      | Relevant solicitation period began, according to the CFTC complaint.                       | Customer wallet inflows needed immediate custody tracing.        |
+| September 2017-2018 | Investors transferred more than 750 bitcoin and 2,000 ether to Vista-controlled wallets.   | Deposit scale required blockchain and trade-record matching.     |
+| Late 2017           | Temurian allegedly marketed Vista directly and through network marketers.                  | Recruiting channels needed separation from proof of performance. |
+| January 2018        | Temurian allegedly discussed replacing fixed-return language with variable daily benefits. | Language changes did not substitute for execution records.       |
+| Early 2018          | Vista allegedly promoted a mini-miner product after investors questioned missing returns.  | Product pivot required independent technical verification.       |
+| February 15, 2023   | CFTC filed its complaint in the Eastern District of New York.                              | Enforcement record challenged the trading and mining claims.     |
+| February 16, 2023   | CFTC announced charges against Vista and Temurian.                                         | Public case converted wallet and marketing facts into claims.    |
+
+## Reconciliation Metrics
+
+| Metric                  | Enforcement-record figure or claim                            | Market-health interpretation                                          |
+| ----------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Solicitation period     | At least September 2017 through January 2018                  | A short period can still produce large inflows when returns are high. |
+| Assets solicited        | More than $7 million worth of bitcoin and ether               | Value scale required custody and trading venue reconciliation.        |
+| Bitcoin transferred     | More than 750 BTC                                             | Wallet-level tracing should identify trading versus payout flows.     |
+| Ether transferred       | More than 2,000 ETH                                           | Ether custody should reconcile to customer allocations and outflows.  |
+| U.S. investor bitcoin   | About 165 BTC from U.S.-based investors                       | Domestic investor exposure supported regulatory focus.                |
+| U.S. investor ether     | About 800 ETH from U.S.-based investors                       | U.S. flows needed customer-level accounting.                          |
+| Promised daily return   | 2.5 percent daily, according to CFTC allegations              | Fixed returns required strategy and drawdown proof.                   |
+| Promised outcome        | Digital assets would double within 80 days, according to CFTC | Doubling claims needed realized trade evidence.                       |
+| Claimed trading engine  | Automated robot traders                                       | Algorithm claims needed order logs and venue records.                 |
+| Trading record alleged  | CFTC alleged Vista never traded customer digital assets       | No-trade finding breaks the return narrative.                         |
+| Payout pattern alleged  | New investor assets were used to pay earlier investors        | Return payments could be funded by deposits rather than trading.      |
+| Follow-on product claim | Mini-miner that could mine digital assets from home           | Product pivots require separate proof of capability and delivery.     |
+
+## Detection Checklist
+
+1. Require exchange, broker, custodian, or wallet evidence for every claimed automated trading program.
+2. Compare fixed daily returns with realized trade logs, market volatility, fees, and loss days.
+3. Trace wallet deposits to trading venues rather than assuming that wallet inflows are trading capital.
+4. Test investor payouts against new deposit timing to identify circular funding.
+5. Review network-marketer materials separately from operator materials because both can contain performance claims.
+6. Treat changes from fixed-return language to variable-return language as a risk event, not a cure.
+7. Verify new recovery products, such as mining devices, independently from the original trading claim.
+8. Preserve legal posture: this article relies on CFTC allegations and public CFTC statements.
+
+## Market-Health Lessons
+
+Vista shows why "algorithmic" and "robot" language should not reduce due diligence. A bot claim is only useful if it can be tied to code ownership, exchange connectivity, order history, fills, custody, and risk controls. Without those records, the automation claim is a marketing wrapper.
+
+The case also shows how blockchain visibility can help separate trading from redistribution. Wallet inflows alone do not prove market activity. The relevant question is what happens after assets enter platform-controlled wallets: whether they move to trading venues, sit idle, pay older investors, or leave the customer ledger entirely.
+
+Finally, a product pivot can be a warning sign. When a platform that promised digital-asset trading later offers a mining device to address customer concerns, reviewers should not let the new story carry forward trust from the old one. Each claim needs its own operational proof.
+
+## References
+
+- [CFTC press release 8660-23, February 16, 2023](https://www.cftc.gov/PressRoom/PressReleases/8660-23)
+- [CFTC complaint against Armen Temurian and Vista Network Technologies, February 15, 2023](https://www.cftc.gov/media/8181/enftemuriancomplaint021523/download)
+- [Statement of Commissioner Kristin N. Johnson, February 16, 2023](https://www.cftc.gov/PressRoom/SpeechesTestimony/johnsonstatement021623)

--- a/content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/vista-summary.csv
+++ b/content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/vista-summary.csv
@@ -1,0 +1,14 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2017,Vista founded,Vista Network Technologies; Armen Temurian,CFTC complaint said Temurian co-founded Vista in mid-2017,Founder and entity controls needed registration review,CFTC complaint
+2017-08,Website launched,Vista; vista.network,CFTC complaint said Vista launched its website by August 2017,Website claims became the primary solicitation surface,CFTC complaint
+2017-09,Relevant solicitation period begins,Vista; Armen Temurian,CFTC alleged Vista began soliciting investors for the digital asset commodity scheme by September 2017,Customer wallet inflows needed custody tracing,CFTC complaint
+2017-09 to 2018-01,Digital asset deposits collected,Vista; Bitcoin; Ether,CFTC alleged investors transferred more than 750 BTC and more than 2000 ETH to Vista-controlled wallets,Deposit scale required blockchain and trade-record matching,CFTC complaint
+2017-09 to 2018-01,U.S. investor deposits collected,Vista; U.S.-based investors,CFTC alleged about 165 BTC and 800 ETH came from U.S.-based investors,U.S. flows needed customer-level accounting,CFTC complaint
+2017,Automated trading return marketed,Vista; Robot Traders,CFTC alleged Vista promised automated trading and a 2.5 percent daily return,Algorithm claims needed order logs and venue records,CFTC complaint
+2017,Investor-doubling claim marketed,Vista; Bitcoin; Ether,CFTC alleged Vista claimed bitcoin and ether could double within 80 days,Doubling claims needed realized trading evidence,CFTC complaint
+2017-12,Network marketing video used,Vista; Armen Temurian; Network Marketer A,CFTC complaint described a December 2017 marketing video using Vista materials and daily-return claims,Recruiting channels needed separation from proof of performance,CFTC complaint
+2018-01,Return language changed,Vista; Armen Temurian,CFTC complaint said Temurian discussed replacing fixed-return wording with variable daily benefits,Language changes did not substitute for execution records,CFTC complaint
+2018,Mini-miner product promoted,Vista; VistaLive; mini-miner,CFTC alleged Vista offered a mini-miner product after some investors questioned missing returns,Product pivot required independent technical verification,CFTC complaint
+2022-09-06,Under-oath testimony,Vista; Armen Temurian,CFTC complaint said Temurian admitted Vista never traded for customers,No-trade admission broke the trading-return narrative,CFTC complaint
+2023-02-15,CFTC complaint filed,CFTC; Vista; Armen Temurian,CFTC filed complaint alleging fraud and misappropriation involving bitcoin and ether,Public enforcement challenged the trading and mining claims,CFTC complaint
+2023-02-16,CFTC charges announced,CFTC; Vista; Armen Temurian,CFTC announced charges alleging over 7 million USD worth of customer bitcoin and ether was solicited,Public release summarized investor harm and requested remedies,CFTC press release 8660-23


### PR DESCRIPTION
## Summary

/claim #277

Adds a single Market Health article on Vista Network Technologies and the alleged “Robot Traders” digital-asset return claims. The article focuses on wallet inflow scale, automated trading assertions, fixed daily returns, network marketing distribution, and reconciliation controls for separating trading from redistribution.

The PR includes:

- `content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/index.md`
- `content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/vista-summary.csv`

## Validation

- `npx prettier --write content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/index.md`
- `npx prettier --check content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/index.md`
- `ruby -rcsv -e 'rows = CSV.read(ARGV[0], headers: true); abort "no rows" if rows.empty?; widths = rows.map { |r| r.fields.size }.uniq; abort "bad widths #{widths.inspect}" unless widths == [rows.headers.size]; puts "csv ok: #{rows.size} rows, #{rows.headers.size} columns"' content/research/market-health/posts/2023-02-16-vista-robot-traders-digital-asset-claims/vista-summary.csv`\n- `git diff --check`\n\n@marina-chibizova could you review this submission for #277?\n