### PR TITLE
[codex] Add Ichioka Ventures forex and digital asset article

### DIFF
--- a/content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/ichioka-summary.csv
+++ b/content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/ichioka-summary.csv
@@ -1,0 +1,10 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2018,Scheme begins,William Koo Ichioka; Ichioka Ventures,CFTC said the fraudulent scheme began in 2018,Performance records needed reconstruction from first deposits,CFTC press release 8970-24
+2019-08,Ichioka Ventures LLC formed,Ichioka Ventures LLC; William Koo Ichioka,CFTC complaint said Ichioka Ventures LLC was formed in August 2019,Entity formation needed registration and pool-structure review,CFTC complaint
+2018 to 2022-05,Participants solicited,Ichioka Ventures; pool participants,CFTC alleged solicitation of more than 100 individuals and entities,Participant count required formal ledgers and custody controls,CFTC complaint
+2018 to 2022-05,Return claim promoted,Ichioka Ventures,CFTC said website described 30 business day term with 10 percent return,Fixed short-period returns needed realized-P&L support,CFTC press release 8727-23
+2023-06-22,CFTC complaint filed,CFTC; William Koo Ichioka,CFTC charged Ichioka with soliciting and misappropriating more than 21 million USD,Public enforcement challenged return and fund-use claims,CFTC press release 8727-23
+2023-08-14,Initial consent order entered,William Koo Ichioka; CFTC,CFTC said court entered permanent injunction trading ban and registration ban,Order restricted future market access,CFTC press release 8970-24
+2024-09-19,Supplemental monetary order entered,William Koo Ichioka,Court ordered 31330715.86 USD restitution and 5000000 USD civil monetary penalty,Final monetary relief quantified restitution and penalty,CFTC supplemental consent order
+2024-09-20,CFTC announces final civil monetary relief,CFTC; William Koo Ichioka,CFTC announced more than 36 million USD in monetary relief,Final civil resolution fixed market-harm measurement,CFTC press release 8970-24
+2024,Criminal sentence referenced,William Koo Ichioka,CFTC release said Ichioka was sentenced to 48 months in prison and 5 years supervised release,Parallel criminal case confirmed misconduct severity,CFTC press release 8970-24

--- a/content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/index.md
+++ b/content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/index.md
@@ -1,0 +1,113 @@
+---
+title: "Ichioka Ventures Forex and Digital Asset Return Claims"
+date: 2024-09-20
+entities:
+  - William Koo Ichioka
+  - Ichioka Ventures
+  - Ichioka Ventures LLC
+  - Bitcoin
+  - Ether
+---
+
+## Summary
+
+This case study analyzes Ichioka Ventures as a market-health warning about commodity pools that promise high short-period returns while commingling participant funds, overstating account values, and using false statements to preserve confidence. On September 20, 2024, the CFTC announced that the U.S. District Court for the Northern District of California entered an order assessing more than $36 million in monetary relief against William Koo Ichioka.
+
+The order required $31,330,715.86 in restitution and a $5 million civil monetary penalty. The CFTC said an earlier consent order found that Ichioka engaged in a fraudulent scheme beginning in 2018, accepted investment funds with false claims of a 10 percent return every 30 business days, commingled participant money with his own funds, used participant money for personal expenses, and concealed the conduct with false financial documents and false account statements.
+
+For market-health review, Ichioka Ventures is useful because the advertised performance had a precise cadence. A 10 percent return every 30 business days can be reconciled against actual trading, cash flows, account statements, participant inflows, withdrawals, fees, and personal spending. When account statements are false or funds are commingled, the performance record becomes an artifact of reporting rather than market activity.
+
+The supporting dataset is available in [ichioka-summary.csv](ichioka-summary.csv).
+
+## Trading Narrative
+
+The CFTC's June 2023 release said Ichioka operated a commodity-interest pool under the name Ichioka Ventures and solicited more than $21 million from more than 100 participants. The investment story involved digital asset commodities, including bitcoin and ether, along with forex transactions. The website allegedly described the investment term as 30 business days with a 10 percent return and represented that funds could be withdrawn or reinvested.
+
+The September 2024 release added the final monetary relief and sharpened the market-health lesson. Although Ichioka invested some funds in forex and digital asset commodities, the CFTC said he commingled participant money with his own funds and used participant money for personal expenses such as rent, jewelry, watches, and luxury vehicles. A real commodity pool must separate pool property, trading accounts, participant ledgers, manager compensation, and personal spending.
+
+The false-document control is central. The CFTC said Ichioka overstated asset values by generating false financial documents and presenting false account statements to participants. In market-health terms, a statement is not evidence unless it reconciles to custodian records, bank records, exchange accounts, and transaction history.
+
+The final order also shows why restitution figures can exceed the initial civil filing figure. The June 2023 release described more than $21 million misappropriated from more than 100 participants, while the September 2024 monetary order required more than $31 million in restitution. Harm measurement can expand as criminal restitution schedules, interest, and participant-loss accounting mature.
+
+## False Market Signals
+
+### Ten percent every 30 business days
+
+A short-period fixed return should be reconciled to realized trading performance. Without trade records and loss history, the promise is a solicitation claim, not a market result.
+
+### Withdraw or reinvest framing
+
+Easy withdrawal and reinvestment language can reduce perceived liquidity risk. Reviewers should compare withdrawal claims with actual cash, asset custody, and redemption history.
+
+### False account statements
+
+Account statements are only reliable if they match independent custodian, bank, and venue records. Internally generated statements can conceal losses or personal use.
+
+### Commingled pool and personal funds
+
+Commingling breaks the audit trail from participant contributions to trades. A commodity pool needs separate pool accounts and clear manager-compensation rules.
+
+### Personal luxury spending
+
+Spending pool assets on personal rent, jewelry, watches, or vehicles indicates that participant funds may be funding lifestyle rather than trading.
+
+### Parallel criminal resolution
+
+The criminal sentence and restitution order provide independent confirmation that the conduct was not only a civil compliance failure. Market-health review should track parallel actions when measuring harm.
+
+## Event Timeline
+
+| Date or period     | Event                                                                                   | Market-health signal                                            |
+| ------------------ | --------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| 2018               | CFTC said the fraudulent scheme began.                                                  | Performance records needed reconstruction from first deposits.  |
+| August 2019        | Ichioka Ventures LLC was formed, according to the CFTC complaint.                       | Entity formation needed registration and pool-structure review. |
+| 2018-May 2022      | Complaint alleged solicitation of more than 100 participants.                           | Participant count required formal ledgers and custody controls. |
+| 2018-May 2022      | Ichioka allegedly promised 10 percent returns every 30 business days.                   | Fixed short-period returns needed realized-P&L support.         |
+| June 22, 2023      | CFTC filed its complaint and announced the initial consent-order path.                  | Public enforcement challenged the return and fund-use claims.   |
+| August 14, 2023    | Court entered an initial consent order and permanent injunction, according to the CFTC. | Trading and registration bans addressed future market access.   |
+| September 19, 2024 | Court entered the supplemental monetary order.                                          | Final monetary relief quantified restitution and penalty.       |
+| September 20, 2024 | CFTC announced more than $36 million in total monetary relief.                          | Final civil resolution fixed the market-harm measurement.       |
+
+## Reconciliation Metrics
+
+| Metric                   | Enforcement-record figure or claim                         | Market-health interpretation                                      |
+| ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| Participants             | More than 100 individuals and entities                     | Pool scale required customer-level ledgers and custody controls.  |
+| Initial misappropriation | More than $21 million                                      | Deposits needed tracing to trades, redemptions, and personal use. |
+| Restitution obligation   | $31,330,715.86                                             | Final loss accounting exceeded initial civil filing figure.       |
+| Civil monetary penalty   | $5,000,000                                                 | Penalty reflected deterrence beyond victim restitution.           |
+| Total monetary relief    | More than $36 million                                      | Combined sanctions measured final civil exposure.                 |
+| Promised return          | 10 percent every 30 business days                          | Short-period fixed returns required realized performance proof.   |
+| Claimed markets          | Forex, bitcoin, ether, and other digital asset commodities | Multi-market claim required venue-specific records.               |
+| Commingling finding      | Participant money commingled with personal funds           | Pool accounting separation failed.                                |
+| Concealment method       | False financial documents and false account statements     | Statements required third-party verification.                     |
+| Personal-use categories  | Rent, jewelry, watches, luxury vehicles                    | Spending categories contradicted pool-purpose claims.             |
+| Criminal sentence        | 48 months in prison and 5 years supervised release         | Parallel criminal action confirmed misconduct severity.           |
+| Criminal restitution     | $31,330,715.86                                             | Criminal and CFTC restitution figures aligned.                    |
+
+## Detection Checklist
+
+1. Reconcile every promised 30-business-day return to realized trades, account balances, and participant allocations.
+2. Verify pool bank and trading accounts are separate from manager personal accounts.
+3. Match internal account statements to custodian, exchange, and bank records before treating them as performance evidence.
+4. Trace manager personal spending against pool deposits and authorized compensation.
+5. Compare advertised redemption terms with actual liquidity, cash balances, and withdrawal history.
+6. Confirm CPO and associated registration status before accepting funds for forex or digital asset commodity trading.
+7. Track parallel criminal and SEC actions because they can update loss amounts and final remedies.
+8. Preserve legal posture: this article relies on CFTC orders, CFTC release language, and public court records.
+
+## Market-Health Lessons
+
+Ichioka Ventures shows how a precise return schedule can create false confidence. The more specific the return promise, the easier it is to test: a reviewer can ask for the trading records and cash movements that produced each 30-business-day result.
+
+The case also shows why commingling is a market-health failure, not just an accounting issue. Once participant funds and personal funds share the same path, reported performance can no longer be trusted without a full reconstruction of deposits, trades, withdrawals, and personal expenditures.
+
+Finally, final monetary relief matters because it reflects harm measurement after the record matures. The $31.33 million restitution figure is a better market-health scale marker than the initial solicitation headline alone.
+
+## References
+
+- [CFTC press release 8970-24, September 20, 2024](https://www.cftc.gov/PressRoom/PressReleases/8970-24)
+- [CFTC press release 8727-23, June 22, 2023](https://www.cftc.gov/PressRoom/PressReleases/8727-23)
+- [CFTC complaint against William Koo Ichioka, June 22, 2023](https://www.cftc.gov/media/8796/enfichiokacomplaint062323/download)
+- [CFTC supplemental consent order assessing restitution and civil monetary penalty, September 19, 2024](https://www.cftc.gov/media/11296/enfwilliamkooichiokaorder091924/download)
+- [CFTC consent order for permanent injunction, August 14, 2023](https://www.cftc.gov/media/11306/enfwilliamkooichiokaconsentorder081323/download)


### PR DESCRIPTION
## Summary

/claim #277

Adds a single Market Health article on Ichioka Ventures and the 10% every 30 business days forex/digital asset return claims. The article uses the final CFTC monetary-relief order and focuses on commingling, false account statements, personal-use spending, and reconciliation controls for short-period return promises.

The PR includes:

- `content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/index.md`
- `content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/ichioka-summary.csv`

## Validation

- `npx prettier --write content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/index.md`
- `npx prettier --check content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/index.md`
- `ruby -rcsv -e 'rows = CSV.read(ARGV[0], headers: true); abort "no rows" if rows.empty?; widths = rows.map { |r| r.fields.size }.uniq; abort "bad widths #{widths.inspect}" unless widths == [rows.headers.size]; puts "csv ok: #{rows.size} rows, #{rows.headers.size} columns"' content/research/market-health/posts/2024-09-20-ichioka-ventures-forex-digital-asset-claims/ichioka-summary.csv`\n- `git diff --check`\n\n@marina-chibizova could you review this submission for #277?\n