### PR TITLE
[codex] Add Tinoco and Kikit forex crypto article

### DIFF
--- a/content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/index.md
+++ b/content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/index.md
@@ -1,0 +1,111 @@
+---
+title: "Tinoco and Kikit Forex and Cryptocurrency Profit Claims"
+date: 2024-07-26
+entities:
+  - Abner Alejandro Tinoco
+  - Kikit & Mess Investments LLC
+  - Kikit & Mess
+---
+
+## Summary
+
+This case study analyzes the Tinoco and Kikit & Mess Investments fraud as a market-health warning about managed-portfolio claims that report investment profits while customer money is used for personal spending and circular payouts. On July 26, 2024, the CFTC announced that the U.S. District Court for the Western District of Texas entered an order assessing more than $31 million in monetary relief against Abner Alejandro Tinoco and Kikit & Mess Investments, LLC.
+
+The July 9, 2024 order required $6,203,792.18 in restitution to 199 defrauded victims, $6,257,904.89 in disgorgement, and an $18,773,714 civil monetary penalty. The CFTC said an earlier consent order found that Tinoco and Kikit accepted more than $7.2 million from clients in a scheme beginning in September 2020, paid bogus investment profits to other clients, and did not invest client funds as represented.
+
+For market-health review, this case is useful because the failure was not just a missing registration. The CFTC said client funds were supposed to be managed in customized portfolios for forex and cryptocurrency trading, but the funds instead paid Tinoco's personal expenses, including private-jet travel, a luxury mansion, real estate, and luxury vehicles. A managed-portfolio story should collapse quickly if bank records, trading records, and customer-profit statements do not reconcile.
+
+The supporting dataset is available in [tinoco-kikit-summary.csv](tinoco-kikit-summary.csv).
+
+## Trading Narrative
+
+The CFTC's October 2021 release said Tinoco and Kikit solicited clients through several channels, including Kikit's website, to manage customized client portfolios in forex and cryptocurrencies. The initial enforcement release alleged more than $3.9 million from at least 61 clients. By the final monetary order, the receiver identified 199 claimants and the CFTC described more than $7.2 million of accepted investment funds.
+
+The marketed performance depended on reported profits. According to the CFTC's July 2024 release, the initial consent order found defendants paid bogus investment profits to other clients in a Ponzi-like manner. That makes the key market-health question the source of every reported profit: actual trading gains, new customer deposits, or diverted customer principal.
+
+The spending pattern contradicted the trading story. The CFTC said the order found the defendants did not invest client funds as represented and used those funds for Tinoco's personal expenses, including private-jet travel costs, a luxury mansion, other real estate, and luxury automobiles. A managed-account operator should be able to show segregated client accounts, broker or exchange statements, trade records, fee calculations, and authorized withdrawals.
+
+The criminal action added another reconciliation layer. The CFTC release said Tinoco pleaded guilty to wire-fraud charges, was sentenced to 84 months in prison and three years of supervised release, and was ordered to pay $9,023,695.77 in restitution. Parallel criminal restitution can expose a broader harm figure than a single civil restitution schedule.
+
+## False Market Signals
+
+### Customized portfolio language
+
+Customized portfolio language can suggest individualized risk management. Reviewers should verify that customer funds were actually allocated to trading accounts and strategies tied to each client.
+
+### Reported investment profits
+
+Reported profits are not performance unless reconciled to trade records. If profit payments come from later customer deposits, they are payout mechanics rather than market returns.
+
+### Website solicitation
+
+A website can make a managed-account program appear established. Domain content and online claims should be matched to entity registration, trading accounts, and customer agreements.
+
+### Luxury asset spending
+
+Private-jet travel, mansion expenses, real estate, and luxury vehicles are not trading costs. Personal spending should be traced against investor deposits and authorized compensation.
+
+### Receiver claimant schedule
+
+The final order's 199-claimant restitution schedule shows why customer-level accounting matters. Each claimant balance required receiver reconstruction rather than relying on platform records alone.
+
+### Parallel criminal restitution
+
+The criminal restitution amount exceeded the CFTC civil restitution figure. Market-health analysis should track both because they can measure harm under different proceedings.
+
+## Event Timeline
+
+| Date or period    | Event                                                                                         | Market-health signal                                           |
+| ----------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| September 2020    | Fraudulent scheme began, according to the CFTC's final-order release.                         | Trading and payout records needed reconstruction from launch.  |
+| 2020-2021         | Defendants solicited clients for purported customized forex and cryptocurrency portfolios.    | Managed-portfolio claims needed account-level evidence.        |
+| September 2021    | CFTC filed its civil enforcement action.                                                      | Public enforcement challenged the trading narrative.           |
+| October 13, 2021  | Court entered an asset freeze, record-preservation order, and temporary receiver appointment. | Emergency relief preserved evidence and customer funds.        |
+| October 20, 2021  | CFTC announced charges alleging more than $3.9 million misappropriated.                       | Initial public claim quantified early known harm.              |
+| March 25, 2022    | Court entered an initial consent order and permanent injunction.                              | Consent order found liability and imposed trading bans.        |
+| February 29, 2024 | Tinoco pleaded guilty and was sentenced in the parallel criminal case, according to CFTC.     | Criminal case confirmed misconduct and added restitution.      |
+| July 9, 2024      | Court entered final monetary order.                                                           | Final order quantified restitution, disgorgement, and penalty. |
+| July 26, 2024     | CFTC announced more than $31 million in monetary relief.                                      | Public resolution fixed final civil sanction scale.            |
+
+## Reconciliation Metrics
+
+| Metric                    | Enforcement-record figure or claim                               | Market-health interpretation                                      |
+| ------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Initial client count      | At least 61 clients in the 2021 CFTC release                     | Early harm required client-level tracing.                         |
+| Final claimant count      | 199 defrauded victims in the final monetary order                | Receiver reconstruction expanded the customer schedule.           |
+| Initial solicitation      | More than $3.9 million in the 2021 release                       | Initial enforcement figures may understate final harm.            |
+| Accepted investment funds | More than $7.2 million in the consent-order findings             | Deposits needed tracing to trades, payouts, and personal use.     |
+| Civil restitution         | $6,203,792.18                                                    | Victim-redress schedule tied to receiver claimants.               |
+| Disgorgement              | $6,257,904.89                                                    | Gain measure received dollar-for-dollar credit for restitution.   |
+| Civil monetary penalty    | $18,773,714                                                      | Penalty was three times unlawful gains.                           |
+| Total civil relief        | More than $31 million                                            | Civil sanctions combined redress, disgorgement, and deterrence.   |
+| Criminal restitution      | $9,023,695.77                                                    | Parallel case measured victim restitution separately.             |
+| Criminal sentence         | 84 months imprisonment plus 3 years supervised release           | Criminal resolution confirmed conduct severity.                   |
+| Claimed markets           | Forex and cryptocurrencies                                       | Multi-market claims required venue-specific records.              |
+| Spending categories       | Private-jet travel, mansion, real estate, and luxury automobiles | Personal spending contradicted managed-portfolio representations. |
+
+## Detection Checklist
+
+1. Reconcile every reported customer profit to executed trades, realized gains, and fees.
+2. Trace profit payments against later customer deposits to identify circular payout patterns.
+3. Verify customized portfolio claims with account-level allocations and broker or exchange records.
+4. Separate manager compensation from personal spending funded directly by customer deposits.
+5. Compare early complaint figures with receiver schedules and final orders as loss accounting matures.
+6. Track civil and criminal restitution separately because they can use different claimant sets and procedures.
+7. Confirm CFTC registration status before accepting managed forex or cryptocurrency trading services.
+8. Preserve legal posture: this article relies on CFTC order findings, CFTC releases, and public court records.
+
+## Market-Health Lessons
+
+Tinoco and Kikit show how a managed-portfolio label can hide a simple fund-flow problem. If the money does not enter trading accounts and reported profits do not come from trades, the portfolio is only a narrative.
+
+The case also shows why lifestyle spending is a direct market-health signal. Personal purchases are not merely bad optics; they prove that customer capital may be leaving the stated trading strategy before any market risk is even taken.
+
+Finally, receiver schedules matter. The move from an initial 61-client allegation to a 199-claimant restitution order shows why final harm analysis should rely on reconstructed claims, not only the first enforcement headline.
+
+## References
+
+- [CFTC press release 8934-24, July 26, 2024](https://www.cftc.gov/PressRoom/PressReleases/8934-24)
+- [CFTC final monetary order against Abner Alejandro Tinoco and Kikit & Mess Investments, July 9, 2024](https://www.cftc.gov/media/10986/enfabneralejandrotinocoorder070924/download)
+- [CFTC press release 8452-21, October 20, 2021](https://www.cftc.gov/PressRoom/PressReleases/8452-21)
+- [CFTC complaint against Abner Alejandro Tinoco and Kikit & Mess Investments, September 28, 2021](https://www.cftc.gov/media/6576/enfabneralejandrotinococomplaint092821/download)

--- a/content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/tinoco-kikit-summary.csv
+++ b/content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/tinoco-kikit-summary.csv
@@ -1,0 +1,10 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2020-09,Scheme begins,Abner Alejandro Tinoco; Kikit & Mess Investments,CFTC said the fraudulent scheme began in September 2020,Trading and payout records needed reconstruction from launch,CFTC press release 8934-24
+2020-2021,Managed-portfolio solicitation,Tinoco; Kikit & Mess; clients,CFTC alleged clients gave funds for customized forex and cryptocurrency portfolios,Managed-portfolio claims needed account-level evidence,CFTC press release 8452-21
+2021-09-28,CFTC complaint filed,CFTC; Tinoco; Kikit & Mess,CFTC filed enforcement action alleging fraud and misappropriation,Public enforcement challenged the trading narrative,CFTC final monetary order
+2021-10-13,Asset freeze and receiver order entered,CFTC; Tinoco; Kikit & Mess,CFTC said court froze assets preserved records and appointed a temporary receiver,Emergency relief preserved evidence and customer funds,CFTC press release 8452-21
+2021-10-20,CFTC charges announced,CFTC; Tinoco; Kikit & Mess,CFTC announced charges alleging more than 3.9 million USD misappropriated from at least 61 clients,Initial public claim quantified early known harm,CFTC press release 8452-21
+2022-03-25,Initial consent order entered,Tinoco; Kikit & Mess,CFTC said court entered permanent injunction trading ban and registration ban,Consent order found liability and imposed market-access bans,CFTC press release 8934-24
+2024-02-29,Criminal sentence entered,Abner Alejandro Tinoco,CFTC release said Tinoco was sentenced to 84 months prison 3 years supervised release and 9023695.77 USD restitution,Parallel criminal case confirmed misconduct and added restitution,CFTC press release 8934-24
+2024-07-09,Final monetary order entered,Tinoco; Kikit & Mess,Court ordered 6203792.18 USD restitution 6257904.89 USD disgorgement and 18773714 USD penalty,Final order quantified restitution disgorgement and penalty,CFTC final monetary order
+2024-07-26,CFTC announces final civil relief,CFTC; Tinoco; Kikit & Mess,CFTC announced more than 31 million USD in monetary relief,Public resolution fixed final civil sanction scale,CFTC press release 8934-24


### PR DESCRIPTION
## Summary

/claim #277

Adds a single Market Health article on Abner Alejandro Tinoco and Kikit & Mess Investments. The article focuses on customized forex/cryptocurrency portfolio claims, bogus reported investment profits, personal spending from customer deposits, receiver claimant accounting, and final civil/criminal restitution figures.

The PR includes:

- `content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/index.md`
- `content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/tinoco-kikit-summary.csv`

## Validation

- `npx prettier --write content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/index.md`
- `npx prettier --check content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/index.md`
- `ruby -rcsv -e 'rows = CSV.read(ARGV[0], headers: true); abort "no rows" if rows.empty?; widths = rows.map { |r| r.fields.size }.uniq; abort "bad widths #{widths.inspect}" unless widths == [rows.headers.size]; puts "csv ok: #{rows.size} rows, #{rows.headers.size} columns"' content/research/market-health/posts/2024-07-26-tinoco-kikit-forex-crypto-profit-claims/tinoco-kikit-summary.csv`\n- `git diff --check`\n\n@marina-chibizova could you review this submission for #277?\n