### PR TITLE
[codex] Add HashFlare mining dashboard article

### DIFF
--- a/content/research/market-health/posts/2025-08-12-hashflare-mining-dashboard-claims/hashflare-summary.csv
+++ b/content/research/market-health/posts/2025-08-12-hashflare-mining-dashboard-claims/hashflare-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2015,HashFlare operating period begins,HashFlare; Sergei Potapenko; Ivan Turogin,DOJ said HashFlare sales occurred from 2015 to 2019,Start of customer cloud-mining contract exposure,DOJ sentencing release
+2015 to 2019,HashFlare sales reported,HashFlare; customers,DOJ said sales totaled more than 577 million USD,Scale required substantial mining capacity and accounting controls,DOJ sentencing release
+2015 to 2019,Dashboard mining returns reported,HashFlare,DOJ said fake online dashboards falsely reported mining activity and returns,Dashboard balances required independent pool and wallet reconciliation,DOJ sentencing release
+2015 to 2019,Computing-capacity mismatch,HashFlare,DOJ said HashFlare lacked capacity for the vast majority of cryptocurrency it claimed to generate,Reported returns exceeded verifiable production capability,DOJ guilty plea release
+2025-02-13,Guilty pleas announced,Sergei Potapenko; Ivan Turogin,DOJ said both pleaded guilty to conspiracy to commit wire fraud,Guilty pleas confirmed the fraud-conspiracy record,DOJ guilty plea release
+2025-02,Forfeiture agreement reported,Sergei Potapenko; Ivan Turogin,DOJ said defendants agreed to forfeit assets valued over 400 million USD,Proceeds needed tracing against customer contract funding,DOJ guilty plea release
+2025-08-12,Sentences announced,Sergei Potapenko; Ivan Turogin,DOJ announced 16-month prison sentences fines and supervised release conditions,Criminal outcome confirmed accountability for the scheme,DOJ sentencing release
+2025-08-12,Forfeited asset value reported,HashFlare; United States,DOJ said forfeited assets were valued at more than 450 million USD,Asset recovery scale highlighted custody and use-of-funds review,DOJ sentencing release

--- a/content/research/market-health/posts/2025-08-12-hashflare-mining-dashboard-claims/index.md
+++ b/content/research/market-health/posts/2025-08-12-hashflare-mining-dashboard-claims/index.md
@@ -1,0 +1,96 @@
+---
+title: "HashFlare Mining Dashboard Claims"
+date: 2025-08-12
+entities:
+  - HashFlare
+  - Sergei Potapenko
+  - Ivan Turogin
+  - Bitcoin
+  - Cryptocurrency Mining
+---
+
+## Summary
+
+This case study analyzes HashFlare as a market-health warning about cryptocurrency mining services that sell mining contracts and display customer returns without enough verifiable computing capacity behind the dashboard. On August 12, 2025, DOJ announced that Sergei Potapenko and Ivan Turogin were sentenced for a $577 million cryptocurrency fraud scheme involving HashFlare.
+
+DOJ said HashFlare was a purported cryptocurrency mining service that sold contracts entitling customers to a share of cryptocurrency mined by the service. Between 2015 and 2019, HashFlare sales totaled more than $577 million. DOJ said the web-based dashboard falsely reported mining activity and returns, while HashFlare lacked the computing capacity to mine the vast majority of cryptocurrency it claimed to generate.
+
+The market-health signal is the separation between dashboard accounting and physical or on-chain mining evidence. A real cloud-mining service should be able to connect customer contracts to mining hardware, hashrate, electricity and hosting costs, mining-pool rewards, wallet payouts, and customer withdrawals. The DOJ record instead describes fake online dashboard data, insufficient capacity, and customer money diverted to real estate, luxury vehicles, investment accounts, and cryptocurrency accounts.
+
+The supporting dataset is available in [hashflare-summary.csv](hashflare-summary.csv).
+
+## Mining Contract Narrative
+
+HashFlare customers bought contracts that purportedly gave them a share of cryptocurrency mined by the service. That structure depends on a measurable capacity claim: if a company sells mining output, the company must have enough hardware, power, hosting, pool participation, and wallet payout history to support the output shown to customers.
+
+DOJ's February 2025 guilty-plea release said HashFlare did not possess the required computing capacity to perform the vast majority of the mining described to customers. The same release said the web-based dashboard that appeared to show mining profits reflected falsified data. The August 2025 sentencing release reiterated that HashFlare sales totaled more than $577 million and that fake dashboards falsely reported mining activity and returns.
+
+For market-health review, the central question is not whether the dashboard looked precise. The question is whether the dashboard reconciled to mining capacity. Hashrate, pool rewards, block events, fees, electricity, maintenance, contract terms, and wallet withdrawals should all support the same output story. Without that reconciliation, dashboard returns are platform statements rather than market evidence.
+
+## False Market Signals
+
+### Web-based mining dashboard
+
+DOJ said HashFlare relied on fake online dashboards that falsely reported mining activity and returns. A dashboard can summarize customer exposure, but it is not proof of mining unless it matches external pool data, hashrate, and wallet payouts.
+
+### Contract entitlement model
+
+Contracts promising a share of mined cryptocurrency create a specific obligation. Customer balances should map to hashrate allocations, pool rewards, costs, and distribution rules. If the service lacks capacity, the contract entitlement becomes a synthetic accounting entry.
+
+### Capacity mismatch
+
+DOJ said HashFlare lacked the computing capacity to mine the vast majority of the cryptocurrency it claimed to generate. Capacity mismatch is the key operational red flag for cloud-mining products because mining returns cannot exceed what hardware, power, and pools can produce.
+
+### Asset diversion
+
+DOJ said Potapenko and Turogin used investor funds to purchase real estate, luxury vehicles, and fund investment and cryptocurrency accounts for personal use. Spending records should be reconciled against claimed mining capital, equipment purchases, and customer payouts.
+
+### Asset forfeiture and remission
+
+DOJ reported forfeited cryptocurrency, funds, vehicles, real property, and cryptocurrency mining equipment valued at more than $450 million at sentencing. Large forfeiture records provide a recovery path for victims, but they also show why customer-contract proceeds must be traced to actual mining operations during the life of the product.
+
+## Event Timeline
+
+| Date or period       | Event                                                                                              | Market-health signal                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| 2015                 | DOJ said HashFlare sales began during the charged operating period.                                | Start of customer mining-contract exposure.                                       |
+| 2015-2019            | DOJ said HashFlare sales totaled more than $577 million.                                           | Scale required substantial hardware, power, hosting, and payout controls.         |
+| 2015-2019            | DOJ said dashboards falsely reported mining activity and returns.                                  | Customer balances required independent mining-capacity proof.                     |
+| 2015-2019            | DOJ said HashFlare lacked capacity for the vast majority of claimed mining.                        | Reported returns exceeded verifiable production capability.                       |
+| February 12-13, 2025 | Potapenko and Turogin pleaded guilty to conspiracy to commit wire fraud.                           | Guilty pleas confirmed the fraud-conspiracy record.                               |
+| February 2025        | DOJ said the defendants agreed to forfeit assets valued at more than $400 million.                 | Asset recovery record showed large proceeds outside normal customer accounting.   |
+| August 12, 2025      | DOJ announced 16-month prison sentences and forfeiture of assets valued at more than $450 million. | Sentencing and forfeiture closed the criminal case phase available in DOJ record. |
+
+## Reconciliation Metrics
+
+| Metric                      | Enforcement-record figure                                                                      | Market-health interpretation                                                        |
+| --------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Sales total                 | More than $577 million between 2015 and 2019                                                   | Claimed mining required institutional-scale capacity and accounting.                |
+| Customer count              | DOJ described hundreds of thousands of victims worldwide, including in the United States       | High-volume contracts needed scalable customer-level ledgers and withdrawals.       |
+| Computing capacity          | DOJ said HashFlare lacked capacity for the vast majority of claimed mining                     | Reported returns could not be trusted without hardware and pool verification.       |
+| Dashboard data              | DOJ said the web-based dashboard reflected falsified data                                      | Dashboard balances were not independent market evidence.                            |
+| Plea forfeiture value       | More than $400 million agreed to be forfeited as of the guilty pleas                           | Proceeds and assets needed tracing against contract funding and customer claims.    |
+| Sentencing forfeiture value | More than $450 million in cryptocurrency, funds, vehicles, real property, and mining equipment | Asset recovery scale highlighted the importance of custody and use-of-funds review. |
+| Sentence                    | 16 months in prison for each defendant, with fines and community service                       | Criminal outcome confirmed accountability for the HashFlare scheme.                 |
+
+## Detection Checklist
+
+1. Reconcile every mining contract to allocated hashrate, equipment, hosting, power, and pool participation.
+2. Compare dashboard mining returns with mining-pool records, wallet payouts, block rewards, and fees.
+3. Test whether the service has enough computing capacity to support reported customer returns.
+4. Separate customer contract proceeds from operator personal spending, investments, and unrelated cryptocurrency accounts.
+5. Confirm that customer withdrawals are funded by mined cryptocurrency rather than new contract sales.
+6. Review forfeiture, seizure, and restitution records for signs that customer assets left the claimed mining business.
+7. Preserve legal posture: this article relies on DOJ public records, guilty-plea reporting, and sentencing reporting.
+
+## Market-Health Lessons
+
+HashFlare shows that cloud-mining dashboards should be treated as claims, not proof. Mining has observable constraints: hardware capacity, energy cost, pool participation, block rewards, and on-chain wallet movement. A return dashboard that cannot be tied to those constraints can create a false market signal at very large scale.
+
+The case also shows why capacity audits matter before reviewing reported mining returns. If the service cannot mine enough cryptocurrency to support the customer balances it displays, the dashboard is effectively synthetic. Market-health reviewers should make capacity reconciliation the first gate for any mining-contract product.
+
+## References
+
+- [DOJ HashFlare sentencing release, August 12, 2025](https://www.justice.gov/usao-wdwa/pr/two-estonian-fraud-defendants-sentenced-577-million-fraud-scheme)
+- [DOJ HashFlare guilty plea release, February 13, 2025](https://www.justice.gov/usao-wdwa/pr/two-estonian-nationals-plead-guilty-577m-cryptocurrency-fraud-scheme)
+- [DOJ HashFlare case page, U.S. v. Sergei Potapenko and Ivan Turogin](https://www.justice.gov/usao-wdwa/united-states-vs-sergei-potapenko-and-ivan-turogin)


### PR DESCRIPTION
Contributes to #277.

This PR adds a market-health case study for HashFlare, focused on fake online mining dashboards, insufficient computing capacity, and contract-return reconciliation. It includes:

- A new article covering DOJ guilty-plea and sentencing records
- A supporting CSV summarizing the chronology and market-health signals
- Primary-source references for the DOJ sentencing release, guilty plea release, and case page

Local checks:
- `npx prettier --write content/research/market-health/posts/2025-08-12-hashflare-mining-dashboard-claims/index.md`
- `git diff --check -- content/research/market-health/posts/2025-08-12-hashflare-mining-dashboard-claims`

Hugo is not installed in this workspace, so I could not run the full site build locally.