### PR TITLE
[codex] Add EmpowerCoin ECoinPlus Jet-Coin trading article

### DIFF
--- a/content/research/market-health/posts/2025-06-27-empowercoin-ecoinplus-jet-coin-trading-claims/golden-platforms-summary.csv
+++ b/content/research/market-health/posts/2025-06-27-empowercoin-ecoinplus-jet-coin-trading-claims/golden-platforms-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2017-04,Platform series begins,EmpowerCoin; ECoinPlus; Jet-Coin,DOJ said the companies operated between April 2017 and August 2017,Start of fixed-return trading claim period,DOJ Golden sentencing release
+2017-04 to 2017-08,Guaranteed fixed returns promised,EmpowerCoin; ECoinPlus; Jet-Coin,DOJ said investors were promised guaranteed fixed returns from digital-asset trading,Fixed returns required venue-level proof and risk disclosure,DOJ Golden sentencing release
+2017-04 to 2017-08,Investor funds received,EmpowerCoin; ECoinPlus; Jet-Coin; investors,DOJ said the companies received more than 40 million USD from investors,Large inflows required custody execution and withdrawal reconciliation,DOJ Golden sentencing release
+2017,No trading activity reported,EmpowerCoin; ECoinPlus; Jet-Coin,DOJ said none of the companies engaged in actual cryptocurrency trading as claimed,Claimed return engine failed the basic reconciliation test,DOJ Golden sentencing release
+2017,Repayment and theft use of assets reported,Dwayne Golden; Gregory Aggesen; Marquis Demacking Egerton,DOJ said assets were used to repay other investors or stolen by operators,Repayments needed separation from realized trading profit,DOJ Golden sentencing release
+2017-07 to 2022-03,Investigation obstruction conspiracy reported,Dwayne Golden; Gregory Aggesen; William White,DOJ said defendants conspired to obstruct FTC and grand jury investigations,Record integrity risk extended after platform collapse,DOJ Golden sentencing release
+2024-09,Golden guilty plea,Dwayne Golden,DOJ said Golden pleaded guilty in September 2024,Plea confirmed criminal exposure tied to platform conduct,DOJ Golden sentencing release
+2025-06-27,Golden sentenced,Dwayne Golden,DOJ announced 97 months in prison and approximately 2.46 million USD forfeiture,Criminal outcome confirmed accountability and proceeds recovery,DOJ Golden sentencing release

--- a/content/research/market-health/posts/2025-06-27-empowercoin-ecoinplus-jet-coin-trading-claims/index.md
+++ b/content/research/market-health/posts/2025-06-27-empowercoin-ecoinplus-jet-coin-trading-claims/index.md
@@ -1,0 +1,101 @@
+---
+title: "EmpowerCoin ECoinPlus and Jet-Coin Trading Return Claims"
+date: 2025-06-27
+entities:
+  - EmpowerCoin
+  - ECoinPlus
+  - Jet-Coin
+  - Dwayne Golden
+  - Gregory Aggesen
+  - Marquis Demacking Egerton
+  - William White
+  - Digital Assets
+---
+
+## Summary
+
+This case study analyzes EmpowerCoin, ECoinPlus, and Jet-Coin as market-health warnings about digital-asset platforms that promise fixed trading returns without verifiable trading activity. On June 27, 2025, DOJ announced that Dwayne Golden was sentenced to 97 months in prison for conspiracy to commit wire fraud and money laundering tied to fraudulent digital-asset investment companies.
+
+DOJ said Golden and co-conspirators raised more than $40 million from investors based on false promises of guaranteed returns from trading in digital assets. The companies operated as Ponzi schemes, according to DOJ, using investor money to repay existing investors or benefit the operators. DOJ also said Golden and his co-defendants offered no legitimate services and that none of the companies engaged in actual cryptocurrency trading as claimed.
+
+The market-health signal is the mismatch between fixed-return trading promises and the absence of underlying trade records. A real trading operation should provide venue accounts, order history, realized profit and loss, fees, custody records, risk controls, and withdrawal records. Here, DOJ's record describes fixed return promises, collapsed companies, no trading activity, and later obstruction of investigations.
+
+The supporting dataset is available in [golden-platforms-summary.csv](golden-platforms-summary.csv).
+
+## Trading Return Narrative
+
+Between April 2017 and August 2017, DOJ said Golden, Gregory Aggesen, Marquis Demacking Egerton, and others operated EmpowerCoin, ECoinPlus, and Jet-Coin. The companies promised investors guaranteed fixed returns on digital-asset investments. The claimed source of those returns was overseas digital-asset trading operations.
+
+Fixed-return trading claims create a direct reconciliation test. If trading is the return engine, then investor balances should map to exchange deposits, orders, fills, fees, risk limits, realized gains, withdrawals, and remaining balances. DOJ said the assets were instead used to repay other investors or stolen by Golden, Aggesen, and Egerton. DOJ also said the companies collapsed shortly after receiving investor assets without having engaged in trading activity.
+
+The short operating period increases the market-health signal. In a matter of months, the companies received more than $40 million from investors, promised fixed returns, and collapsed. That timing makes deposit inflow, referral activity, and displayed balances especially important to separate from actual trading performance.
+
+## False Market Signals
+
+### Guaranteed fixed returns
+
+Trading returns are variable because markets move, liquidity changes, fees accrue, and strategies lose money. A guaranteed fixed return from digital-asset trading requires strong independent proof because it conflicts with normal market risk.
+
+### Overseas trading explanation
+
+DOJ said the companies represented that returns came from overseas digital-asset trading operations. Cross-border venue explanations should be supported by named trading accounts, exchange statements, custody paths, compliance records, and bank or wallet flows.
+
+### Multiple platform names
+
+EmpowerCoin, ECoinPlus, and Jet-Coin operated as a series of digital-asset companies, according to DOJ. Multiple names can fragment investor attention and make it harder to reconcile balances, operator control, and cash flows across related schemes.
+
+### No legitimate services
+
+DOJ stated that Golden and his co-defendants offered no legitimate services and that none of the companies performed actual cryptocurrency trading as claimed. That is the core market-health failure: a trading-return product without trading.
+
+### Obstruction after collapse
+
+DOJ said Golden, Aggesen, and White conspired from July 2017 to March 2022 to obstruct an FTC investigation and a federal grand jury investigation. Obstruction risk matters for market-health review because records may be destroyed or manipulated after the trading story begins to fail.
+
+## Event Timeline
+
+| Date or period        | Event                                                                                                  | Market-health signal                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| April 2017            | DOJ said the operators began running EmpowerCoin, ECoinPlus, and Jet-Coin.                             | Start of the fixed-return trading claim period.                            |
+| April-August 2017     | DOJ said the companies promised guaranteed fixed returns from overseas digital-asset trading.          | Trading returns needed venue-level proof and risk disclosure.              |
+| April-August 2017     | DOJ said the companies received more than $40 million from investors.                                  | Large inflows required custody, execution, and withdrawal reconciliation.  |
+| 2017                  | DOJ said investor assets were used to repay other investors or stolen by operators.                    | Repayments needed separation from realized trading profit.                 |
+| Shortly after inflows | DOJ said the companies collapsed after receiving investor assets without engaging in trading activity. | Collapse timing contradicted the fixed-return trading story.               |
+| July 2017-March 2022  | DOJ said Golden, Aggesen, and White conspired to obstruct FTC and grand jury investigations.           | Investigative obstruction raised record-integrity risk.                    |
+| September 2024        | DOJ said Golden pleaded guilty.                                                                        | Plea confirmed criminal exposure tied to the platform conduct.             |
+| June 27, 2025         | DOJ announced Golden's 97-month sentence and about $2.46 million forfeiture order.                     | Criminal outcome confirmed accountability and proceeds recovery.           |
+| June 27, 2025         | DOJ said White had been sentenced to 30 months and Aggesen and Egerton were awaiting sentencing.       | Related defendant statuses showed the broader case posture at publication. |
+
+## Reconciliation Metrics
+
+| Metric                | Enforcement-record figure                                               | Market-health interpretation                                              |
+| --------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Investor funds        | More than $40 million received by EmpowerCoin, ECoinPlus, and Jet-Coin  | Trading strategy required institutional-grade custody and execution logs. |
+| Operating period      | April 2017 through August 2017 for the platform series                  | Short time window made trading proof and withdrawal testing urgent.       |
+| Return representation | Guaranteed fixed returns from digital-asset trading                     | Fixed returns conflicted with normal trading risk.                        |
+| Trading activity      | DOJ said none of the companies engaged in actual cryptocurrency trading | Claimed return engine failed the basic reconciliation test.               |
+| Repayment source      | DOJ said investor assets were used to repay other investors or stolen   | Repayments could not be treated as realized market profit.                |
+| Golden sentence       | 97 months in prison                                                     | Criminal outcome confirmed accountability for the scheme.                 |
+| Forfeiture            | Approximately $2.46 million in ill-gotten gains ordered forfeited       | Operator proceeds required tracing against investor losses.               |
+| Obstruction period    | July 2017 to March 2022                                                 | Record-destruction risk extended long after platform collapse.            |
+
+## Detection Checklist
+
+1. Reconcile fixed return claims to actual venue accounts, order history, fees, and realized profit and loss.
+2. Treat overseas trading explanations as unverified until exchange, custody, and banking records are produced.
+3. Separate new investor deposits and inter-investor repayments from market-generated profits.
+4. Track related platform names under common operator, wallet, bank, and marketing control.
+5. Test displayed returns against successful withdrawals and remaining balances.
+6. Preserve platform records quickly when collapse, obstruction, or destroyed-evidence risk appears.
+7. Preserve legal posture: this article relies on DOJ public sentencing reporting and indictment materials.
+
+## Market-Health Lessons
+
+The Golden platform series shows why fixed digital-asset trading returns require a strong evidence threshold. A platform can name multiple products and point to overseas trading, but the market-health question remains the same: did investor funds actually reach trading venues, and did realized trading gains fund the promised returns?
+
+It also shows why investigators and reviewers should consolidate related platform names early. EmpowerCoin, ECoinPlus, and Jet-Coin were separate labels in the investor-facing story, but the market-health analysis depends on aggregating funds, operators, representations, and withdrawals across the full platform series.
+
+## References
+
+- [DOJ Golden sentencing release, June 27, 2025](https://www.justice.gov/usao-edny/pr/co-owner-virtual-currency-companies-sentenced-97-months-prison-operating-crypto-ponzi)
+- [Golden superseding indictment, EDNY docket 22-CR-88](https://www.justice.gov/usao-edny/press-release/file/1480881/dl)


### PR DESCRIPTION
Contributes to #277.

This PR adds a market-health case study for EmpowerCoin, ECoinPlus, and Jet-Coin, focused on fixed digital-asset trading return claims where DOJ says no actual cryptocurrency trading occurred. It includes:

- A new article covering DOJ sentencing reporting and indictment materials
- A supporting CSV summarizing the chronology and market-health signals
- Primary-source references for the DOJ sentencing release and superseding indictment

Local checks:
- `npx prettier --write content/research/market-health/posts/2025-06-27-empowercoin-ecoinplus-jet-coin-trading-claims/index.md`
- `git diff --check -- content/research/market-health/posts/2025-06-27-empowercoin-ecoinplus-jet-coin-trading-claims`

Hugo is not installed in this workspace, so I could not run the full site build locally.