### PR TITLE
[codex] Add Douglas Kim crypto trading loan article

### DIFF
--- a/content/research/market-health/posts/2025-07-09-douglas-kim-crypto-trading-loan-claims/index.md
+++ b/content/research/market-health/posts/2025-07-09-douglas-kim-crypto-trading-loan-claims/index.md
@@ -1,0 +1,96 @@
+---
+title: "Douglas Kim Crypto Trading Loan Claims"
+date: 2025-07-09
+entities:
+  - Douglas Jae Woo Kim
+  - Bitcoin
+  - Ether
+  - Cryptocurrency Trading
+---
+
+## Summary
+
+This case study analyzes the Douglas Jae Woo Kim case as a market-health warning about informal crypto trading loans and investments that promise low-risk or high-return trading without custody and use-of-funds controls. On July 9, 2025, DOJ announced that Kim was sentenced to 48 months in federal prison for defrauding investors of more than $7 million in cryptocurrency and other funds.
+
+DOJ said Kim held himself out as a legitimate cryptocurrency trader between October 2017 and June 2020. He represented that he needed short-term liquidity for cryptocurrency trading or other legitimate business purposes, described the activity as low risk or no risk, and promised high rates of return. DOJ said investor funds were instead transferred to offshore sports betting sites and an offshore casino.
+
+The market-health signal is the mismatch between a trading-liquidity story and the actual destination of funds. A real trading loan should connect funds to trading venues, margin accounts, order history, realized profit and loss, fees, collateral, repayments, and remaining balances. DOJ's record describes funds moving to gambling destinations rather than to the claimed trading activity.
+
+The supporting dataset is available in [kim-summary.csv](kim-summary.csv).
+
+## Trading Loan Narrative
+
+Kim's representations used the language of short-term liquidity. According to DOJ, he asked for loans or investments for cryptocurrency trading or other legitimate business purposes, and he claimed that he could personally guarantee the loans. Those claims created a simple verification requirement: loaned assets should have flowed to known trading venues or business accounts, then back to lenders through documented returns.
+
+DOJ's sentencing release gives several examples of the gap between the trading narrative and the fund flows. In one instance, DOJ said Kim told an investor he was investing in a cryptocurrency operation that would profit from fees charged to a peer-to-peer network and exchange transactions. DOJ said most of the more than $1 million obtained from that investor went to offshore sports betting sites. In another instance, DOJ said funds from a victim who provided more than $500,000 mostly went to offshore sports betting sites. For a January 1, 2018 agreement involving cryptocurrency worth about $200,000 at the time, DOJ said Kim converted more than half of the funds to Bitcoin and transferred substantially all of the converted cryptocurrency to an offshore casino account in the following days.
+
+For market-health review, the important issue is not whether the borrower used trading vocabulary. The issue is whether the trade path exists. If funds are claimed to support short-term trading, then the borrower should be able to produce wallet flows, exchange statements, account balances, executed trades, risk records, and repayment records.
+
+## False Market Signals
+
+### Low-risk trading claims
+
+DOJ said Kim described some activities as low risk or no risk. Crypto trading strategies are exposed to market movement, venue risk, execution risk, leverage risk, and custody risk. Low-risk statements should be tested against actual position history and collateral.
+
+### Personal guarantee claims
+
+Kim claimed he had enough funds to personally guarantee the loans, according to DOJ. A guarantee is only meaningful if it is backed by independently verifiable assets and enforceable documentation.
+
+### Peer-to-peer and exchange transaction story
+
+DOJ said one representation involved profits from peer-to-peer network fees and exchange transactions. That kind of story should leave venue, wallet, and accounting records. Without those records, it is a narrative rather than market evidence.
+
+### Offshore gambling fund flows
+
+DOJ described repeated transfers to offshore sports betting sites and an offshore casino. Those destinations are incompatible with a trading-liquidity explanation unless the borrower can show a legitimate, documented trading purpose, which DOJ's record says was not present.
+
+### Informal investor network
+
+The case involved investors who knew Kim personally, according to DOJ. Informal trust can reduce diligence, but market-health review should still require the same independent custody, trading, and repayment evidence.
+
+## Event Timeline
+
+| Date or period         | Event                                                                                               | Market-health signal                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| October 2017           | DOJ said Kim began the scheme after moving to San Francisco.                                        | Start of the cryptocurrency trading-loan representation period.             |
+| October 2017           | DOJ said Kim obtained more than $1 million from one investor over the course of the scheme.         | Trading use had to be reconciled against offshore betting transfers.        |
+| November 2017          | DOJ said Kim sought cryptocurrency for a trading strategy and described his activity as low risk.   | Low-risk claims required actual trading and collateral records.             |
+| January 1, 2018        | DOJ said Kim signed an agreement for cryptocurrency valued around $200,000.                         | Contracted funds needed immediate custody and use-of-funds controls.        |
+| Early January 2018     | DOJ said Kim converted more than half of those funds to Bitcoin and sent converted assets offshore. | Rapid casino transfer contradicted the trading-liquidity story.             |
+| October 2017-June 2020 | DOJ said Kim defrauded investors of more than $7 million in money and cryptocurrency.               | Multi-year fund flows required venue, wallet, and repayment reconciliation. |
+| February 2025          | A federal jury convicted Kim on wire fraud and money-laundering counts.                             | Trial outcome confirmed the fraud and laundering record.                    |
+| July 9, 2025           | DOJ announced a 48-month prison sentence and supervised release.                                    | Criminal outcome confirmed accountability for the trading-loan scheme.      |
+
+## Reconciliation Metrics
+
+| Metric                | Enforcement-record figure                                                       | Market-health interpretation                                         |
+| --------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Total investor funds  | More than $7 million in cryptocurrency and other funds                          | Large informal loans required venue, wallet, and repayment controls. |
+| Scheme period         | October 2017 through June 2020                                                  | Multi-year claims needed continuous use-of-funds reconciliation.     |
+| Claimed use           | Short-term liquidity for cryptocurrency trading or legitimate business purposes | Trading purpose required exchange and order evidence.                |
+| Risk representation   | Low-risk or no-risk claims reported by DOJ                                      | Risk claims needed collateral and position-history support.          |
+| Gambling destinations | Offshore sports betting sites and an offshore casino                            | Fund destinations conflicted with trading-liquidity representations. |
+| January 2018 contract | Cryptocurrency valued around $200,000 at the time                               | Contracted transfer needed immediate custody proof.                  |
+| Criminal verdict      | Jury conviction on wire fraud and money-laundering counts                       | Court outcome confirmed the enforcement record.                      |
+| Sentence              | 48 months in federal prison and three years of supervised release               | Accountability outcome for the trading-loan scheme.                  |
+
+## Detection Checklist
+
+1. Require exchange account statements, wallet records, order history, and balances for any crypto trading loan.
+2. Treat low-risk or no-risk trading language as unverified until collateral and position history are independently checked.
+3. Confirm that borrowed cryptocurrency goes to trading venues or custody accounts, not unrelated gambling or personal destinations.
+4. Match repayment promises to realized trading profit, not new borrowing.
+5. Use written contracts only as starting evidence; reconcile them to actual fund movement.
+6. Preserve legal posture: this article relies on DOJ public charging, conviction, and sentencing records.
+
+## Market-Health Lessons
+
+The Kim case shows why informal crypto trading loans need the same reconciliation as institutional trading products. A borrower can describe a strategy, a peer-to-peer operation, or a short-term liquidity need, but the claim is only credible if funds move through identifiable trading and custody paths.
+
+The case also shows that destination analysis is often faster than strategy analysis. If funds routed to a trading borrower quickly appear at offshore gambling destinations, reviewers should treat the trading return claim as unsupported until the borrower can explain the full custody and execution path with records.
+
+## References
+
+- [DOJ Kim sentencing release, July 9, 2025](https://www.justice.gov/usao-ndca/pr/new-york-man-who-ran-7-million-dollar-cryptocurrency-investment-scheme-sentenced-four)
+- [DOJ Kim trial conviction release, February 27, 2025](https://www.justice.gov/usao-ndca/pr/new-york-man-who-ran-multi-million-dollar-cryptocurrency-investment-scheme-found)
+- [DOJ Kim charging release, July 15, 2020](https://www.justice.gov/usao-ndca/pr/new-yok-man-charged-wire-fraud-alleged-multi-million-dollar-cryptocurrency-investment)

--- a/content/research/market-health/posts/2025-07-09-douglas-kim-crypto-trading-loan-claims/kim-summary.csv
+++ b/content/research/market-health/posts/2025-07-09-douglas-kim-crypto-trading-loan-claims/kim-summary.csv
@@ -1,0 +1,9 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2017-10,Scheme period begins,Douglas Jae Woo Kim,DOJ said Kim began the scheme after moving to San Francisco,Start of cryptocurrency trading-loan representations,DOJ sentencing release
+2017-10,First example investor funds,Douglas Jae Woo Kim; investor,DOJ said Kim obtained more than 1 million USD from one investor over the course of the scheme,Trading use needed reconciliation against offshore betting transfers,DOJ sentencing release
+2017-11,Trading-strategy funds sought,Douglas Jae Woo Kim; investor,DOJ said Kim sought cryptocurrency for a trading strategy and described activity as low risk,Low-risk claims required actual trading and collateral records,DOJ sentencing release
+2018-01-01,Written cryptocurrency agreement,Douglas Jae Woo Kim; investor,DOJ said an agreement involved cryptocurrency valued around 200000 USD,Contracted funds needed immediate custody proof,DOJ sentencing release
+2018-01,Offshore casino transfer,Douglas Jae Woo Kim,DOJ said more than half was converted to Bitcoin and substantially all converted crypto was sent to an offshore casino,Rapid casino transfer contradicted trading-liquidity story,DOJ sentencing release
+2017-10 to 2020-06,Investor funds obtained,Douglas Jae Woo Kim; investors,DOJ said investors lost more than 7 million USD in cryptocurrency and other funds,Multi-year fund flows required venue wallet and repayment reconciliation,DOJ sentencing release
+2025-02,Federal jury verdict,Douglas Jae Woo Kim,DOJ said a jury convicted Kim on wire fraud and money-laundering counts,Trial outcome confirmed fraud and laundering record,DOJ conviction release
+2025-07-09,Sentence announced,Douglas Jae Woo Kim,DOJ announced 48 months in federal prison and supervised release,Criminal outcome confirmed accountability for trading-loan scheme,DOJ sentencing release


### PR DESCRIPTION
Contributes to #277.

This PR adds a market-health case study for Douglas Jae Woo Kim, focused on informal crypto trading loans where DOJ says funds were sent to offshore betting and casino destinations instead of trading use. It includes:

- A new article covering DOJ charging, conviction, and sentencing records
- A supporting CSV summarizing the chronology and market-health signals
- Primary-source references for the DOJ sentencing, conviction, and charging releases

Local checks:
- `npx prettier --write content/research/market-health/posts/2025-07-09-douglas-kim-crypto-trading-loan-claims/index.md`
- `git diff --check -- content/research/market-health/posts/2025-07-09-douglas-kim-crypto-trading-loan-claims`

Hugo is not installed in this workspace, so I could not run the full site build locally.