### PR TITLE
[codex] Add Rockwell Capital crypto fund article

### DIFF
--- a/content/research/market-health/posts/2026-01-15-rockwell-capital-crypto-fund-return-claims/index.md
+++ b/content/research/market-health/posts/2026-01-15-rockwell-capital-crypto-fund-return-claims/index.md
@@ -1,0 +1,95 @@
+---
+title: "Rockwell Capital Crypto Fund Return Claims"
+date: 2026-01-15
+entities:
+  - Brian Garry Sewell
+  - Rockwell Capital Management
+  - Cryptocurrency
+  - Digital Assets
+---
+
+## Summary
+
+This case study analyzes Brian Garry Sewell and Rockwell Capital Management as a market-health warning about crypto-fund return claims that combine unverifiable manager credentials, low-risk return promises, and opaque cryptocurrency conversion activity. On January 15, 2026, DOJ announced that Sewell was sentenced to three years in prison after pleading guilty to wire fraud that cost investors more than $2.9 million.
+
+DOJ said Sewell participated in a scheme from December 2017 to April 2024 to obtain money and cryptocurrency from victims by lying about his experience, education, and ability to generate large returns. In the related 2024 indictment release, DOJ alleged that Sewell falsely claimed to investors that he ran previous cryptocurrency funds that generated significant returns, that he generated high returns with little risk of loss, and that he concealed his use of Rockwell Capital Management as an unlicensed money transmitting business.
+
+The market-health signal is the combination of investment-return claims and crypto conversion rails. A real crypto fund should be able to reconcile investor deposits, trading venues, custody, wallet flows, realized performance, losses, and withdrawals. A money transmitting business converting bulk cash to cryptocurrency should also be registered and monitored for source-of-funds and anti-money-laundering risk. DOJ's record describes false return credentials, investor losses, and unlicensed bulk cash-to-crypto conversion.
+
+The supporting dataset is available in [rockwell-summary.csv](rockwell-summary.csv).
+
+## Fund Return Narrative
+
+Sewell's investor-facing story depended on credibility and return generation. DOJ said he lied about his experience, education, and ability to produce large returns. The indictment release gave more specific examples, including alleged false claims about prior cryptocurrency funds that generated significant returns and high returns with little risk of loss.
+
+Those claims are testable. Prior fund performance should be supported by audited records, account statements, custody records, trading history, investor capital accounts, realized profit and loss, and withdrawal records. High-return and low-risk claims should be compared against actual strategy risk, drawdowns, and liquidity constraints. Without that evidence, manager biography and return history become marketing signals rather than market evidence.
+
+The Rockwell Capital Management money-transmission facts add a second market-health dimension. DOJ said Sewell managed an unlicensed money transmitting business from March 2020 to September 2020 and converted bulk cash to cryptocurrency for third parties, including criminals engaged in fraud and drug trafficking. That matters because the same entity name appeared in the investor-fraud allegations, creating a need to separate investment management, money transmission, customer funds, and personal or third-party flows.
+
+## False Market Signals
+
+### Prior crypto fund performance
+
+DOJ alleged Sewell falsely claimed to have run previous cryptocurrency funds that generated significant returns. Prior-fund claims should be verified against fund documents, exchange records, wallet activity, and audited investor statements.
+
+### High returns with little risk
+
+High-return and low-risk claims are a classic market-health warning. Crypto funds face price volatility, liquidity risk, custody risk, operational risk, counterparty risk, and regulatory risk. Claims that minimize those risks require strong independent proof.
+
+### Manager credentials
+
+DOJ said Sewell lied about experience and education. Manager credentials influence investor trust, but they do not prove trading ability. They should be checked separately from performance and custody evidence.
+
+### Unlicensed crypto conversion activity
+
+DOJ said Rockwell Capital Management converted bulk cash to cryptocurrency for third parties without registering as a money transmitting business. Unlicensed conversion activity can obscure source-of-funds and destination-of-funds evidence.
+
+### Investor restitution
+
+DOJ said Sewell was ordered to pay $3,605,182 in restitution in the investor-fraud case and $217,727 in restitution in the money-transmission case. Restitution figures provide a loss baseline for reviewing whether returns, withdrawals, and reported balances were supported by actual performance.
+
+## Event Timeline
+
+| Date or period           | Event                                                                                                    | Market-health signal                                                         |
+| ------------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| December 2017            | DOJ said Sewell's investor-fraud scheme began.                                                           | Start of the return-generation representation period.                        |
+| March-September 2020     | DOJ said Rockwell Capital Management operated as an unlicensed money transmitting business.              | Crypto conversion flows required registration and source-of-funds review.    |
+| June 2020-May 2021       | DOJ alleged Rockwell transferred more than $2.6 million for a separate entity in the indictment release. | Related conversion activity needed separation from investment-fund claims.   |
+| December 2017-April 2024 | DOJ said Sewell obtained money from at least 17 investors by lying about returns and credentials.        | Investor deposits required custody, trading, and performance reconciliation. |
+| June 17, 2024            | DOJ announced indictments tied to unlicensed money transmission and separate financial fraud.            | Charges identified the combined investment and conversion risk.              |
+| January 15, 2026         | DOJ announced Sewell's three-year sentence in concurrent cases.                                          | Criminal outcome confirmed accountability for the misconduct.                |
+| January 15, 2026         | DOJ reported restitution orders in both cases.                                                           | Restitution established a recovery and loss baseline.                        |
+
+## Reconciliation Metrics
+
+| Metric                         | Enforcement-record figure                                                    | Market-health interpretation                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Investor amount obtained       | More than $2.9 million from at least 17 investors                            | Claimed fund performance required account, custody, and trading records.       |
+| Investor restitution           | $3,605,182 ordered in the investor-fraud case                                | Loss baseline exceeded reported investor amount due to broader victim impact.  |
+| Money-transmission restitution | $217,727 ordered to the U.S. Department of Homeland Security                 | Unlicensed conversion activity carried separate loss and enforcement exposure. |
+| Money-transmission period      | March 2020 through September 2020                                            | Crypto conversion flows needed licensing and AML controls.                     |
+| Related transfer amount        | More than $2.6 million transferred for a separate entity, as alleged in 2024 | Third-party flows needed separation from investor-fund activity.               |
+| Claimed prior performance      | Previous cryptocurrency funds allegedly generated significant returns        | Prior-fund claims required independent verification.                           |
+| Risk claim                     | High returns with little risk of loss alleged in 2024 release                | Risk language conflicted with normal crypto-fund volatility.                   |
+| Sentence                       | 36 months in prison and 36 months of supervised release in concurrent cases  | Criminal outcome confirmed accountability.                                     |
+
+## Detection Checklist
+
+1. Verify prior crypto-fund performance with audited records, exchange statements, wallet flows, and investor capital accounts.
+2. Treat high-return and low-risk claims as unverified until drawdowns, losses, liquidity, and custody records are reviewed.
+3. Separate investment-management flows from money-transmission flows under the same entity or operator.
+4. Confirm whether cash-to-crypto conversion activity is properly registered and monitored.
+5. Reconcile investor deposits to trading venues, wallets, fees, withdrawals, and remaining balances.
+6. Check manager credentials independently from performance claims.
+7. Preserve legal posture: this article relies on DOJ public sentencing and indictment reporting.
+
+## Market-Health Lessons
+
+The Sewell/Rockwell case shows why crypto-fund review should not stop at promised returns. Manager biography, prior-fund claims, and low-risk language all need independent verification before they can support a market-health conclusion.
+
+The case also shows why adjacent crypto conversion activity matters. If an investment manager or related entity is also moving bulk cash into cryptocurrency for third parties, reviewers should separate those ledgers immediately. Otherwise, investor deposits, conversion fees, third-party funds, and personal use can become difficult to distinguish.
+
+## References
+
+- [DOJ Sewell sentencing release, January 15, 2026](https://www.justice.gov/usao-ut/pr/southern-utah-man-sentenced-three-years-prison-wire-fraud-cost-investors-millions)
+- [DOJ Sewell indictment release, June 17, 2024](https://www.justice.gov/usao-ut/pr/two-washington-county-residents-indicted-after-allegedly-operating-unlicensed-money)

--- a/content/research/market-health/posts/2026-01-15-rockwell-capital-crypto-fund-return-claims/rockwell-summary.csv
+++ b/content/research/market-health/posts/2026-01-15-rockwell-capital-crypto-fund-return-claims/rockwell-summary.csv
@@ -1,0 +1,8 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2017-12,Investor-fraud scheme begins,Brian Garry Sewell,DOJ said Sewell participated in a scheme from December 2017 to April 2024,Start of return-generation representation period,DOJ sentencing release
+2020-03 to 2020-09,Unlicensed money transmission period,Rockwell Capital Management; Brian Garry Sewell,DOJ said Rockwell converted bulk cash to cryptocurrency without registration,Crypto conversion flows required registration and source-of-funds review,DOJ sentencing release
+2020-06 to 2021-05,Related transfer activity alleged,Rockwell Capital Management,DOJ alleged Rockwell transferred over 2.6 million USD on behalf of a separate entity,Third-party flows needed separation from investor-fund activity,DOJ indictment release
+2017-12 to 2024-04,Investor funds obtained,Brian Garry Sewell; investors,DOJ said Sewell obtained more than 2.9 million USD from at least 17 investors,Claimed performance required account custody and trading records,DOJ sentencing release
+2024-06-17,Indictments announced,Brian Garry Sewell; Rockwell Capital Management,DOJ announced charges tied to unlicensed money transmission and separate financial fraud,Charges identified combined investment and conversion risk,DOJ indictment release
+2026-01-15,Sentencing announced,Brian Garry Sewell,DOJ announced 36 months in prison and supervised release in concurrent cases,Criminal outcome confirmed accountability for misconduct,DOJ sentencing release
+2026-01-15,Restitution ordered,Brian Garry Sewell,DOJ said court ordered 3605182 USD in investor-fraud restitution and 217727 USD in money-transmission restitution,Restitution established recovery and loss baseline,DOJ sentencing release


### PR DESCRIPTION
Contributes to #277.

This PR adds a market-health case study for Brian Sewell and Rockwell Capital Management, focused on crypto-fund return claims, low-risk representations, and adjacent unlicensed cash-to-crypto conversion activity. It includes:

- A new article covering DOJ sentencing and indictment reporting
- A supporting CSV summarizing the chronology and market-health signals
- Primary-source references for the DOJ sentencing and indictment releases

Local checks:
- `npx prettier --write content/research/market-health/posts/2026-01-15-rockwell-capital-crypto-fund-return-claims/index.md`
- `git diff --check -- content/research/market-health/posts/2026-01-15-rockwell-capital-crypto-fund-return-claims`

Hugo is not installed in this workspace, so I could not run the full site build locally.