### PR TITLE
[codex] Add AML Bitcoin technology claims article

### DIFF
--- a/content/research/market-health/posts/2025-07-29-aml-bitcoin-technology-deal-claims/aml-bitcoin-summary.csv
+++ b/content/research/market-health/posts/2025-07-29-aml-bitcoin-technology-deal-claims/aml-bitcoin-summary.csv
@@ -1,0 +1,8 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2025-03,Jury conviction announced,Rowland Marcus Andrade; AML Bitcoin,DOJ said a jury convicted Andrade of wire fraud and money laundering,Trial outcome confirmed fraud and laundering record,DOJ conviction release
+2025-07-29,Sentence announced,Rowland Marcus Andrade,DOJ announced 84 months in federal prison and supervised release,Criminal outcome confirmed accountability,DOJ sentencing release
+token-sale-period,Investor fraud amount reported,AML Bitcoin; investors,DOJ said Andrade defrauded cryptocurrency investors out of approximately 10 million USD,Token-sale proceeds required project and treasury reconciliation,DOJ sentencing release
+token-sale-period,Technology and viability claims reported,AML Bitcoin,DOJ said Andrade misrepresented development viability business deals and release date,Offering claims required independent technical and commercial proof,DOJ sentencing release
+token-sale-period,Panama Canal Authority claim,AML Bitcoin; Panama Canal Authority,DOJ said Andrade falsely claimed AML Bitcoin adoption by the Panama Canal Authority was close when no agreement existed,Named-partner adoption claims required counterparty verification,DOJ sentencing release
+token-sale-period,Proceeds diversion reported,Rowland Marcus Andrade,DOJ said more than 2 million USD in sale proceeds was diverted to personal expenses,Personal spending conflicted with development and adoption claims,DOJ sentencing release
+2025-09-16,Forfeiture and restitution hearing scheduled,Rowland Marcus Andrade,DOJ said court ordered a hearing to determine forfeiture and restitution amounts,Final recovery figures required later court follow-up,DOJ sentencing release

--- a/content/research/market-health/posts/2025-07-29-aml-bitcoin-technology-deal-claims/index.md
+++ b/content/research/market-health/posts/2025-07-29-aml-bitcoin-technology-deal-claims/index.md
@@ -1,0 +1,95 @@
+---
+title: "AML Bitcoin Technology and Deal Claims"
+date: 2025-07-29
+entities:
+  - AML Bitcoin
+  - Rowland Marcus Andrade
+  - NAC Foundation
+  - Panama Canal Authority
+  - Cryptocurrency
+---
+
+## Summary
+
+This case study analyzes AML Bitcoin as a market-health warning about cryptocurrency offerings that use technology-readiness and business-adoption claims to support investor demand before the claims are independently verifiable. On July 29, 2025, DOJ announced that AML Bitcoin founder and CEO Rowland Marcus Andrade was sentenced to 84 months in federal prison for wire fraud and money laundering.
+
+DOJ said a federal jury found Andrade guilty in March 2025 in connection with the fraudulent marketing and sale of AML Bitcoin. According to DOJ, the scheme raised millions of dollars through false and misleading statements about the cryptocurrency, its technology, its viability, potential business deals, and release date. DOJ specifically said Andrade falsely claimed that the Panama Canal Authority was close to permitting AML Bitcoin to be used for ships passing through the Panama Canal when no such agreement existed.
+
+The market-health signal is the way product-readiness and adoption claims can become price-support or fundraising signals. A token issuer's statements about technology development, launch timing, and major commercial adoption should be checked against contracts, implementation evidence, source-code readiness, compliance status, partner confirmations, and treasury use. DOJ's record describes investor funds being diverted to personal expenses, including real estate and luxury vehicles.
+
+The supporting dataset is available in [aml-bitcoin-summary.csv](aml-bitcoin-summary.csv).
+
+## Token Offering Narrative
+
+AML Bitcoin was marketed as a sophisticated cryptocurrency with technology and business adoption prospects. DOJ said Andrade made false statements to the public and potential purchasers about development, viability, potential deals, and release timing. In token markets, those categories are economically important because they can influence whether investors believe a token has utility, adoption, liquidity, or future demand.
+
+The Panama Canal Authority claim illustrates the adoption-risk problem. A major institutional or infrastructure use case can become a powerful market signal, but the signal is only reliable if the relationship is documented and confirmable. DOJ said no such agreement existed. Market-health review should therefore treat claimed partner adoption as unverified until it is supported by signed agreements, public partner statements, implementation plans, and technical integration evidence.
+
+The use-of-proceeds record is also material. DOJ said Andrade defrauded investors out of approximately $10 million, diverted more than $2 million from AML Bitcoin sale proceeds, and spent those funds on personal expenses including properties and luxury automobiles. Investor proceeds should be traceable to token development, compliance work, operations, and reserves rather than unrelated personal expenditures.
+
+## False Market Signals
+
+### Technology-readiness claims
+
+DOJ said Andrade misrepresented AML Bitcoin's technology development and viability. Technology-readiness claims should be supported by code repositories, audits, testnet or mainnet evidence, roadmap completion, independent demos, and security review.
+
+### Release-date claims
+
+Launch timing affects investor expectations and liquidity. If a token issuer gives release-date signals, reviewers should check whether development, compliance, exchange, wallet, custody, and partner dependencies support that timeline.
+
+### Business-deal claims
+
+DOJ highlighted a false claim involving the Panama Canal Authority. Business-deal claims should be confirmed by the named counterparty or by legally binding records, not only by issuer marketing.
+
+### Personal use of proceeds
+
+DOJ said more than $2 million in sale proceeds was diverted to personal expenses. Use-of-proceeds analysis is a core market-health control because development claims require funding paths that match actual development and business work.
+
+### Laundering through bank accounts
+
+DOJ said the jury found that Andrade laundered investor funds through a series of bank accounts and used the funds for personal expenses and asset purchases. Layered banking flows can obscure whether investor money funded the represented token project.
+
+## Event Timeline
+
+| Date or period     | Event                                                                                                 | Market-health signal                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Token sale period  | DOJ said AML Bitcoin was marketed and sold through false and misleading statements.                   | Offering claims required technology, deal, and use-of-proceeds proof. |
+| Pretrial period    | DOJ said Andrade made false public statements about technology, viability, deals, and release date.   | Public issuer claims could influence investor demand and valuation.   |
+| Claimed adoption   | DOJ said Andrade falsely claimed Panama Canal Authority adoption was close when no agreement existed. | Named-partner claims needed counterparty verification.                |
+| March 2025         | DOJ announced a federal jury convicted Andrade of wire fraud and money laundering.                    | Trial outcome confirmed the fraud and laundering record.              |
+| July 29, 2025      | DOJ announced an 84-month federal prison sentence.                                                    | Criminal outcome confirmed accountability for the token-sale scheme.  |
+| September 16, 2025 | DOJ said a hearing was ordered to determine forfeiture and restitution amounts.                       | Recovery amounts remained subject to later court determination.       |
+| October 31, 2025   | DOJ said Andrade was scheduled to begin serving his sentence.                                         | Sentencing implementation date created a case-status milestone.       |
+
+## Reconciliation Metrics
+
+| Metric                    | Enforcement-record figure                                            | Market-health interpretation                                                       |
+| ------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Investor fraud amount     | Approximately $10 million defrauded from cryptocurrency investors    | Token-sale proceeds required project and treasury reconciliation.                  |
+| Diverted proceeds         | More than $2 million diverted from AML Bitcoin sale proceeds         | Personal spending conflicted with development and adoption claims.                 |
+| Sentence                  | 84 months in federal prison and three years of supervised release    | Criminal outcome confirmed accountability.                                         |
+| Technology claim category | Development, viability, business deals, and release date             | Each category required independent evidence before being treated as market signal. |
+| Panama Canal claim        | DOJ said no agreement existed despite claims that adoption was close | Partner-adoption statements required counterparty confirmation.                    |
+| Asset purchases           | Two Texas properties and two luxury automobiles described by DOJ     | Investor proceeds were routed to personal assets.                                  |
+| Restitution status        | Hearing ordered for September 16, 2025                               | Final recovery figures required later court follow-up.                             |
+
+## Detection Checklist
+
+1. Verify token technology claims with code, audits, deployment records, technical demos, and independent security review.
+2. Confirm named partner or customer adoption directly with the counterparty or binding records.
+3. Reconcile sale proceeds to development, compliance, operations, reserves, and disclosed use of funds.
+4. Treat release-date claims as unverified until dependencies and implementation evidence are checked.
+5. Review bank-account transfers and asset purchases for diversion from represented project use.
+6. Preserve legal posture: this article relies on DOJ public conviction and sentencing reporting.
+
+## Market-Health Lessons
+
+AML Bitcoin shows that token market health is not only about secondary-market trades. Primary offering claims about technology, launch readiness, and adoption can shape investor expectations before a token is liquid or fully delivered.
+
+The case also shows why named commercial relationships need direct verification. A single claimed institutional use case can materially affect perceived token value, but market-health reviewers should not credit that signal unless the named counterparty, contract, integration, and implementation path all support it.
+
+## References
+
+- [DOJ AML Bitcoin sentencing release, July 29, 2025](https://www.justice.gov/usao-ndca/pr/founder-and-ceo-aml-bitcoin-sentenced-seven-years-prison-multi-million-dollar-fraud)
+- [DOJ AML Bitcoin conviction release, March 12, 2025](https://www.justice.gov/usao-ndca/pr/cryptocurrency-founder-and-ceo-convicted-wire-fraud-and-money-laundering-connection)
+- [AML Bitcoin indictment, Northern District of California](https://www.justice.gov/usao-ndca/press-release/file/1290051/dl)


### PR DESCRIPTION
Contributes to #277.

This PR adds a market-health case study for AML Bitcoin, focused on token technology-readiness, release-date, and business-adoption claims where DOJ says false statements supported the offering. It includes:

- A new article covering DOJ conviction and sentencing reporting
- A supporting CSV summarizing the chronology and market-health signals
- Primary-source references for the DOJ sentencing release, conviction release, and indictment

Local checks:
- `npx prettier --write content/research/market-health/posts/2025-07-29-aml-bitcoin-technology-deal-claims/index.md`
- `git diff --check -- content/research/market-health/posts/2025-07-29-aml-bitcoin-technology-deal-claims`

Hugo is not installed in this workspace, so I could not run the full site build locally.