### PR TITLE
[codex] Add Profit Connect AI mining return article

### DIFF
--- a/content/research/market-health/posts/2025-02-14-profit-connect-ai-mining-return-claims/index.md
+++ b/content/research/market-health/posts/2025-02-14-profit-connect-ai-mining-return-claims/index.md
@@ -1,0 +1,95 @@
+---
+title: "Profit Connect AI Mining Return Claims"
+date: 2025-02-14
+entities:
+  - Profit Connect
+  - Profit Connect Wealth Services
+  - Brent C. Kovar
+  - Cryptocurrency Mining
+  - Artificial Intelligence
+---
+
+## Summary
+
+This case study analyzes the Profit Connect indictment as a market-health warning about crypto-mining investment products that combine artificial-intelligence claims, fixed rates of return, and money-back guarantees. On February 14, 2025, DOJ announced that Brent C. Kovar, owner of a Las Vegas company, had been indicted in an alleged $24 million cryptocurrency Ponzi scheme.
+
+According to DOJ's summary of the indictment, Kovar allegedly misrepresented that Profit Connect was a profitable, operating artificial-intelligence company that mined cryptocurrency, verified cryptocurrency transactions, paid fixed investment returns, and provided a 100 percent money-back guarantee. DOJ said the indictment alleged that Kovar obtained approximately $24 million from at least 400 investors.
+
+The market-health signal is the collision between fixed yield, AI/supercomputer mining claims, and repayment guarantees. A real mining and transaction-verification business should be able to show hardware, hashrate, validator or mining-pool records, power and hosting costs, wallets, customer allocations, revenue, expenses, and withdrawals. DOJ's indictment summary instead describes investor money allegedly used to operate the company, buy gifts for employees, buy a house, and repay investors as if those repayments came from mining and transaction verification.
+
+The supporting dataset is available in [profit-connect-summary.csv](profit-connect-summary.csv).
+
+## Alleged Mining and AI Narrative
+
+DOJ said the indictment alleged that from late 2017 to July 2021, Kovar owned Profit Connect, a Las Vegas company that purportedly used AI software on a supercomputer to mine cryptocurrency and verify cryptocurrency transactions. The same release said Kovar allegedly represented that Profit Connect paid fixed returns of 15 percent to 30 percent APR and provided a 100 percent money-back guarantee.
+
+Those statements create several independent checks. Mining output should connect to hardware, electricity, pool rewards, wallet flows, and customer contracts. Transaction-verification revenue should map to the relevant blockchain or network role. AI and supercomputer claims should be backed by infrastructure records, model or software descriptions, hosting invoices, and measurable production. Fixed APR and full money-back guarantees should be reconciled to actual revenue, reserve policy, and liquidity.
+
+DOJ also said the indictment alleged that Kovar made the misrepresentations through a website, YouTube video, and PowerPoint presentation, leased office space for a sales office and a warehouse for a data center, and sold investments through Profit Connect Wealth Services. Marketing infrastructure and leased space can support credibility, but market-health review should test whether those signals correspond to real production capacity.
+
+## False Market Signals
+
+### AI supercomputer framing
+
+AI and supercomputer language can make a product seem technically advanced. For a mining-return product, reviewers should require evidence that the claimed AI system or computing infrastructure actually produced the stated revenue.
+
+### Fixed 15 percent to 30 percent APR
+
+Mining economics are variable because of network difficulty, coin price, block rewards, electricity, hardware depreciation, pool fees, and uptime. A fixed APR range requires revenue and reserve proof.
+
+### 100 percent money-back guarantee
+
+A money-back guarantee can create a false safety signal if reserves are not segregated and liquid. Reviewers should verify reserve accounts, redemption history, and whether repayments are funded by operations or new investor deposits.
+
+### FDIC backing implication
+
+DOJ said Kovar allegedly misled some investors to believe their investments were backed by the FDIC. Deposit-insurance references should be verified directly against the type of product, the legal entity, and the insured institution.
+
+### Repayments described as operating returns
+
+DOJ said investor money was allegedly used to repay investors as if repayments came from mining cryptocurrency and verifying transactions. Repayments need to be reconciled to actual operating revenue rather than later investor funds.
+
+## Event Timeline
+
+| Date or period        | Event                                                                                               | Market-health signal                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Late 2017             | DOJ said the indictment alleged Kovar began owning and operating Profit Connect.                    | Start of the AI mining and verification return claim period.                 |
+| Late 2017-July 2021   | DOJ said Profit Connect allegedly claimed to mine cryptocurrency and verify transactions.           | Claimed activity required infrastructure, mining, wallet, and revenue proof. |
+| Late 2017-July 2021   | DOJ said Profit Connect allegedly promised 15 percent to 30 percent APR.                            | Fixed APR needed reconciliation to variable mining economics.                |
+| Late 2017-July 2021   | DOJ said Profit Connect allegedly provided a 100 percent money-back guarantee.                      | Guarantee claims required reserve and redemption proof.                      |
+| Late 2017-July 2021   | DOJ said Kovar allegedly obtained about $24 million from at least 400 investors.                    | Scale required customer-level ledgers and custody controls.                  |
+| Charged scheme period | DOJ said investor money was allegedly used for operations, gifts, a house, and investor repayments. | Use of proceeds needed testing against claimed mining revenue.               |
+| February 14, 2025     | DOJ announced the indictment and Kovar's initial appearance.                                        | Charging event formalized the alleged market-health failures.                |
+| April 8, 2025         | DOJ said a jury trial had been scheduled to begin on that date.                                     | Case posture remained indictment-stage at the time of the release.           |
+
+## Reconciliation Metrics
+
+| Metric               | Indictment-summary figure                                                        | Market-health interpretation                                                   |
+| -------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Investor amount      | Approximately $24 million                                                        | Claimed mining and verification returns required production reconciliation.    |
+| Investor count       | At least 400 investors                                                           | Scale required reliable customer ledgers and redemption records.               |
+| Claimed fixed return | 15 percent to 30 percent APR                                                     | Fixed yield conflicted with variable mining economics unless reserves existed. |
+| Claimed guarantee    | 100 percent money-back guarantee                                                 | Guarantee required segregated, liquid backing.                                 |
+| Claimed operations   | AI software on a supercomputer mining cryptocurrency and verifying transactions  | Technical claims required infrastructure and network evidence.                 |
+| Charged counts       | 12 wire fraud counts, three mail fraud counts, and three money-laundering counts | Criminal allegations reflected a serious enforcement posture.                  |
+| Legal posture        | Indictment-stage allegations; defendant presumed innocent                        | Article should treat claims as allegations until adjudicated.                  |
+
+## Detection Checklist
+
+1. Verify claimed mining or validation activity with hardware, hosting, power, pool, wallet, and network records.
+2. Test AI or supercomputer claims against actual infrastructure and production metrics.
+3. Reconcile fixed APR promises to operating revenue, reserves, and historical payouts.
+4. Verify any money-back guarantee through segregated reserve accounts and redemption history.
+5. Confirm any FDIC or insured-product statement against the actual investment instrument and legal entity.
+6. Separate investor repayments from mining or verification revenue.
+7. Preserve legal posture: this article relies on DOJ's indictment-stage public release, and the defendant is presumed innocent unless proven guilty.
+
+## Market-Health Lessons
+
+Profit Connect shows why AI and mining language should not lower the evidence threshold for investment products. Technical claims are only useful if they connect to measurable infrastructure and on-chain or operational revenue.
+
+The case also shows why guarantees and fixed APR claims are especially important to test. Mining and validation revenue fluctuate, so a fixed return plus a full money-back guarantee should trigger immediate review of reserves, liquidity, and actual operating income.
+
+## References
+
+- [DOJ Profit Connect indictment release, February 14, 2025](https://www.justice.gov/usao-nv/pr/owner-las-vegas-company-indicted-24-million-cryptocurrency-ponzi-scheme)

--- a/content/research/market-health/posts/2025-02-14-profit-connect-ai-mining-return-claims/profit-connect-summary.csv
+++ b/content/research/market-health/posts/2025-02-14-profit-connect-ai-mining-return-claims/profit-connect-summary.csv
@@ -1,0 +1,8 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2017-late,Alleged Profit Connect operation begins,Profit Connect; Brent C. Kovar,DOJ said the indictment alleged Kovar owned Profit Connect from late 2017 to July 2021,Start of AI mining and verification return claim period,DOJ indictment release
+2017-late to 2021-07,AI mining and verification claims,Profit Connect,DOJ said Profit Connect allegedly claimed AI software on a supercomputer mined cryptocurrency and verified transactions,Claimed activity required infrastructure mining wallet and revenue proof,DOJ indictment release
+2017-late to 2021-07,Fixed return claim,Profit Connect,DOJ said Profit Connect allegedly promised 15 percent to 30 percent APR,Fixed yield required reconciliation to variable mining economics,DOJ indictment release
+2017-late to 2021-07,Money-back guarantee claim,Profit Connect,DOJ said Profit Connect allegedly provided a 100 percent money-back guarantee,Guarantee required reserve and redemption proof,DOJ indictment release
+2017-late to 2021-07,Investor scale alleged,Profit Connect; investors,DOJ said Kovar allegedly obtained approximately 24 million USD from at least 400 investors,Scale required customer-level ledgers and custody controls,DOJ indictment release
+charged-period,Use of proceeds alleged,Profit Connect; Brent C. Kovar,DOJ said investor money was allegedly used for operations gifts a house and investor repayments,Use of proceeds needed testing against claimed mining revenue,DOJ indictment release
+2025-02-14,Indictment announced,Brent C. Kovar; Profit Connect,DOJ announced indictment on wire fraud mail fraud and money-laundering counts,Charging event formalized alleged market-health failures,DOJ indictment release


### PR DESCRIPTION
Contributes to #277.

This PR adds a market-health case study for Profit Connect, focused on indictment-stage allegations about AI/supercomputer cryptocurrency mining, fixed APR, and a money-back guarantee. It includes:

- A new article covering DOJ indictment reporting while preserving the allegation/presumption-of-innocence posture
- A supporting CSV summarizing the alleged chronology and market-health signals
- A primary-source reference for the DOJ indictment release

Local checks:
- `npx prettier --write content/research/market-health/posts/2025-02-14-profit-connect-ai-mining-return-claims/index.md`
- `git diff --check -- content/research/market-health/posts/2025-02-14-profit-connect-ai-mining-return-claims`

Hugo is not installed in this workspace, so I could not run the full site build locally.