### PR TITLE
[codex] Add BKCoin crypto fund return article

### DIFF
--- a/content/research/market-health/posts/2025-06-04-bkcoin-crypto-fund-return-claims/bkcoin-summary.csv
+++ b/content/research/market-health/posts/2025-06-04-bkcoin-crypto-fund-return-claims/bkcoin-summary.csv
@@ -1,0 +1,10 @@
+event_date,event,entities,reported_metric,market_health_signal,source
+2018-10 to 2022-09,Investor funds raised,BKCoin Management; Kevin Kang,SEC alleged approximately 100 million USD raised from at least 55 investors,Scale required fund-level account-level and custody tracing,SEC litigation release
+2018-10 to 2022-09,Crypto trading return claim,BKCoin Management; BKCoin Funds,SEC alleged investors were told funds would primarily trade crypto assets,Trading returns required exchange custody order and P&L records,SEC litigation release
+2018-10 to 2022-09,Fund structure claim,BKCoin Management; investors,SEC alleged separately managed accounts and five private funds were represented,Segregation claims required bank exchange and administrator proof,SEC litigation release
+offering period,Commingling alleged,BKCoin Management; Kevin Kang,SEC alleged investor assets were commingled and fund structures disregarded,Commingling weakened reported fund-level balances and return claims,SEC litigation release
+offering period,Ponzi-like payments alleged,BKCoin Management; investors,SEC alleged more than 3.6 million USD used for Ponzi-like payments,Distributions needed source-of-funds testing,SEC litigation release
+offering period,Altered administrator documents alleged,Kevin Kang; third-party administrator,SEC alleged altered documents with inflated bank balances were provided to an administrator,Independent source records were needed to verify administrator materials,SEC litigation release
+2023-03-06,Emergency action announced,SEC; BKCoin Management; Kevin Kang,SEC announced asset freeze receiver appointment and emergency relief,Enforcement action documented alleged fund-control failures,SEC litigation release
+2024-08-13,Partial judgment entered,Kevin Kang,SEC-hosted partial judgment showed case moved toward judgment-stage relief,Judgment-stage posture changed risk and legal status,SEC partial judgment
+2025-06-04,Final judgment entered,Kevin Kang,Court ordered 944874.11 USD in disgorgement prejudgment interest and civil penalty,Final judgment imposed injunctions conduct restrictions and payment,SEC final judgment

--- a/content/research/market-health/posts/2025-06-04-bkcoin-crypto-fund-return-claims/index.md
+++ b/content/research/market-health/posts/2025-06-04-bkcoin-crypto-fund-return-claims/index.md
@@ -1,0 +1,100 @@
+---
+title: "BKCoin Crypto Fund Return Claims"
+date: 2025-06-04
+entities:
+  - BKCoin Management
+  - Min Woo Kang
+  - Kevin Kang
+  - Bison Digital
+  - BKCoin Funds
+  - Crypto Asset Trading
+---
+
+## Summary
+
+This case study analyzes the SEC's BKCoin action as a market-health warning about crypto-asset funds that claim structured trading accounts, audited credibility, and fund-level separation while investor assets are allegedly commingled and used for Ponzi-like payments. On March 6, 2023, the SEC announced an emergency action against BKCoin Management LLC and principal Min Woo Kang, also known as Kevin Kang.
+
+According to the SEC's litigation release, from at least October 2018 through September 2022, BKCoin raised approximately $100 million from at least 55 investors to invest in crypto assets. The SEC alleged that BKCoin and Kang told investors their money would be used primarily to trade crypto assets through separately managed accounts and five private funds.
+
+The SEC alleged that the defendants disregarded fund structures, commingled investor assets, used more than $3.6 million for Ponzi-like payments, and misappropriated at least $371,000 for personal expenses. The SEC also alleged that Kang tried to conceal unauthorized use of investor money by giving altered documents with inflated bank balances to the third-party administrator for certain funds.
+
+On June 4, 2025, the court entered a final judgment as to Kang. The judgment permanently enjoined him from violating antifraud provisions, imposed conduct-based securities and adviser restrictions, barred him from serving as an officer or director of certain companies, and ordered $944,874.11 in disgorgement, prejudgment interest, and civil penalty. The supporting dataset is available in [bkcoin-summary.csv](bkcoin-summary.csv).
+
+## Fund Structure Narrative
+
+The SEC's complaint alleged that BKCoin presented a professional investment-adviser structure. Investor funds were supposedly allocated to separately managed accounts and five private funds, with crypto-asset trading expected to generate returns.
+
+That structure creates measurable controls. A fund manager should be able to map each investor contribution to a fund or account, bank ledger, exchange account, custody account, executed trade, valuation policy, administrator report, audited financial statement, and redemption or distribution ledger.
+
+The SEC alleged that BKCoin and Kang disregarded the stated structures and commingled assets. In market-health terms, commingling can make account statements, fund-level return figures, and redemption history unreliable unless they are reconciled against independent bank, exchange, custody, administrator, and audit records.
+
+## False Market Signals
+
+### Separately managed account claim
+
+The SEC alleged that investors were told their money would be used through separately managed accounts and private funds. Reviewers should verify whether money actually remained segregated at the promised account and fund levels.
+
+### Crypto trading return claim
+
+The release said investors were told BKCoin would generate returns by trading crypto assets. Trading return claims require exchange statements, order history, realized and unrealized P&L, fees, custody records, and risk limits.
+
+### Ponzi-like payment signal
+
+The SEC alleged that more than $3.6 million was used to make Ponzi-like payments to fund investors. Payouts should be reconciled to actual trading profits rather than later investor deposits.
+
+### Administrator-document signal
+
+The SEC alleged that Kang provided altered documents with inflated bank balances to the third-party administrator for certain funds. Administrator records should be matched to source bank and custody statements, not accepted as stand-alone proof.
+
+### Audit-opinion signal
+
+The SEC alleged that BKCoin materially misrepresented to some investors that BKCoin or one of its funds had received an audit opinion from a "top four auditor," when no such audit opinion existed. Audit claims should be verified directly against the auditor, engagement scope, date, entity, and issued opinion.
+
+## Event Timeline
+
+| Date or period              | Event                                                                                                          | Market-health signal                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| October 2018-September 2022 | The SEC alleged BKCoin raised approximately $100 million from at least 55 investors.                           | Scale required fund-level ledgers, custody, and trading reconciliation.   |
+| Offering period             | Investors were allegedly told funds would primarily trade crypto assets.                                       | Trading returns required exchange, custody, order, and P&L records.       |
+| Offering period             | Investors were allegedly told returns would come through separately managed accounts and five funds.           | Structure claims needed segregation proof.                                |
+| Offering period             | The SEC alleged investor assets were commingled and fund structures disregarded.                               | Commingling weakened reported fund-level balances and return claims.      |
+| Offering period             | The SEC alleged more than $3.6 million was used for Ponzi-like payments.                                       | Distributions needed source-of-funds testing.                             |
+| Offering period             | The SEC alleged Kang misappropriated at least $371,000 and sent altered balance documents to an administrator. | Independent source records were needed to verify administrator materials. |
+| March 6, 2023               | The SEC announced emergency relief, including an asset freeze and receiver appointment.                        | Enforcement action documented alleged fund-control failures.              |
+| August 13, 2024             | The court entered a partial judgment as to Kang.                                                               | Case moved from emergency allegations toward judgment-stage relief.       |
+| June 4, 2025                | The court entered final judgment as to Kang.                                                                   | Final judgment imposed injunctions, conduct restrictions, and payment.    |
+
+## Reconciliation Metrics
+
+| Metric                  | SEC allegation or judgment figure                                                     | Market-health interpretation                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Amount raised           | Approximately $100 million                                                            | Investor funds needed fund-level, account-level, and custody tracing.        |
+| Investor count          | At least 55 investors                                                                 | Customer records should connect subscriptions, allocations, and redemptions. |
+| Fund structure          | Separately managed accounts and five private funds                                    | Segregation claims required bank, exchange, and administrator proof.         |
+| Ponzi-like payments     | More than $3.6 million                                                                | Distributions needed reconciliation to real trading profits.                 |
+| Personal-use allegation | At least $371,000                                                                     | Use-of-proceeds controls were a core failure point.                          |
+| Bison Digital flow      | Approximately $12 million allegedly received by Bison Digital                         | Relief-defendant transfers needed economic-purpose review.                   |
+| Kang final judgment     | $944,874.11 in disgorgement, prejudgment interest, and civil penalty                  | Judgment confirmed a final monetary remedy against Kang.                     |
+| Legal posture           | Final judgment against Kang without admission or denial, except bankruptcy provisions | Article should separate alleged facts from judgment and settlement posture.  |
+
+## Detection Checklist
+
+1. Reconcile investor subscriptions to fund bank accounts, exchange accounts, custody accounts, and administrator records.
+2. Test separately managed account claims against actual account segregation and account ownership.
+3. Reconcile trading returns to executed crypto-asset trades, fees, custody, valuation policy, and realized P&L.
+4. Trace investor distributions to trading profits rather than later investor deposits.
+5. Verify audit-opinion claims directly with the auditor, the exact fund entity, the period covered, and the issued opinion.
+6. Compare administrator materials against source bank and custody statements.
+7. Preserve legal posture: Kang's June 4, 2025 final judgment imposed remedies without a broad admission of the complaint allegations, except as stated for bankruptcy nondischargeability.
+
+## Market-Health Lessons
+
+BKCoin shows why fund structure is itself a market-health signal. Separately managed accounts, private funds, administrators, and audit references can all signal institutional discipline, but each claim needs source-record verification.
+
+The case also shows why payout history is not enough to validate a crypto trading fund. If distributions come from investor money rather than trading profits, apparent performance becomes a financing artifact instead of market evidence.
+
+## References
+
+- [SEC litigation release, BKCoin, March 6, 2023](https://www.sec.gov/enforcement-litigation/litigation-releases/lr-25657)
+- [SEC complaint, SEC v. BKCoin Management, LLC, et al.](https://www.sec.gov/litigation/complaints/2023/comp-pr2023-45.pdf)
+- [Final judgment as to Min Woo Kang, June 4, 2025](https://www.sec.gov/file/finaljudg23-cv-20719kang)


### PR DESCRIPTION
## Summary
- Add a market-health case study on BKCoin crypto-fund trading return and fund-structure claims.
- Include a CSV timeline covering investor funds, fund-structure representations, commingling, Ponzi-like payments, altered administrator records, and the 2025 final judgment as to Kang.
- Source the article from the SEC litigation release, complaint, and SEC-hosted final judgment.

## Validation
- npx prettier --write content/research/market-health/posts/2025-06-04-bkcoin-crypto-fund-return-claims/index.md
- git diff --cached --check -- content/research/market-health/posts/2025-06-04-bkcoin-crypto-fund-return-claims
- Hugo is not installed locally, so the full site build was not run.

Contributes to #277.