### PR TITLE
Add Scream fixed-price collateral market health case study

### DIFF
--- a/content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/index.md
+++ b/content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/index.md
@@ -1,0 +1,132 @@
+---
+title: "Scream's fUSD and DEI fixed-price collateral failure"
+date: "2022-05-16"
+description: "A Fantom lending market kept depegged stablecoins priced at one dollar, allowing borrowers to transform discounted fUSD and DEI collateral into protocol bad debt."
+entities:
+  - Scream
+  - fUSD
+  - DEI
+  - Fantom
+  - SCREAM
+---
+
+In May 2022, Scream, a Compound-style lending protocol on Fantom, showed how a
+stablecoin depeg can become a market-manipulation channel when collateral
+prices are fixed by policy rather than refreshed from executable markets.
+During the post-Terra stablecoin stress, Fantom USD (fUSD) and DEI traded below
+their dollar targets while Scream continued to value them at one dollar in its
+lending markets. Users could therefore acquire or hold discounted fUSD and DEI,
+deposit them as if they were worth par, and borrow other stablecoins against the
+inflated collateral value.
+
+The public loss estimates converged around 35 million dollars of bad debt.
+CryptoSlate reported that Scream had hardcoded fUSD and DEI at one dollar, that
+DEI traded as low as 0.52 dollars and fUSD as low as 0.69 dollars, and that
+borrowers drained stablecoins such as FRAX, Fantom USDT, USDC, and MIM from the
+protocol while posting the depegged assets as collateral. Crypto.news reported
+the same 35 million dollar bad-debt estimate and noted that fUSD's Scream
+deposit limit was set to infinity rather than zero. DefiLlama's Scream protocol
+history shows total liquidity falling from 184.4 million dollars on May 13,
+2022 to 98.3 million dollars on May 16, 65.8 million dollars on May 17, and
+33.8 million dollars by May 20.
+
+This was not a conventional smart-contract drain in which the attacker directly
+breaks an invariant and transfers funds. The exploitable surface was the
+market-health layer between an external traded price and an internal collateral
+price. Once the internal price failed to move with the market, the lending
+engine created artificial solvency for accounts backed by below-par collateral.
+The protocol's accounting still saw one dollar of fUSD or DEI; secondary
+markets saw a much lower liquidation value.
+
+## Incident metrics
+
+| Signal                    | Observation                                                                                                         | Market-health interpretation                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Internal collateral price | fUSD and DEI were quoted at one dollar inside Scream while trading below peg                                        | A fixed collateral quote disconnected borrower health from liquidation value                              |
+| Reported external lows    | fUSD around 0.69 dollars and DEI around 0.52 dollars in public reports                                              | The haircut required to keep loans solvent was materially larger than a normal stablecoin basis           |
+| Reported bad debt         | Approximately 35 million dollars                                                                                    | The pricing gap was large enough to turn collateral-price risk into protocol insolvency                   |
+| Liquidity drop            | DefiLlama shows Scream TVL/liquidity falling from 184.4 million dollars on May 13 to 33.8 million dollars on May 20 | Liquidity flight compounded the accounting loss and reduced remaining user exit capacity                  |
+| Limit configuration       | Public reports said the fUSD deposit limit was effectively unlimited                                                | Exposure caps failed at the exact point where the oracle/input price was least reliable                   |
+| Remediation signal        | Scream said it would work with Fantom Foundation liquidation support and move toward Chainlink oracle pricing       | The corrective action shifted from manual fixed prices toward live price feeds and liquidation automation |
+
+The same data is separated into `scream-fusd-dei-market-signals.csv` for reuse
+in incident dashboards or cross-protocol comparison.
+
+## Manipulation path
+
+The useful surveillance model is a three-step loop:
+
+1. A supposedly stable collateral asset loses peg in executable markets.
+2. The lending protocol continues to mark that asset at par, either through a
+   hardcoded price, stale oracle, or governance-maintained assumption.
+3. Borrowers convert the spread into extraction by borrowing assets that still
+   trade near par.
+
+The strategy does not require the borrower to manipulate the external price
+directly. The market manipulation is the use of the internal misquote as a
+synthetic exchange rate. When fUSD or DEI collateral was accepted at one dollar
+inside Scream while available market evidence implied lower realizable value,
+the lending pool became an off-market venue where discounted collateral could be
+monetized at par.
+
+This pattern is especially dangerous for algorithmic or protocol-native
+stablecoins because their peg can fail exactly when correlated collateral,
+liquidity depth, and user confidence deteriorate. During a broad stablecoin
+shock, governance teams and protocol operators may also be slower to cut limits
+because reducing a collateral asset to market price can immediately crystallize
+bad debt and liquidations. That delay is itself a market-health signal.
+
+## Detection controls
+
+Lending markets should treat stablecoin parity as an assumption that expires
+quickly, not as a constant. For every collateral asset that is expected to trade
+at one dollar, the risk engine should track a minimum set of real-time and
+delayed controls:
+
+- Compare internal collateral price with executable DEX/CEX prices, pool
+  redemption rates, and deep-liquidity stablecoin pairs.
+- Trigger a collateral-factor reduction or borrow pause when a stablecoin
+  trades outside a narrow band, such as 0.98 to 1.02 dollars, for more than a
+  short observation window.
+- Cap deposits and borrows for newly listed or recently stressed stablecoins
+  until the peg, redemption path, and liquidity depth are proven in live market
+  conditions.
+- Monitor borrow concentration against the questionable collateral, especially
+  when users borrow more liquid stablecoins or assets with better redemption
+  quality.
+- Separate emergency liquidation logic from the same governance path that
+  listed the collateral, so operators can reduce exposure without waiting for a
+  full governance cycle.
+- Publish outstanding bad debt by collateral type after a depeg so depositors
+  can distinguish ordinary utilization from insolvency.
+
+The critical metric is not only the collateral price itself. A protocol can see
+early warning by combining oracle-vs-market divergence, collateral deposit
+velocity, stablecoin borrow outflows, and remaining pool liquidity. In Scream's
+case, the useful alarm would have been the joint movement: below-peg fUSD and
+DEI, unchanged one-dollar internal collateral valuation, high borrowing demand
+for stronger stablecoins, and a rapid drop in Scream liquidity.
+
+## Lessons for market health
+
+Stablecoin lending markets need a market-health rule that is stricter than
+"stablecoins equal one dollar." A better rule is: a stablecoin counts as one
+dollar only while observable markets, redemption mechanics, and liquidity depth
+continue to support that value. When those signals break, the protocol should
+assume the asset is volatile collateral and apply haircuts, limits, or a pause.
+
+The Scream incident also shows why exchange and protocol surveillance should
+watch internal pricing venues, not only public markets. If a public market says
+an asset is worth 0.52 to 0.69 dollars while a lending market lets it borrow at
+one dollar, the lending market is effectively offering a subsidized exit path.
+That spread can be extracted until the borrowable assets are gone or until the
+operator updates the price. A market-health dashboard should therefore surface
+protocol-level mispricing as an abuse opportunity even before a transaction is
+classified as an exploit.
+
+## References
+
+- [CryptoSlate: Scream protocol loses millions to stablecoin depeg](https://cryptoslate.com/scream-protocol-losses-millions-to-stablecoin-depeg/)
+- [Crypto.news: Fantom's Scream DeFi Protocol incurs $35M bad debt](https://crypto.news/fantoms-scream-defi-protocol-incurs-35m-bad-debt-as-two-more-stablecoins-lose-usd-peg/)
+- [Smart Contract Hacking incident page for Scream](https://smartcontractshacking.com/hacks/scream-hack-2022)
+- [DefiLlama Scream protocol data](https://defillama.com/protocol/scream)

--- a/content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/scream-fusd-dei-market-signals.csv
+++ b/content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/scream-fusd-dei-market-signals.csv
@@ -1,0 +1,12 @@
+date,entity,signal,value,source,market_health_use
+2022-05-13,Scream,total_liquidity_usd,184441420,https://api.llama.fi/protocol/scream,pre-incident liquidity baseline
+2022-05-16,Scream,total_liquidity_usd,98347123,https://api.llama.fi/protocol/scream,liquidity drawdown during bad-debt recognition
+2022-05-17,Scream,total_liquidity_usd,65795865,https://api.llama.fi/protocol/scream,continued liquidity exit after depeg-priced borrowing
+2022-05-20,Scream,total_liquidity_usd,33768023,https://api.llama.fi/protocol/scream,post-incident liquidity floor in source window
+2022-05-16,Scream,reported_bad_debt_usd,35000000,https://cryptoslate.com/scream-protocol-losses-millions-to-stablecoin-depeg/,protocol insolvency estimate from fixed-price collateral
+2022-05-16,fUSD,reported_market_low_usd,0.69,https://cryptoslate.com/scream-protocol-losses-millions-to-stablecoin-depeg/,external price below internal one-dollar collateral quote
+2022-05-16,DEI,reported_market_low_usd,0.52,https://cryptoslate.com/scream-protocol-losses-millions-to-stablecoin-depeg/,external price below internal one-dollar collateral quote
+2022-05-16,fUSD,reported_deposit_limit,infinity,https://crypto.news/fantoms-scream-defi-protocol-incurs-35m-bad-debt-as-two-more-stablecoins-lose-usd-peg/,missing exposure cap during collateral price stress
+2022-05-16,Scream,affected_borrow_assets,"FRAX;Fantom USDT;USDC;MIM;DAI",https://crypto.news/fantoms-scream-defi-protocol-incurs-35m-bad-debt-as-two-more-stablecoins-lose-usd-peg/,borrowed stronger stablecoins against mispriced collateral
+2022-05-16,Scream,reported_tvl_change_24h_pct,-50,https://cryptoslate.com/scream-protocol-losses-millions-to-stablecoin-depeg/,rapid liquidity loss and withdrawal pressure
+2022-05-16,Scream,remediation_signal,"liquidation bot and Chainlink oracle migration",https://cryptoslate.com/scream-protocol-losses-millions-to-stablecoin-depeg/,move from fixed pricing toward live oracle and liquidation controls


### PR DESCRIPTION
## Summary

Adds a single Market Health article for issue #277 covering the May 2022 Scream fUSD/DEI fixed-price collateral failure on Fantom.

Scope:
- new article under `content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/`
- companion `scream-fusd-dei-market-signals.csv` with structured TVL, bad-debt, depeg, limit, and remediation signals
- source-linked monitoring notes for oracle-vs-market divergence, stablecoin collateral caps, borrow concentration, and liquidity drawdown

I checked open/all PRs and local market-health content for Scream, fUSD, and DEI first and did not find an existing Scream market-health article submission. This is distinct from the open Deus Finance article, which covers the May 2023 DEUS/DEI contract exploit rather than Scream's May 2022 lending-market collateral pricing failure.

Validation run locally:
- `npx --yes prettier --check --ignore-unknown content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/index.md content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/scream-fusd-dei-market-signals.csv`
- `npx --yes markdownlint-cli --disable MD013 --ignore node_modules -- content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/index.md`
- `awk -F, 'NF != 6 { print "bad row", NR, NF; bad=1 } END { exit bad }' content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/scream-fusd-dei-market-signals.csv`
- `git diff --cached --check`
- referenced URL check: all referenced URLs returned HTTP 200 locally

Hugo build was not run because `hugo` is not installed in this environment.

@marina-chibizova @sofiasedlova could you review when convenient?

For #277. /claim #277


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a new Market Health case study documenting the May 2022 Scream fUSD/DEI fixed-price collateral failure on Fantom.

## Changes

**New files added:**
- `content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/index.md` — Main article with structured frontmatter and detailed incident analysis (132 lines added)
- `content/research/market-health/posts/2022-05-16-scream-fusd-dei-oracle-price-failure/scream-fusd-dei-market-signals.csv` — Companion CSV containing structured market signals (TVL, bad-debt, depeg, limit, remediation)

## Content overview

The article documents how Scream continued valuing fUSD/DEI collateral at one dollar while those assets traded below peg, resulting in approximately $35M in reported bad debt. The post includes:
- Incident metrics with tabular data and interpretations
- Manipulation path explanation (three-step synthetic exchange rate loop)
- Detection controls covering risk-engine rules and monitoring approaches
- Lessons for market health (stricter parity rules and internal pricing venue surveillance)
- References section with external sources and data links

## Validation

Author completed the following validation steps:
- Prettier formatting check
- markdownlint validation (MD013 disabled)
- CSV row-count and field-count verification using awk
- `git diff --cached --check`
- Referenced URL validation (HTTP 200 responses verified locally)

Hugo build was not executed due to unavailable tooling in the validation environment.

## Notes

The author verified no duplicate content exists in related issues or current PRs and confirmed this incident is distinct from a separate Deus Finance article covering a May 2023 incident (referenced in issue #277).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/1046)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->