### PR TITLE
Add 0VIX vGHST oracle-manipulation market health case

### DIFF
--- a/content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/0vix-vghst-market-signals.csv
+++ b/content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/0vix-vghst-market-signals.csv
@@ -1,0 +1,7 @@
+date,entity,signal,value,source,market_health_use
+2023-04-27,0VIX,total_liquidity_usd,6417598,https://api.llama.fi/protocol/0vix,pre-exploit liquidity baseline
+2023-04-28,0VIX,total_liquidity_usd,6338982,https://api.llama.fi/protocol/0vix,incident-day protocol liquidity
+2023-04-29,0VIX,total_liquidity_usd,1645963,https://api.llama.fi/protocol/0vix,post-exploit liquidity drawdown
+2023-04-28,0VIX,exploit_mechanism,flash-loan funded vGHST price and oracle manipulation,https://blog.solidityscan.com/ovix-protocol-hack-analysis-oracle-price-manipulation-4bd2755ea85e/,same-transaction collateral repricing and liquidation path
+2023-04-28,0VIX,loss_estimate_usd,2000000,https://theblockchain.digital/0vix-protocol-drained-for-2m-in-oracle-manipulation-exploit/,loss magnitude for risk scoring
+2023-04-28,0VIX,transaction_shape,278_events,https://smartcontractshacking.com/hacks/ovix-hack-2023,complex one-transaction path suitable for flash-loan alerting

--- a/content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/index.md
+++ b/content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/index.md
@@ -1,0 +1,104 @@
+---
+title: "0VIX vGHST oracle-manipulation market-health case"
+date: "2023-04-28"
+description: "0VIX was drained after a flash-loan funded vGHST price manipulation turned oracle pricing into an unsafe collateral and liquidation signal."
+entities:
+  - 0VIX
+  - vGHST
+  - GHST
+  - Polygon
+---
+
+0VIX, a Polygon lending protocol, was exploited on April 28, 2023 after an
+attacker used flash-loan liquidity and vGHST accounting to manipulate the value
+reported to the lending market. The incident is a useful market-health case
+because the loss was not only a contract-level exploit. It was also a live
+market-state failure: collateral pricing, pool balances, liquidation paths, and
+protocol exposure moved together inside a short execution window.
+
+Security write-ups describe an attacker depositing a large amount of vGHST into
+the vGHST oracle flow and inflating the vGHST-to-GHST price used by the
+protocol. 0VIX publicly paused its POS and zkEVM markets while investigating an
+issue related to vGHST, and later incident summaries estimated the loss at about
+2 million dollars. DefiLlama's protocol data shows total liquidity near 6.34
+million dollars on April 28 and about 1.65 million dollars on April 29, making
+the liquidity shock visible as a next-day market-health break.
+
+## Incident metrics
+
+| Signal              | Observation                                                                    | Market-health interpretation                                                                          |
+| ------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Oracle path         | vGHST pricing was manipulated through the protocol's oracle-related accounting | Collateral valuation depended on a manipulable market state instead of a hardened reference price     |
+| Funding source      | The attacker used flash-loan liquidity in the transaction path                 | Borrowed notional can create abnormal collateral pressure without prior position history              |
+| Asset concentration | The reported issue centered on vGHST-related markets and oToken operations     | A single collateral lane became the risk carrier for the broader lending market                       |
+| Loss estimate       | Public summaries put the loss near 2 million dollars                           | The manipulated quote was large enough to drain economically meaningful liquidity                     |
+| Liquidity path      | DefiLlama shows 0VIX liquidity falling from about 6.34 million to 1.65 million | The exploit produced a measurable protocol-liquidity drawdown within one day                          |
+| Operational action  | 0VIX paused POS and zkEVM markets while investigating the vGHST issue          | Market-health monitoring should escalate oracle anomalies into borrow and liquidation pause decisions |
+
+The companion `0vix-vghst-market-signals.csv` file separates the TVL,
+mechanism, loss-estimate, and transaction-shape observations for reuse in
+dashboards or automated surveillance checks.
+
+## Manipulation path
+
+The core loop was:
+
+1. Flash-loan liquidity let the attacker create a large temporary position.
+2. The attacker moved vGHST-related balances through the lending and oracle
+   path.
+3. The protocol accepted the manipulated vGHST-to-GHST value as a usable market
+   signal.
+4. Inflated collateral value and liquidation mechanics let the attacker extract
+   assets from the lending market.
+5. 0VIX paused affected operations while investigating the vGHST incident.
+
+That loop is important for market-health monitoring because every step is a
+state transition that can be observed before, during, or immediately after the
+loss. A surveillance system does not need to understand every contract opcode to
+flag the combination of flash-loan notional, concentrated collateral movement,
+oracle repricing, and same-transaction borrowing or liquidation activity.
+
+## Detection controls
+
+Lending protocols should treat small collateral-oracle surfaces as high-priority
+market-health inputs when the collateral can be moved or repriced inside the
+same transaction that consumes the quote. Useful controls include:
+
+- **Oracle-vs-pool divergence:** compare collateral oracle output with pool
+  balance changes and external market depth before accepting new borrows.
+- **Flash-loan notional screens:** flag borrowing or liquidation paths where
+  temporary capital is large relative to the asset's ordinary liquidity.
+- **Per-asset supply and borrow caps:** reduce the maximum loss that a
+  single-collateral oracle path can create before governance or operators
+  intervene.
+- **Same-transaction liquidation guards:** slow or pause liquidations when the
+  collateral value was just moved by the same account or funding source.
+- **Emergency pause triggers:** connect oracle anomaly alerts to market-specific
+  pause controls for minting, transfers, borrowing, and liquidation.
+
+0VIX shows why a lending dashboard should not render oracle values as isolated
+price points. The operational risk appears when oracle movement, collateral
+composition, and borrow or liquidation demand align. That alignment is the
+market-health signal.
+
+## Lessons for market health
+
+The safest lesson is that collateral oracles need behavioral context. A price
+that changes because a deep external market repriced an asset is different from
+a price that changes because a thin collateral path was manipulated by temporary
+capital. Both may look like numeric quote movement, but only the second implies
+an immediate abuse path through borrowing and liquidation.
+
+For surveillance teams, the 0VIX case supports alerts that combine four data
+families: oracle output, collateral balance movement, transaction funding
+source, and protocol-liquidity drawdown. If those signals fire together, the
+defensive action should be market-specific and fast: set the affected collateral
+factor to zero, cap new exposure, or pause the affected mint and liquidation
+paths until the oracle input is validated against external depth.
+
+## References
+
+- [SolidityScan: Ovix Protocol Hack Analysis - Oracle Price Manipulation](https://blog.solidityscan.com/ovix-protocol-hack-analysis-oracle-price-manipulation-4bd2755ea85e/)
+- [TheBlockchain.Digital: 0VIX Protocol Drained For $2m In Oracle Manipulation Exploit](https://theblockchain.digital/0vix-protocol-drained-for-2m-in-oracle-manipulation-exploit/)
+- [Smart Contract Hacking: Ovix Hack (2023)](https://smartcontractshacking.com/hacks/ovix-hack-2023)
+- [DefiLlama 0VIX protocol data](https://defillama.com/protocol/0vix)


### PR DESCRIPTION
## Summary
Adds a single Market Health article for issue #277 covering the April 2023 0VIX vGHST/GHST oracle-manipulation and liquidation-risk incident on Polygon.

Scope:
- new article under `content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/`
- companion `0vix-vghst-market-signals.csv` with TVL, mechanism, loss-estimate, and transaction-shape signals
- source-linked monitoring notes for oracle-vs-pool divergence, flash-loan notional, same-transaction liquidation paths, collateral caps, and pause triggers

I checked open/all PRs and local content for 0VIX/vGHST first. The repo already has a cyberattack incident page for 0VIX, but I did not find an open Market Health article or companion dataset for this collateral-oracle case.

## Validation
- `npx --yes prettier --write --ignore-unknown content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/index.md content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/0vix-vghst-market-signals.csv`
- `npx --yes prettier --check --ignore-unknown content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/index.md content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/0vix-vghst-market-signals.csv`
- `npx --yes markdownlint-cli --disable MD013 --ignore node_modules -- content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/index.md`
- `awk -F, 'NF != 6 { print "bad row", NR, NF; bad=1 } END { exit bad }' content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation/0vix-vghst-market-signals.csv`
- `git diff --check`
- `LC_ALL=C rg -n "[^[:ascii:]]" content/research/market-health/posts/2023-04-28-0vix-vghst-oracle-manipulation` returned no matches
- referenced URL check returned HTTP 200 for SolidityScan, TheBlockchain.Digital, Smart Contract Hacking, DefiLlama, and the DefiLlama API source
- duplicate PR search for `0vix OR 0VIX OR vGHST` found only the existing merged cyberattack PR #162

Hugo build was not run because `hugo` is not installed locally.

@marina-chibizova @sofiasedlova could you review when convenient?

For #277. /claim #277
