### PR TITLE
Add Rodeo TWAP oracle market health case

### DIFF
--- a/content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/index.md
+++ b/content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/index.md
@@ -1,0 +1,104 @@
+---
+title: "Rodeo Finance TWAP oracle manipulation market-health case"
+date: "2023-07-11"
+description: "Rodeo Finance lost about 472 ETH on Arbitrum after a sandwich-style sequence manipulated a TWAP oracle path used by its leveraged yield strategy."
+entities:
+  - Rodeo Finance
+  - Arbitrum
+  - unshETH
+  - USDC
+  - Camelot
+---
+
+Rodeo Finance was exploited on Arbitrum on July 11, 2023 after an attacker
+manipulated the oracle path used by a leveraged yield strategy. Public incident
+writeups describe the attack as a sandwich-style manipulation of a TWAP oracle:
+the attacker moved the relevant market price, caused Rodeo's strategy logic to
+act on the distorted reading, and then arbitraged the pool back toward its
+normal state after the protocol had already taken the harmful action.
+
+The loss was reported at roughly 472 ETH, or about 880,000 to 888,000 dollars
+after recalculation. Some summaries cite a larger gross impact near 1.7 million
+dollars before partial recovery. For market-health analysis, the important
+signal is that a TWAP control meant to reduce spot-price manipulation still
+became usable inside a tightly ordered transaction sequence when the relevant
+pool depth and update path were not strong enough for the strategy's exposure.
+
+## Incident metrics
+
+| Signal            | Observation                                                                  | Market-health interpretation                                                       |
+| ----------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Exploit date      | The malicious transaction sequence occurred on July 11, 2023                 | Same-day strategy and oracle monitoring should cover active Arbitrum yield markets |
+| Reported loss     | DN Institute and PeckShield-linked reporting put the loss near 472 ETH       | A single oracle path created material lending and strategy exposure                |
+| Oracle weakness   | The strategy depended on a TWAP oracle path that could be sandwiched         | TWAP windows still need manipulation-cost and liquidity-depth checks               |
+| Market route      | Public reports tie the manipulation to unshETH and related swap routes       | Strategy assets need route-specific liquidity and slippage monitors                |
+| Recovery signal   | Smart Contract Hacking reports about 810,000 dollars recovered from the farm | Recovery and net-loss data should be tracked separately from gross exploit impact  |
+| TVL impact        | Crypto Briefing reported TVL fell from about 20 million dollars to below 500 | Post-exploit liquidity flight is a market-health event, not only a security metric |
+| Attacker movement | Public reporting described bridged funds and Tornado Cash routing            | Cross-chain and mixer flows help classify adversarial extraction                   |
+
+The companion `rodeo-twap-market-signals.csv` file records exploit-date, loss,
+oracle, route, recovery, TVL-impact, and fund-flow signals for reuse.
+
+## Manipulation path
+
+The exploit turned a manipulated oracle window into a harmful strategy action:
+
+1. The attacker prepared the Arbitrum transaction sequence and targeted the
+   strategy path that relied on the vulnerable TWAP reading.
+2. The attacker manipulated the market route used by the oracle, affecting the
+   price context Rodeo used for the strategy operation.
+3. Rodeo's logic acted on the distorted price and moved assets through the
+   leveraged strategy path.
+4. The attacker traded the pool back toward its prior state, capturing the
+   difference created by the protocol's action at the manipulated price.
+5. Proceeds were bridged and swapped across Ethereum and Arbitrum routes, with
+   public reporting noting Tornado Cash activity.
+
+The market-health lesson is that TWAP does not automatically remove oracle
+risk. A TWAP is safer only when its update cadence, observation window,
+underlying pool liquidity, and strategy exposure are sized together. If a
+strategy can force or rely on a vulnerable update during a sandwichable route,
+then the TWAP becomes a delayed spot-price dependency rather than a robust
+market signal.
+
+## Detection controls
+
+Rodeo points to controls that should sit around leveraged-yield strategy
+oracles:
+
+- **TWAP manipulation-cost checks:** compare the cost of moving the reference
+  pool with the strategy's maximum borrow or investment exposure.
+- **Route-depth gates:** pause strategy actions when the reference route has
+  shallow liquidity relative to the transaction size.
+- **Same-block route reversal alerts:** flag transactions that move an oracle
+  route, trigger protocol strategy logic, and then restore the route.
+- **Gross versus net loss tracking:** separate stolen amount, recovered amount,
+  and remaining net loss in incident dashboards.
+- **TVL-flight monitors:** track post-incident TVL collapse as a liquidity and
+  user-confidence metric.
+- **Cross-chain flow alerts:** connect Arbitrum exploit transactions with
+  bridge, Ethereum swap, and mixer activity.
+
+These controls focus on observable market state rather than private attacker
+intent. They would surface when a strategy's reference route becomes cheaper to
+manipulate than the value protected by that route.
+
+## Lessons for market health
+
+Rodeo Finance is a reminder that oracle design and market liquidity cannot be
+reviewed separately. A price feed can have the right label, such as TWAP, while
+still being unsafe for a specific strategy if the reference market is thin or
+the action being authorized is too large.
+
+For market-health teams, the actionable pattern is a sequence that combines
+large route movement, strategy execution, route reversal, rapid TVL exit, and
+cross-chain fund movement. When those signals appear together, the protocol is
+not only experiencing a contract exploit. It is showing that market depth,
+oracle design, and strategy exposure have become misaligned.
+
+## References
+
+- [DN Institute cyberattack incident: Rodeo Finance](https://dn.institute/research/cyberattacks/incidents/2023-07-11-rodeo-finance/)
+- [Smart Contract Hacking: Rodeo Finance Hack](https://smartcontractshacking.com/hacks/rodeo-finance-hack-2023)
+- [Crypto Briefing: DeFi Protocol Rodeo Finance Hacked](https://cryptobriefing.com/defi-protocol-rodeo-finance-hacked-1-53m-of-eth-stolen/)
+- [CertiK: Lending Contract Exploits - A Retrospective](https://www.certik.com/blog/lending-contract-exploits-a-retrospective)

--- a/content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/rodeo-twap-market-signals.csv
+++ b/content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/rodeo-twap-market-signals.csv
@@ -1,0 +1,8 @@
+signal_type,observed_value,source,market_health_use,monitoring_rule
+exploit_date,2023-07-11,DN Institute incident record,Timestamp anchor for Arbitrum strategy monitoring,Replay strategy and oracle activity around exploit transactions
+reported_loss,about 472 ETH or 880000 to 888000 USD,DN Institute and Crypto Briefing,Materiality gauge for TWAP oracle exposure,Escalate when one oracle route can move strategy funds
+oracle_weakness,TWAP oracle path manipulated through sandwich-style routing,DN Institute and Smart Contract Hacking,Root market-health failure mode,Compare manipulation cost with maximum strategy exposure
+market_route,unshETH and related swap routes,Crypto Briefing and public analyses,Identifies reference-market dependency,Gate strategy actions when route depth is thin
+recovery_signal,about 810000 USD recovered from the Rodeo farm,Smart Contract Hacking,Separates gross impact from net loss,Track recovery amount separately from stolen amount
+tvl_impact,TVL reportedly fell from about 20 million USD to below 500 USD,Crypto Briefing,Measures user-confidence and liquidity flight,Alert on extreme TVL drawdown after oracle incidents
+fund_flow,bridged swapped and Tornado Cash routed funds,Crypto Briefing,Classifies adversarial extraction path,Connect Arbitrum exploit flow with Ethereum bridge and mixer events


### PR DESCRIPTION
For #277.

This adds a single Market Health article on the July 2023 Rodeo Finance TWAP-oracle manipulation exploit on Arbitrum, plus a companion CSV of exploit-date, loss, oracle, market-route, recovery, TVL-impact, and fund-flow signals.

Validation run locally:
- `npx --yes prettier --check --ignore-unknown content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/index.md content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/rodeo-twap-market-signals.csv`
- `npx --yes markdownlint-cli --disable MD013 --ignore node_modules -- content/research/market-health/posts/2023-07-11-rodeo-twap-oracle-manipulation/index.md`
- `ruby -rcsv` CSV field-count check
- `git diff --check`
- referenced URL check: all HTTP 200

Duplicate check: I searched open PRs and issue comments for Rodeo/unshETH/TWAP and did not find an existing Rodeo Market Health submission. The existing Rodeo cyberattack incident page is cited as a source.

Hugo build was not run because `hugo` is not installed in this environment.