### PR TITLE
Add Synthetix sUSD depeg market health case

### DIFF
--- a/content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/index.md
+++ b/content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/index.md
@@ -1,0 +1,65 @@
+---
+title: "Synthetix sUSD Depeg After SIP-420 Debt Model Changes"
+date: 2025-04-18
+entities:
+  - Synthetix
+  - sUSD
+  - SNX
+  - Curve
+---
+
+## Summary
+
+In April 2025, Synthetix's sUSD stablecoin entered a severe peg-stress period, trading near $0.68 at the worst point reported in public coverage. [CoinCentral reported](https://coincentral.com/synthetixs-susd-stablecoin-continues-to-struggle-with-depeg-drops-as-low-as-0-66/) that the move followed implementation of SIP-420, a Synthetix governance change that altered debt-risk allocation and reduced collateralization requirements. The same report noted that sUSD's market capitalization fell from about $30 million to $24.5 million during April and that Curve pools became heavily imbalanced toward sUSD.
+
+This case matters for Market Health because the depeg was not framed as a direct smart-contract hack or bad-debt event. Instead, the stress came from a mechanism transition: the protocol improved capital efficiency while weakening the reflexive incentive that previously encouraged individual stakers to buy discounted sUSD and repay debt. [CoinNess summarized Parsec's analysis](https://coinness.com/en/news/61173) as attributing the depeg primarily to SIP-420's shift of debt into a communal pool, removing a defense mechanism that had helped stabilize the peg.
+
+Synthetix later published a [peg update](https://blog.synthetix.io/synthetix-susd-peg-update/) saying sUSD had navigated instability after SIP-420 and describing recovery steps including the 420 Pool, sUSD reward campaigns, staker ratio requirements, and market-led treasury buybacks capped at $1 million per day.
+
+## Metrics Used
+
+### Peg deviation and recovery gap
+
+The core signal was sUSD's deviation from the $1 target. A move to $0.68 implies an approximate 32% discount to par. By the time of Synthetix's May 15 update, the protocol said sUSD was at 93 cents and still had roughly 6.5 cents left to reclaim before returning to $1. This makes the depeg measurable as both maximum drawdown from peg and remaining recovery gap.
+
+Useful stablecoin health metrics include:
+
+- maximum discount to the target peg;
+- number of days spent below 95 cents and 90 cents;
+- recovery speed after protocol incentives are introduced;
+- liquidity-pool imbalance during the depeg period;
+- whether peg support depends on organic demand, incentives, or treasury intervention.
+
+### Debt-model incentive break
+
+Before the transition, individual stakers had a stronger reason to buy sUSD below $1 and use it to repay debt. After SIP-420 moved debt into a communal pool, that direct arbitrage pressure weakened. In market-health terms, this is an incentive-alignment metric: a stablecoin can be overcollateralized on paper but still trade below peg if the actor who can restore demand is no longer personally exposed to the discount.
+
+For monitoring, the relevant signal is not only collateral ratio but also who bears the marginal cost of a peg break. A design where peg support depends on a shared treasury or broad staker coordination should be treated differently from a design where individual debt positions create constant buyback pressure.
+
+### Liquidity concentration
+
+CoinCentral reported that sUSD became more than 90% of total supply in Curve pools during the depeg period. Such an imbalance indicates one-sided selling pressure and weak external demand. A pool can still have liquidity, but if almost all of it is the depegging asset, swaps out of that asset become expensive and the pool stops acting as a credible price stabilizer.
+
+The same fields are summarized in [synthetix-susd-signals.csv](synthetix-susd-signals.csv) for dataset-based review.
+
+| Signal                | Observation                                                                     | Market-health interpretation                                                            |
+| --------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Maximum peg deviation | sUSD traded near $0.68 in April 2025                                            | Deep discount showed market confidence was impaired despite collateral backing          |
+| Recovery gap          | Synthetix later described sUSD at 93 cents with about 6.5 cents left to reclaim | Recovery progress can be tracked separately from the original drawdown                  |
+| Debt-risk shift       | SIP-420 moved debt risk from individual stakers toward a communal pool          | Changed incentives weakened the old reflexive buyback mechanism                         |
+| Liquidity imbalance   | sUSD reportedly exceeded 90% of total supply in Curve pools                     | One-sided pool composition signaled persistent exit pressure                            |
+| Intervention path     | 420 Pool rewards and market-led buybacks were introduced                        | Peg defense required incentives and treasury action, not only passive collateralization |
+
+## Timeline
+
+- **January 2025:** sUSD began showing instability, with public coverage later describing a drop to around $0.96 at the start of the year.
+- **April 11, 2025:** CoinNess summarized Parsec's view that SIP-420 was the primary driver of the recent sUSD depeg because communalized debt weakened a previous stabilizing incentive.
+- **April 18, 2025:** CoinCentral reported that sUSD had traded near $0.68, roughly 30% below its $1 target, and that the depeg had intensified after SIP-420.
+- **April 18, 2025:** Synthetix introduced the sUSD 420 Pool incentive program, later described in public coverage as distributing 5 million SNX over 12 months to users who locked sUSD.
+- **May 15, 2025:** Synthetix published a peg update saying 420 Pool deposits and reward campaigns had improved the situation, and announced market-led sUSD buybacks capped at $1 million per day as needed.
+
+## Market Health Lessons
+
+The sUSD depeg shows that stablecoin health cannot be evaluated from collateralization alone. A stablecoin also needs durable demand, liquid exit routes, and clear incentives for the parties responsible for defending the peg. SIP-420 may have improved capital efficiency, but it also changed who had a direct reason to buy discounted sUSD.
+
+For stablecoin monitoring, the most important indicators are peg deviation, liquidity-pool composition, debt-holder incentives, market-cap contraction, and the degree to which recovery depends on emergency rewards or treasury buybacks. If a stablecoin's peg support shifts from automatic user incentives to discretionary protocol intervention, the market should treat the asset as less resilient until the new demand loop is proven.

--- a/content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/synthetix-susd-signals.csv
+++ b/content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/synthetix-susd-signals.csv
@@ -1,0 +1,6 @@
+signal,observation,market_health_use,source
+peg_deviation,"sUSD traded near $0.68 in April 2025","Measure maximum discount to the $1 target and duration below key peg bands","https://coincentral.com/synthetixs-susd-stablecoin-continues-to-struggle-with-depeg-drops-as-low-as-0-66/"
+market_cap_contraction,"sUSD market capitalization fell from about $30 million to $24.5 million during April 2025","Track supply and market-cap contraction during confidence stress","https://coincentral.com/synthetixs-susd-stablecoin-continues-to-struggle-with-depeg-drops-as-low-as-0-66/"
+liquidity_imbalance,"sUSD reportedly exceeded 90% of total supply in Curve pools","Detect one-sided pool composition and weak exit liquidity","https://coincentral.com/synthetixs-susd-stablecoin-continues-to-struggle-with-depeg-drops-as-low-as-0-66/"
+debt_model_change,"Parsec analysis attributed the depeg to SIP-420 moving debt into a communal pool","Monitor whether peg-defense incentives remain with individual debt holders","https://coinness.com/en/news/61173"
+recovery_measures,"Synthetix cited 420 Pool deposits, reward campaigns, staker ratio requirements, and treasury buybacks","Track whether recovery depends on incentives or protocol balance-sheet intervention","https://blog.synthetix.io/synthetix-susd-peg-update/"


### PR DESCRIPTION
## Summary
- add a single Market Health article on the April 2025 Synthetix sUSD depeg after SIP-420 debt-model changes
- include a companion signal CSV covering peg deviation, market-cap contraction, Curve liquidity imbalance, debt-model incentive changes, and recovery measures
- cite Synthetix, CoinCentral, and CoinNess sources

## Validation
- npx --yes prettier --check --ignore-unknown content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/index.md content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/synthetix-susd-signals.csv
- ruby -rcsv -e 'CSV.foreach("content/research/market-health/posts/2025-04-18-synthetix-susd-depeg/synthetix-susd-signals.csv", headers: true).with_index(2) { |row, line| raise "bad field count at line #{line}" unless row.headers.size == row.fields.size }; puts "csv ok"'\n- git diff --check\n- source URL checks returned HTTP 200 for Synthetix, CoinCentral, and CoinNess\n\nBounty issue: #277