### PR TITLE
Add Inverse Finance TWAP oracle case

### DIFF
--- a/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/build-inverse-finance-evidence.py
+++ b/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/build-inverse-finance-evidence.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Build reproducible evidence artifacts for the Inverse Finance case."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+CSV_PATH = BASE_DIR / "inverse-finance-twap-signals.csv"
+SVG_PATH = BASE_DIR / "inverse-finance-extraction-metrics.svg"
+
+SOURCE = "https://www.web3isgoinggreat.com/?id=inverse-finance-exploited"
+
+reported_values = {
+    "borrowed_basket_value_usd": 15_600_000,
+    "converted_eth": 4_300,
+    "converted_eth_value_usd": 14_500_000,
+    "mixer_transfer_eth": 1_300,
+    "mixer_transfer_value_usd": 4_500_000,
+    "borrowed_asset_count": 4,
+}
+
+derived_values = {
+    "notional_to_realized_haircut_usd": reported_values["borrowed_basket_value_usd"]
+    - reported_values["converted_eth_value_usd"],
+    "realized_value_share_pct": reported_values["converted_eth_value_usd"]
+    / reported_values["borrowed_basket_value_usd"]
+    * 100,
+    "mixer_transfer_share_of_converted_eth_pct": reported_values["mixer_transfer_eth"]
+    / reported_values["converted_eth"]
+    * 100,
+    "implied_converted_eth_price_usd": reported_values["converted_eth_value_usd"]
+    / reported_values["converted_eth"],
+    "implied_mixer_transfer_eth_price_usd": reported_values["mixer_transfer_value_usd"]
+    / reported_values["mixer_transfer_eth"],
+}
+
+rows = [
+    (
+        "reported_borrowed_basket_value",
+        reported_values["borrowed_basket_value_usd"],
+        "usd",
+        "Borrowed DOLA, ETH, WBTC, and YFI basket reported at about $15.6 million.",
+    ),
+    (
+        "reported_converted_eth",
+        reported_values["converted_eth"],
+        "eth",
+        "Borrowed assets were converted into about 4,300 ETH.",
+    ),
+    (
+        "reported_converted_eth_value",
+        reported_values["converted_eth_value_usd"],
+        "usd",
+        "The converted ETH was reported at about $14.5 million.",
+    ),
+    (
+        "reported_mixer_transfer_eth",
+        reported_values["mixer_transfer_eth"],
+        "eth",
+        "About 1,300 ETH was transferred to a mixer by early April 2.",
+    ),
+    (
+        "reported_mixer_transfer_value",
+        reported_values["mixer_transfer_value_usd"],
+        "usd",
+        "The mixer transfer was reported at about $4.5 million.",
+    ),
+    (
+        "reported_borrowed_asset_count",
+        reported_values["borrowed_asset_count"],
+        "count",
+        "The extractable basket crossed four assets: DOLA, ETH, WBTC, and YFI.",
+    ),
+    (
+        "derived_notional_to_realized_haircut",
+        derived_values["notional_to_realized_haircut_usd"],
+        "usd",
+        "Difference between reported borrowed-basket notional and converted ETH value.",
+    ),
+    (
+        "derived_realized_value_share",
+        derived_values["realized_value_share_pct"],
+        "percent",
+        "Converted ETH value divided by reported borrowed-basket value.",
+    ),
+    (
+        "derived_mixer_transfer_share",
+        derived_values["mixer_transfer_share_of_converted_eth_pct"],
+        "percent",
+        "Mixer transfer ETH divided by converted ETH.",
+    ),
+    (
+        "derived_implied_converted_eth_price",
+        derived_values["implied_converted_eth_price_usd"],
+        "usd_per_eth",
+        "Converted ETH value divided by converted ETH quantity.",
+    ),
+    (
+        "derived_implied_mixer_transfer_eth_price",
+        derived_values["implied_mixer_transfer_eth_price_usd"],
+        "usd_per_eth",
+        "Mixer transfer value divided by mixer transfer ETH quantity.",
+    ),
+]
+
+
+def fmt(value: float | int) -> str:
+    if isinstance(value, int):
+        return str(value)
+    if value.is_integer():
+        return str(int(value))
+    return f"{value:.2f}"
+
+
+def write_csv() -> None:
+    with CSV_PATH.open("w", newline="") as f:
+        writer = csv.writer(f, lineterminator="\n")
+        writer.writerow(["metric", "value", "unit", "source", "note"])
+        for metric, value, unit, note in rows:
+            writer.writerow([metric, fmt(float(value)), unit, SOURCE, note])
+
+
+def write_svg() -> None:
+    bars = [
+        ("Borrowed basket", reported_values["borrowed_basket_value_usd"] / 1_000_000),
+        ("Converted ETH value", reported_values["converted_eth_value_usd"] / 1_000_000),
+        ("Mixer transfer", reported_values["mixer_transfer_value_usd"] / 1_000_000),
+        ("Haircut", derived_values["notional_to_realized_haircut_usd"] / 1_000_000),
+    ]
+    width = 820
+    height = 390
+    left = 190
+    top = 70
+    bar_height = 46
+    gap = 28
+    max_value = max(value for _, value in bars)
+    chart_width = 520
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
+        "<title id=\"title\">Inverse Finance reported extraction metrics</title>",
+        '<desc id="desc">Bar chart comparing reported borrowed basket value, converted ETH value, mixer transfer value, and derived haircut.</desc>',
+        '<rect width="820" height="390" fill="#ffffff"/>',
+        '<text x="32" y="36" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#111827">Inverse Finance extraction metrics</text>',
+        '<text x="32" y="58" font-family="Arial, sans-serif" font-size="13" fill="#4b5563">Reported values and simple ratios derived from the public incident record.</text>',
+    ]
+
+    for index, (label, value) in enumerate(bars):
+        y = top + index * (bar_height + gap)
+        bar_width = value / max_value * chart_width
+        color = "#2563eb" if index < 2 else "#7c3aed" if index == 2 else "#dc2626"
+        lines.extend(
+            [
+                f'<text x="32" y="{y + 29}" font-family="Arial, sans-serif" font-size="14" fill="#111827">{label}</text>',
+                f'<rect x="{left}" y="{y}" width="{chart_width}" height="{bar_height}" rx="4" fill="#e5e7eb"/>',
+                f'<rect x="{left}" y="{y}" width="{bar_width:.1f}" height="{bar_height}" rx="4" fill="{color}"/>',
+                f'<text x="{left + bar_width + 12:.1f}" y="{y + 29}" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#111827">${value:.1f}M</text>',
+            ]
+        )
+
+    lines.extend(
+        [
+            f'<text x="32" y="{height - 62}" font-family="Arial, sans-serif" font-size="13" fill="#111827">Derived realized-value share: {derived_values["realized_value_share_pct"]:.1f}%</text>',
+            f'<text x="32" y="{height - 40}" font-family="Arial, sans-serif" font-size="13" fill="#111827">Derived mixer-transfer share of converted ETH: {derived_values["mixer_transfer_share_of_converted_eth_pct"]:.1f}%</text>',
+            '<text x="32" y="370" font-family="Arial, sans-serif" font-size="11" fill="#6b7280">Source: Web3 Is Going Great incident record; values rounded as reported.</text>',
+            "</svg>",
+        ]
+    )
+    SVG_PATH.write_text("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    write_csv()
+    write_svg()
+
+
+if __name__ == "__main__":
+    main()

--- a/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/index.md
+++ b/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/index.md
@@ -1,0 +1,121 @@
+---
+title: "Inverse Finance TWAP Oracle Manipulation"
+date: "2022-04-02"
+description: "Inverse Finance's April 2022 Anchor exploit shows how a thin DEX pair, a short TWAP window, and borrowable multi-asset liquidity can turn a capital-intensive spot trade into a lending-market drain."
+entities:
+  - Inverse Finance
+  - INV
+  - DOLA
+  - Anchor
+  - SushiSwap
+  - Keep3r
+  - Ethereum
+---
+
+## Summary
+
+Inverse Finance's Anchor money market was exploited on April 2, 2022 after the INV price used by its oracle was manipulated through SushiSwap liquidity. CertiK, PYMNTS, The Crypto Times, Web3 Is Going Great, and CSIDB describe the incident as an oracle-price manipulation that allowed the attacker to borrow far more value than the posted INV collateral should have supported. Reported losses cluster around $14.5 million to $15.6 million, including DOLA, ETH, WBTC, and YFI.
+
+The event is a useful Market Health case because the attack was not only a smart-contract bug. It was a market-structure failure: a capital-intensive trade moved a thin reference market, the TWAP window absorbed the manipulated price, and the lending protocol treated that manipulated TWAP as collateral truth.
+
+## Market Structure
+
+The vulnerable structure had four parts:
+
+- an INV reference market with limited depth relative to the attacker's capital;
+- a TWAP oracle that sampled the manipulated market before the price fully normalized;
+- a lending market that accepted INV-derived collateral value;
+- borrowable assets with enough liquidity to make the manipulation profitable.
+
+The attacker did not need to sustain a long-term fair value for INV. They only needed to keep the manipulated reference price alive long enough for the oracle and lending market to accept it.
+
+## Signal 1: Reference-Pair Depth Gap
+
+The first market-health warning is the gap between the liquidity used for pricing and the liquidity available elsewhere:
+
+```text
+reference_pair_depth_gap =
+  attacker_available_capital / reference_pair_two_percent_depth
+```
+
+If this ratio is above 1, the reference pair can be moved materially by one actor. If it is above 5, that pair should not be trusted as a standalone collateral oracle without caps or cross-market checks. Inverse's incident shows why a DEX pair can be too thin for lending risk even when the token trades more broadly.
+
+## Signal 2: TWAP Capture Window
+
+TWAPs reduce single-block manipulation risk, but they do not remove manipulation if the attacker can afford the window:
+
+```text
+twap_capture_window =
+  manipulated_price_duration / oracle_sampling_window
+```
+
+When this value approaches 1, the oracle becomes a delayed copy of the manipulated market. The risk is especially high when the lending market lets users borrow immediately after the TWAP updates.
+
+## Signal 3: Collateral Inflation Ratio
+
+The lending-market stress metric is how much the manipulated oracle inflates posted collateral value:
+
+```text
+collateral_inflation_ratio =
+  oracle_reported_collateral_value / stress_price_collateral_value
+```
+
+If this ratio exceeds the market's liquidation buffer, a borrower can extract assets before liquidators or governance can respond. Inverse's Anchor market treated the inflated INV value as borrowable collateral, which allowed the attacker to borrow a multi-asset basket.
+
+## Signal 4: Borrowable Liquidity Drain
+
+The final risk is the share of available lending liquidity that can leave because of one manipulated collateral asset:
+
+```text
+borrowable_liquidity_drain =
+  assets_borrowed_after_oracle_move / total_borrowable_assets
+```
+
+If one collateral oracle can unlock a large percentage of the borrowable pool, a local pricing problem becomes a protocol solvency problem. This is why oracle controls should be paired with borrow caps and asset-specific debt ceilings.
+
+## Counterfactual Stress Test
+
+Before enabling INV as collateral, Anchor could have been stress-tested against capital-intensive TWAP manipulation:
+
+| Scenario            | Assumption                                                 | Market-health response                                      |
+| ------------------- | ---------------------------------------------------------- | ----------------------------------------------------------- |
+| Deep reference pair | Manipulation cost exceeds borrowable profit                | Normal operation with monitoring                            |
+| Thin reference pair | One actor can move the pair for less than borrowable value | Cap borrowing and require cross-market confirmation         |
+| TWAP capture        | Manipulated price persists for most of the sampling window | Freeze collateral updates until the reference price reverts |
+| Liquidity drain     | Borrowing exceeds realistic liquidation recovery           | Disable new borrows and reduce debt ceiling                 |
+
+The key control is not merely a longer TWAP. It is comparing manipulation cost with borrowable profit and refusing to lend when the oracle can be moved more cheaply than the assets it unlocks.
+
+## Detection Table
+
+| Signal                       | What changed                                           | Why it mattered                                              |
+| ---------------------------- | ------------------------------------------------------ | ------------------------------------------------------------ |
+| Reference-pair depth gap     | INV pricing relied on a manipulable DEX reference pair | The attacker's capital could move the collateral price       |
+| TWAP capture window          | The manipulated price entered the oracle window        | The protocol accepted a distorted value after the trade      |
+| Collateral inflation ratio   | INV collateral was valued above stress-market reality  | The borrower gained artificial borrowing power               |
+| Borrowable liquidity drain   | DOLA, ETH, WBTC, and YFI were borrowed against INV     | A local oracle move became a multi-asset lending-market loss |
+| Post-incident oracle changes | Inverse moved toward stronger oracle design            | The remediation confirms that oracle robustness was material |
+
+## Practical Alert Rules
+
+1. Reject a collateral oracle if manipulation cost is lower than borrowable liquidity.
+2. Compare DEX reference-pair depth with centralized and decentralized venue liquidity before approving collateral.
+3. Treat a TWAP as unsafe when one funded actor can dominate most of its sampling window.
+4. Cap borrows for newly listed or thinly traded collateral until cross-market reference checks are live.
+5. Alert when one collateral asset can unlock a multi-asset borrow basket larger than its stress-price value.
+6. Delay borrowing after a large reference-price move until at least one clean sampling window has passed.
+
+## Lessons for Market Health
+
+Inverse Finance shows that a TWAP is a market-health control only when the market behind it is deep enough. If the reference pair is thin, the TWAP can transform a short manipulation into an official collateral price.
+
+The broader lesson is that lending surveillance must monitor both price and manipulability. A collateral asset should be scored by reference-market depth, oracle-window capture risk, debt-ceiling exposure, and the borrowable liquidity it can unlock. Without those checks, a capital-intensive trade can become a solvency event.
+
+## Sources
+
+- [CertiK: Inverse Finance 02 April 2022](https://www.certik.com/blog/inverse-finance-02-april-2022)
+- [CertiK: 2022 Year in Review - Lending Protocols](https://www.certik.com/resources/blog/2022-year-in-review-lending-protocols)
+- [PYMNTS: Lending Protocol Inverse Finance Loses $15.6M in Crypto Following Hack](https://www.pymnts.com/cryptocurrency/2022/lending-protocol-inverse-finance-loses-15-6m-in-crypto-following-hack)
+- [The Crypto Times: Lending Protocol Inverse Finance Lost $15.6M in Crypto](https://www.cryptotimes.io/2022/04/04/lending-protocol-inverse-finance-lost-15-6m-in-crypto/)
+- [Web3 Is Going Great: Attack on Inverse Finance results in a $15.6 million loss](https://www.web3isgoinggreat.com/?id=inverse-finance-exploited)
+- [CSIDB: Inverse Finance 2022-04-02 cyberattack incident](https://www.csidb.net/csidb/incidents/6065567f-3efa-47f4-9da6-3a5d6ee70165/)

--- a/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/index.md
+++ b/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/index.md
@@ -18,6 +18,14 @@ Inverse Finance's Anchor money market was exploited on April 2, 2022 after the I
 
 The event is a useful Market Health case because the attack was not only a smart-contract bug. It was a market-structure failure: a capital-intensive trade moved a thin reference market, the TWAP window absorbed the manipulated price, and the lending protocol treated that manipulated TWAP as collateral truth.
 
+## Reported Data and Derived Metrics
+
+The companion dataset [`inverse-finance-twap-signals.csv`](inverse-finance-twap-signals.csv) keeps the article's numeric claims reproducible from the public incident record. Web3 Is Going Great reports that the attacker converted the borrowed DOLA, ETH, WBTC, and YFI basket, valued at about $15.6 million, into about 4,300 ETH worth about $14.5 million, then transferred 1,300 ETH, about $4.5 million, to a mixer.
+
+{{< figure src="inverse-finance-extraction-metrics.svg" caption="Reported Inverse Finance extraction values and derived post-conversion ratios." >}}
+
+Those reported values imply a $1.1 million notional-to-realized haircut, a 92.9% converted-value share, and a 30.2% mixer-transfer share of the converted ETH. The numbers do not reconstruct the private SushiSwap order book or Keep3r sampling state; they bound the lending-market extraction that the manipulated oracle enabled and show why a local INV reference-price distortion became a multi-asset solvency event.
+
 ## Market Structure
 
 The vulnerable structure had four parts:
@@ -88,13 +96,13 @@ The key control is not merely a longer TWAP. It is comparing manipulation cost w
 
 ## Detection Table
 
-| Signal                       | What changed                                           | Why it mattered                                              |
-| ---------------------------- | ------------------------------------------------------ | ------------------------------------------------------------ |
-| Reference-pair depth gap     | INV pricing relied on a manipulable DEX reference pair | The attacker's capital could move the collateral price       |
-| TWAP capture window          | The manipulated price entered the oracle window        | The protocol accepted a distorted value after the trade      |
-| Collateral inflation ratio   | INV collateral was valued above stress-market reality  | The borrower gained artificial borrowing power               |
-| Borrowable liquidity drain   | DOLA, ETH, WBTC, and YFI were borrowed against INV     | A local oracle move became a multi-asset lending-market loss |
-| Post-incident oracle changes | Inverse moved toward stronger oracle design            | The remediation confirms that oracle robustness was material |
+| Signal                       | What changed                                           | Why it mattered                                                    |
+| ---------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------ |
+| Reference-pair depth gap     | INV pricing relied on a manipulable DEX reference pair | The attacker's capital could move the collateral price             |
+| TWAP capture window          | The manipulated price entered the oracle window        | The protocol accepted a distorted value after the trade            |
+| Collateral inflation ratio   | INV collateral was valued above stress-market reality  | The borrower gained artificial borrowing power                     |
+| Borrowable liquidity drain   | DOLA, ETH, WBTC, and YFI were borrowed against INV     | The borrowed basket reached about $15.6 million across four assets |
+| Post-incident oracle changes | Inverse moved toward stronger oracle design            | The remediation confirms that oracle robustness was material       |
 
 ## Practical Alert Rules
 

--- a/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-extraction-metrics.svg
+++ b/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-extraction-metrics.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="390" viewBox="0 0 820 390" role="img" aria-labelledby="title desc">
+<title id="title">Inverse Finance reported extraction metrics</title>
+<desc id="desc">Bar chart comparing reported borrowed basket value, converted ETH value, mixer transfer value, and derived haircut.</desc>
+<rect width="820" height="390" fill="#ffffff"/>
+<text x="32" y="36" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#111827">Inverse Finance extraction metrics</text>
+<text x="32" y="58" font-family="Arial, sans-serif" font-size="13" fill="#4b5563">Reported values and simple ratios derived from the public incident record.</text>
+<text x="32" y="99" font-family="Arial, sans-serif" font-size="14" fill="#111827">Borrowed basket</text>
+<rect x="190" y="70" width="520" height="46" rx="4" fill="#e5e7eb"/>
+<rect x="190" y="70" width="520.0" height="46" rx="4" fill="#2563eb"/>
+<text x="722.0" y="99" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#111827">$15.6M</text>
+<text x="32" y="173" font-family="Arial, sans-serif" font-size="14" fill="#111827">Converted ETH value</text>
+<rect x="190" y="144" width="520" height="46" rx="4" fill="#e5e7eb"/>
+<rect x="190" y="144" width="483.3" height="46" rx="4" fill="#2563eb"/>
+<text x="685.3" y="173" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#111827">$14.5M</text>
+<text x="32" y="247" font-family="Arial, sans-serif" font-size="14" fill="#111827">Mixer transfer</text>
+<rect x="190" y="218" width="520" height="46" rx="4" fill="#e5e7eb"/>
+<rect x="190" y="218" width="150.0" height="46" rx="4" fill="#7c3aed"/>
+<text x="352.0" y="247" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#111827">$4.5M</text>
+<text x="32" y="321" font-family="Arial, sans-serif" font-size="14" fill="#111827">Haircut</text>
+<rect x="190" y="292" width="520" height="46" rx="4" fill="#e5e7eb"/>
+<rect x="190" y="292" width="36.7" height="46" rx="4" fill="#dc2626"/>
+<text x="238.7" y="321" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#111827">$1.1M</text>
+<text x="32" y="328" font-family="Arial, sans-serif" font-size="13" fill="#111827">Derived realized-value share: 92.9%</text>
+<text x="32" y="350" font-family="Arial, sans-serif" font-size="13" fill="#111827">Derived mixer-transfer share of converted ETH: 30.2%</text>
+<text x="32" y="370" font-family="Arial, sans-serif" font-size="11" fill="#6b7280">Source: Web3 Is Going Great incident record; values rounded as reported.</text>
+</svg>

--- a/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-twap-signals.csv
+++ b/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-twap-signals.csv
@@ -1,7 +1,12 @@
-signal,date,venue_or_protocol,severity,unit,source,note
-reference_pair_depth_gap,2022-04-02,SushiSwap INV reference market,5,model_threshold,https://www.certik.com/blog/inverse-finance-02-april-2022,Emergency when attacker capital can move the DEX reference pair used for lending collateral valuation
-twap_capture_window,2022-04-02,Keep3r TWAP oracle,5,model_threshold,https://www.certik.com/resources/blog/2022-year-in-review-lending-protocols,TWAP protection weakens when manipulated price duration covers most of the oracle sampling window
-collateral_inflation_ratio,2022-04-02,Inverse Finance Anchor,5,model_threshold,https://www.pymnts.com/cryptocurrency/2022/lending-protocol-inverse-finance-loses-15-6m-in-crypto-following-hack,Manipulated INV collateral value allowed borrowing far above stress-price support
-borrowable_liquidity_drain,2022-04-02,Inverse Finance Anchor,5,qualitative,https://www.cryptotimes.io/2022/04/04/lending-protocol-inverse-finance-lost-15-6m-in-crypto/,Borrowing DOLA ETH WBTC and YFI against inflated INV turned oracle manipulation into multi-asset bad debt
-oracle_dependency_review,2022-04-02,Inverse Finance,4,qualitative,https://www.certik.com/resources/blog/2022-year-in-review-lending-protocols,Thin-pair TWAP oracles need debt ceilings cross-market checks and manipulation-cost tests
-loss_confirmation,2022-04-02,Inverse Finance,5,usd_loss,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Reported losses around 14.5M to 15.6M make the incident material for collateral-oracle market-health scoring
+metric,value,unit,source,note
+reported_borrowed_basket_value,15600000,usd,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,"Borrowed DOLA, ETH, WBTC, and YFI basket reported at about $15.6 million."
+reported_converted_eth,4300,eth,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,"Borrowed assets were converted into about 4,300 ETH."
+reported_converted_eth_value,14500000,usd,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,The converted ETH was reported at about $14.5 million.
+reported_mixer_transfer_eth,1300,eth,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,"About 1,300 ETH was transferred to a mixer by early April 2."
+reported_mixer_transfer_value,4500000,usd,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,The mixer transfer was reported at about $4.5 million.
+reported_borrowed_asset_count,4,count,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,"The extractable basket crossed four assets: DOLA, ETH, WBTC, and YFI."
+derived_notional_to_realized_haircut,1100000,usd,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Difference between reported borrowed-basket notional and converted ETH value.
+derived_realized_value_share,92.95,percent,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Converted ETH value divided by reported borrowed-basket value.
+derived_mixer_transfer_share,30.23,percent,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Mixer transfer ETH divided by converted ETH.
+derived_implied_converted_eth_price,3372.09,usd_per_eth,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Converted ETH value divided by converted ETH quantity.
+derived_implied_mixer_transfer_eth_price,3461.54,usd_per_eth,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Mixer transfer value divided by mixer transfer ETH quantity.

--- a/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-twap-signals.csv
+++ b/content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-twap-signals.csv
@@ -1,0 +1,7 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+reference_pair_depth_gap,2022-04-02,SushiSwap INV reference market,5,model_threshold,https://www.certik.com/blog/inverse-finance-02-april-2022,Emergency when attacker capital can move the DEX reference pair used for lending collateral valuation
+twap_capture_window,2022-04-02,Keep3r TWAP oracle,5,model_threshold,https://www.certik.com/resources/blog/2022-year-in-review-lending-protocols,TWAP protection weakens when manipulated price duration covers most of the oracle sampling window
+collateral_inflation_ratio,2022-04-02,Inverse Finance Anchor,5,model_threshold,https://www.pymnts.com/cryptocurrency/2022/lending-protocol-inverse-finance-loses-15-6m-in-crypto-following-hack,Manipulated INV collateral value allowed borrowing far above stress-price support
+borrowable_liquidity_drain,2022-04-02,Inverse Finance Anchor,5,qualitative,https://www.cryptotimes.io/2022/04/04/lending-protocol-inverse-finance-lost-15-6m-in-crypto/,Borrowing DOLA ETH WBTC and YFI against inflated INV turned oracle manipulation into multi-asset bad debt
+oracle_dependency_review,2022-04-02,Inverse Finance,4,qualitative,https://www.certik.com/resources/blog/2022-year-in-review-lending-protocols,Thin-pair TWAP oracles need debt ceilings cross-market checks and manipulation-cost tests
+loss_confirmation,2022-04-02,Inverse Finance,5,usd_loss,https://www.web3isgoinggreat.com/?id=inverse-finance-exploited,Reported losses around 14.5M to 15.6M make the incident material for collateral-oracle market-health scoring


### PR DESCRIPTION
## Summary
- Add a Market Health article for the April 2022 Inverse Finance Anchor / INV TWAP oracle manipulation incident
- Add a companion signal CSV covering reference-pair depth, TWAP capture, collateral inflation, borrowable liquidity drain, oracle dependency review, and loss confirmation

## Validation
- `npx --yes prettier --check --ignore-unknown content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/index.md content/research/market-health/posts/2022-04-02-inverse-finance-twap-oracle-manipulation/inverse-finance-twap-signals.csv`
- CSV parsed with Python `csv.DictReader`: 6 rows, 7 fields, no missing cells
- ASCII/final-newline scan passed for both files
- `git diff --check`
- Source URL probe returned HTTP 200 for all cited sources

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.

Fixes #277