### PR TITLE
Add Genesis Gemini Earn redemption freeze case

### DIFF
--- a/content/research/market-health/posts/2022-11-16-genesis-gemini-earn-redemption-freeze/genesis-gemini-earn-signals.csv
+++ b/content/research/market-health/posts/2022-11-16-genesis-gemini-earn-redemption-freeze/genesis-gemini-earn-signals.csv
@@ -1,0 +1,7 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+embedded_counterparty_dependency,2022-11-16,Gemini Earn,critical,ratio,https://www.gemini.com/blog/an-important-message-regarding-gemini-earn,Gemini Earn redemption performance depended on Genesis as the lending counterparty.
+redemption_sla_break,2022-11-16,Gemini Earn,critical,redemption_status,https://www.gemini.com/blog/an-important-message-regarding-gemini-earn,Genesis could not meet Earn customer redemptions within the expected service-level window.
+product_ring_fence_fragility,2022-11-16,Gemini,high,confidence_gap,https://www.gemini.com/blog/an-important-message-regarding-gemini-earn,Gemini had to distinguish Earn from other Gemini products and services after the redemption halt.
+bankruptcy_recovery_dependency,2023-01-19,Genesis Global Capital,critical,legal_recovery,https://techcrunch.com/2023/01/19/dcgs-crypto-lending-subsidiary-genesis-files-for-chapter-11-bankruptcy/,Customer recovery became dependent on Genesis bankruptcy proceedings and creditor outcomes.
+recovery_communication_lag,2023-01-01,Gemini Earn,high,time,https://www.gemini.com/blog/gemini-earn-update,Earn users faced a long update and recovery process after redemptions were frozen.
+actual_recovery_access,2024-01-01,Gemini Earn,medium,recovery_status,https://www.gemini.com/earn,Market health should track actual customer access and distribution status rather than only announcements.

--- a/content/research/market-health/posts/2022-11-16-genesis-gemini-earn-redemption-freeze/index.md
+++ b/content/research/market-health/posts/2022-11-16-genesis-gemini-earn-redemption-freeze/index.md
@@ -1,0 +1,133 @@
+---
+title: "Genesis Gemini Earn Redemption Freeze and Credit Contagion"
+date: "2022-11-16"
+description: "Genesis Global Capital's November 2022 redemption halt and its impact on Gemini Earn show how hidden lending-counterparty exposure can turn an exchange yield product into a market-health and customer-liquidity crisis."
+entities:
+  - Genesis Global Capital
+  - Gemini Earn
+  - Gemini
+  - Digital Currency Group
+  - FTX
+  - Crypto Credit Markets
+---
+
+## Summary
+
+Genesis Global Capital halted redemptions and new loan originations in November 2022 after the FTX collapse created severe market stress and abnormal withdrawal demand. Gemini then informed Earn users that Genesis, the lending partner for the Earn program, would not be able to meet customer redemptions within the expected service window. Gemini's own Earn updates later described a long recovery process that depended on Genesis, Digital Currency Group, bankruptcy proceedings, and negotiated creditor outcomes.
+
+This is a Market Health case because the affected users did not only face a legal dispute. They faced a liquidity shock created by a hidden dependency between an exchange-branded yield product and an external lending counterparty. The exchange interface made the product look like part of a familiar platform, but redemption ability depended on Genesis's balance sheet and liquidity.
+
+For market-health monitoring, Genesis/Gemini Earn shows that yield products should be watched like credit markets. A high advertised platform trust level does not remove counterparty risk. If a lending partner halts redemptions, exchange customers experience the same practical outcome as a withdrawal freeze even if the exchange's spot-trading platform remains operational.
+
+## Market Structure
+
+Gemini Earn connected three layers that customers could easily blend together:
+
+- Gemini provided the user-facing exchange brand and Earn interface;
+- Genesis Global Capital acted as the lending counterparty for Earn assets;
+- Digital Currency Group and Genesis bankruptcy proceedings later shaped recovery expectations.
+
+The problem was not simply that one firm filed for bankruptcy. The market-health failure was that liquidity risk lived outside the product interface. Customers saw Gemini Earn, but redemption depended on Genesis. When Genesis halted redemptions, Gemini Earn users lost ordinary access to assets even though Gemini's other services were described as separate.
+
+## Signal 1: Embedded Counterparty Dependency
+
+The first signal measures how much of a product's redemption ability depends on a single external counterparty:
+
+```text
+embedded_counterparty_dependency =
+  assets_redeemable_only_if_counterparty_pays / total_assets_in_yield_product
+```
+
+If this ratio is high, the user-facing platform is not the full risk surface. A market-health monitor should treat the external lender as part of the product's liquidity stack. Genesis's halt showed that Gemini Earn redemption risk was not limited to Gemini's interface or custody messaging.
+
+## Signal 2: Redemption SLA Break
+
+Gemini told Earn users that Genesis would not be able to meet customer redemptions within the service-level agreement. That creates a direct market-health signal:
+
+```text
+redemption_sla_break =
+  requested_redemptions_not_met_on_schedule / total_redemption_requests
+```
+
+An SLA break is a stronger warning than ordinary outflows. It means the product has crossed from market volatility into failed customer access. Once this happens, yield rates, brand trust, and platform UI language are less important than actual redemption performance.
+
+## Signal 3: Product Ring-Fence Fragility
+
+Gemini emphasized that other Gemini products and services were separate from Earn. That distinction matters, but it also creates a market-health signal:
+
+```text
+product_ring_fence_fragility =
+  customer_confusion_or_outflow_pressure_from_affected_product
+  / unaffected_platform_liquidity
+```
+
+When one product freezes, users may question the rest of the platform even if legal and technical separations exist. Monitoring should therefore watch whether a yield-product freeze creates exchange-wide withdrawals, stablecoin redemptions, or reputational contagion.
+
+## Signal 4: Bankruptcy Recovery Dependency
+
+Genesis later filed for Chapter 11 bankruptcy protection. TechCrunch reported that Genesis Global Holdco and lending subsidiaries filed voluntary petitions, after Genesis had halted withdrawals and new loan originations in November 2022. For Earn users, recovery became tied to creditor negotiations and bankruptcy outcomes:
+
+```text
+bankruptcy_recovery_dependency =
+  customer_recovery_value_dependent_on_bankruptcy_process
+  / customer_assets_locked_in_product
+```
+
+When this ratio is high, the product should remain in impaired market-health status even if a recovery plan is announced. The relevant questions become timing, form of recovery, creditor ranking, and whether market prices or platform statements reflect what users can actually receive.
+
+## Signal 5: Recovery Communication Lag
+
+Gemini's Earn update page illustrates how long-running communication became part of the product's market-health status:
+
+```text
+recovery_communication_lag =
+  time_between_redemption_halt_and_verifiable_customer_recovery
+```
+
+Long lags create space for rumor, legal uncertainty, and secondary-market discounting of claims. A monitor should treat recovery updates as evidence only when they change actual access, asset coverage, or binding settlement terms.
+
+## Counterfactual Stress Test
+
+An exchange-branded yield product should be tested as a counterparty chain:
+
+| Scenario                     | Assumption                                             | Market-health response                                               |
+| ---------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
+| Transparent lending stack    | Users can identify the lending counterparty and limits | Monitor counterparty health alongside exchange status                |
+| Single-counterparty exposure | One lender controls most redemption ability            | Alert on embedded counterparty concentration                         |
+| Redemption SLA break         | Customer redemptions miss the promised window          | Mark the product as impaired and separate it from normal yield data  |
+| Ring-fence pressure          | Other platform products face reputational outflows     | Monitor broader exchange liquidity even if legal exposure is limited |
+| Bankruptcy dependency        | Recoveries depend on court and creditor negotiations   | Keep elevated-risk status until actual recoveries are distributed    |
+
+The test asks whether customers can redeem on schedule if the external lender fails. If not, the product is a credit instrument, not a simple exchange feature.
+
+## Detection Table
+
+| Signal                           | What changed                                                 | Why it mattered                                                  |
+| -------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Embedded counterparty dependency | Gemini Earn redemptions depended on Genesis liquidity        | Customer access risk lived outside the exchange interface        |
+| Redemption SLA break             | Earn redemptions could not be met within the expected window | The product crossed from yield volatility into access failure    |
+| Product ring-fence fragility     | Gemini had to distinguish Earn from other services           | One product freeze could affect confidence in the broader venue  |
+| Bankruptcy recovery dependency   | Genesis recovery moved into Chapter 11 proceedings           | Customer outcomes depended on legal process and creditor ranking |
+| Recovery communication lag       | Updates stretched across a long recovery process             | Users faced uncertainty until recoveries became concrete         |
+
+## Practical Alert Rules
+
+1. Treat exchange yield products as credit products when assets are lent to an external counterparty.
+2. Alert when one lending partner controls redemption performance for most customer balances.
+3. Mark a product as impaired when redemptions miss the stated service window.
+4. Separate exchange spot-custody health from yield-product counterparty health, but monitor contagion between them.
+5. Treat bankruptcy filings as market-health events until recoveries are distributed, not merely announced.
+6. Track recovery updates by binding customer access changes, not by communication volume.
+
+## Lessons for Market Health
+
+Genesis and Gemini Earn show that the most important market-health variable can be hidden behind a product label. Customers may believe they are using an exchange feature, while the economic risk sits with an external lender whose liquidity can fail under market stress.
+
+The broader lesson is that market-health systems should map the redemption chain. A product's usable liquidity is only as strong as the weakest counterparty that must pay for customers to exit. When that counterparty halts redemptions, the market-health status of the whole product should change immediately.
+
+## Sources
+
+- [Gemini: An Important Message Regarding Gemini Earn](https://www.gemini.com/blog/an-important-message-regarding-gemini-earn)
+- [Gemini: Gemini Earn Update](https://www.gemini.com/blog/gemini-earn-update)
+- [Gemini: Earn](https://www.gemini.com/earn)
+- [TechCrunch: DCG's crypto-lending subsidiary Genesis files for Chapter 11 bankruptcy](https://techcrunch.com/2023/01/19/dcgs-crypto-lending-subsidiary-genesis-files-for-chapter-11-bankruptcy/)


### PR DESCRIPTION
## Summary
- Add a Market Health article for Genesis Global Capital's redemption halt and its impact on Gemini Earn.
- Frame embedded lending-counterparty dependency, redemption SLA breaks, product ring-fence fragility, bankruptcy recovery dependency, and recovery communication lag as market-health signals.
- Add a CSV signal table covering those indicators.

## Duplicate check
- Searched open PRs and issues for Genesis Global, Gemini Earn, DCG, and Genesis withdrawal terms; no existing Market Health PR or issue found.
- Repo content search found no Genesis/Gemini Earn/DCG Market Health or Cyberattacks coverage.

## Validation
- `npx prettier --check content/research/market-health/posts/2022-11-16-genesis-gemini-earn-redemption-freeze/index.md`
- CSV parse: 6 rows, 7 columns, consistent field counts
- ASCII and final-newline checks
- `git diff --cached --check`
- Source URL probe: all cited URLs returned HTTP 200

Fixes #277