### PR TITLE
Add Hodlnaut withdrawal freeze market health case

### DIFF
--- a/content/research/market-health/posts/2022-08-08-hodlnaut-terra-withdrawal-freeze/hodlnaut-liquidity-signals.csv
+++ b/content/research/market-health/posts/2022-08-08-hodlnaut-terra-withdrawal-freeze/hodlnaut-liquidity-signals.csv
@@ -1,0 +1,7 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+terra_exposure_impairment,2022-08-19,Hodlnaut,critical,loss_ratio,https://www.hodlnaut.com/press/an-update-on-our-ijm-process,Hodlnaut tied its financial distress to TerraUSD crash losses and other liquidity pressures.
+withdrawal_pressure_spike,2022-08-19,Hodlnaut,high,ratio,https://www.hodlnaut.com/press/an-update-on-our-ijm-process,Unusually high withdrawal volumes were cited as part of the platform stress.
+service_halt_breadth,2022-08-08,Hodlnaut,critical,paused_actions,https://forklog.com/en/hodlnaut-crypto-lending-platform-halts-withdrawals/,Withdrawals token swaps and deposits were halted together.
+judicial_management_dependency,2022-08-13,Hodlnaut,critical,legal_recovery,https://www.hodlnaut.com/press/an-update-for-our-users,Customer outcomes moved into a judicial-management recovery process.
+asset_specific_suspension_signal,2022-05-25,Hodlnaut,medium,asset_restriction,https://www.hodlnaut.com/press/updates-notice-terra-luna-ust,Hodlnaut had earlier restricted LUNA and UST handling after Terra ecosystem volatility.
+reported_terra_loss_gap,2022-08-22,Hodlnaut,critical,usd,https://coinmarketcap.com/academy/article/hodlnaut-in-a-193-million-hole,Reports described roughly 190 million dollars of Terra-related loss exposure.

--- a/content/research/market-health/posts/2022-08-08-hodlnaut-terra-withdrawal-freeze/index.md
+++ b/content/research/market-health/posts/2022-08-08-hodlnaut-terra-withdrawal-freeze/index.md
@@ -1,0 +1,134 @@
+---
+title: "Hodlnaut Terra Exposure and Withdrawal Freeze"
+date: "2022-08-08"
+description: "Hodlnaut's August 2022 withdrawal halt shows how Terra/UST exposure, customer withdrawal pressure, and judicial-management recovery can turn a yield platform into an impaired-liquidity market."
+entities:
+  - Hodlnaut
+  - TerraUSD
+  - UST
+  - LUNA
+  - Centralized Lending
+  - Crypto Credit Markets
+---
+
+## Summary
+
+Hodlnaut suspended withdrawals, token swaps, and deposits on August 8, 2022 while it worked on a recovery plan. ForkLog reported the immediate halt, and Hodlnaut later told users it had applied for judicial management. Hodlnaut's own interim judicial-management update connected its financial distress to losses suffered during the TerraUSD crash, unusually high withdrawal volumes, broad crypto price declines, and issues involving large users.
+
+This is a Market Health case because the platform's advertised yield product became an impaired-liquidity market. Users could no longer move assets, Terra/UST exposure had already damaged balance-sheet confidence, and recovery shifted into a judicial-management process rather than normal market settlement. A quoted token price or platform account balance was no longer enough to describe user risk.
+
+For market-health monitoring, Hodlnaut shows that a lender can pass from asset-specific exposure to platform-wide freeze in stages. Terra/LUNA notices, withdrawal pressure, service suspension, and judicial-management updates should be read together as one liquidity-stress chain.
+
+## Market Structure
+
+Hodlnaut's customer risk sat behind a centralized yield interface. The platform accepted user assets, paid yield, and made risk-management decisions internally. That structure meant users depended on Hodlnaut for three things:
+
+- accurate disclosure of exposure to stressed assets such as UST and LUNA;
+- enough liquid assets to meet withdrawals during market stress;
+- access to a recovery process if liquidity failed.
+
+When Hodlnaut paused withdrawals, deposits, and token swaps, customer account balances stopped behaving like liquid crypto. The economic exposure moved from market price risk into platform recovery risk.
+
+## Signal 1: Terra Exposure Impairment
+
+The first signal is exposure to a collapsed ecosystem relative to platform equity and liquid assets:
+
+```text
+terra_exposure_impairment =
+  losses_from_ust_luna_positions / liquid_assets_available_for_withdrawals
+```
+
+Hodlnaut's judicial-management update identified TerraUSD crash losses as one reason for the firm's financial circumstances. CoinMarketCap's summary of filings described roughly $190 million of Terra-related losses. A market-health monitor should treat large exposure to a failed stablecoin ecosystem as a platform-liquidity risk, not only an investment loss.
+
+## Signal 2: Withdrawal Pressure Spike
+
+Hodlnaut also cited unusually high withdrawal volumes. A useful signal is:
+
+```text
+withdrawal_pressure_spike =
+  withdrawal_requests_during_stress_window / normal_withdrawal_requests
+```
+
+When this ratio rises after a solvency rumor, asset collapse, or platform disclosure, the market can shift from ordinary outflows to a run dynamic. The platform may still be solvent on paper, but liquid assets can become insufficient if customers all demand exit at once.
+
+## Signal 3: Service Halt Breadth
+
+Hodlnaut paused three customer actions at the same time: withdrawals, token swaps, and deposits. This can be monitored as:
+
+```text
+service_halt_breadth =
+  paused_customer_actions / core_customer_actions
+```
+
+A full-width service halt is more severe than a single asset pause. It means the platform is not only blocking one stressed token; it is freezing the normal ways users adjust risk. Hodlnaut's halt therefore represented a platform-wide market-health impairment.
+
+## Signal 4: Judicial-Management Dependency
+
+After the halt, Hodlnaut's recovery depended on Singapore judicial-management proceedings:
+
+```text
+judicial_management_dependency =
+  customer_recovery_value_dependent_on_court_process
+  / customer_assets_locked_on_platform
+```
+
+When this ratio is high, market-health status should remain impaired until users have concrete recovery terms and distributions. A court-supervised process can preserve value, but it also confirms that ordinary market liquidity has failed.
+
+## Signal 5: Product-Specific Asset Suspension
+
+Hodlnaut had previously posted notices about LUNA and UST handling on the platform. Asset-specific restrictions can become early warnings:
+
+```text
+asset_specific_suspension_signal =
+  restricted_assets_connected_to_known_market_collapse / total_supported_assets
+```
+
+The signal is strongest when the restricted assets are tied to a broader solvency story. LUNA and UST notices alone did not prove platform failure, but in hindsight they belonged in the same risk timeline as the later withdrawal halt and judicial-management process.
+
+## Counterfactual Stress Test
+
+A yield platform exposed to unstable assets should be stress-tested with linked liquidity scenarios:
+
+| Scenario                     | Assumption                                           | Market-health response                                             |
+| ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------ |
+| Asset-specific stress        | One supported asset becomes impaired                 | Monitor exposure size, disclosures, and redemption capacity        |
+| Customer withdrawal pressure | Outflows rise above normal stress thresholds         | Alert on run dynamics and liquid-asset coverage                    |
+| Platform-wide service halt   | Withdrawals, swaps, and deposits are paused together | Mark all platform balances as impaired liquidity                   |
+| Judicial-management recovery | Customer outcomes move into court-supervised process | Keep elevated-risk status until recovery terms and distributions   |
+| Disclosure mismatch risk     | Later filings reveal larger exposure than users knew | Treat platform communications as insufficient without balance data |
+
+The goal is to detect when an asset-specific loss can become a platform-wide exit failure.
+
+## Detection Table
+
+| Signal                           | What changed                                       | Why it mattered                                                |
+| -------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
+| Terra exposure impairment        | Hodlnaut tied distress to TerraUSD crash losses    | Asset exposure became customer-liquidity risk                  |
+| Withdrawal pressure spike        | Hodlnaut cited unusually high withdrawal volumes   | Customer outflows could exceed available liquid assets         |
+| Service halt breadth             | Withdrawals, token swaps, and deposits were halted | Users lost the core actions needed to manage risk              |
+| Judicial-management dependency   | Recovery shifted into a court-supervised process   | User outcomes depended on legal recovery, not ordinary markets |
+| Asset-specific suspension signal | LUNA and UST handling had already been restricted  | Asset-specific stress became part of the platform risk history |
+
+## Practical Alert Rules
+
+1. Treat large exposure to a failed stablecoin ecosystem as a platform-liquidity signal.
+2. Escalate when high withdrawal volumes coincide with asset-specific loss disclosures.
+3. Mark balances as impaired when withdrawals, swaps, and deposits are paused together.
+4. Track judicial-management or restructuring updates as market-health data.
+5. Separate account balances from recoverable value once customer actions are frozen.
+6. Watch asset-specific notices for early signs of platform-wide exposure.
+
+## Lessons for Market Health
+
+Hodlnaut shows that platform yield products can hide balance-sheet risk until users try to exit. A customer may see a balance in an account, but that balance is only market-liquid if the platform can honor withdrawals under stress.
+
+The broader lesson is that market-health systems should connect asset exposure, withdrawal pressure, service status, and legal recovery. A Terra/UST loss, a surge in withdrawals, and a judicial-management filing are not separate headlines. Together they describe a transition from market risk to trapped-liquidity risk.
+
+## Sources
+
+- [Hodlnaut: An update for our users](https://www.hodlnaut.com/press/an-update-for-our-users)
+- [Hodlnaut: An update on our Interim Judicial Management / Judicial Management process](https://www.hodlnaut.com/press/an-update-on-our-ijm-process)
+- [Hodlnaut: Notice - Updates on LUNA and UST on the Hodlnaut Platform](https://www.hodlnaut.com/press/updates-notice-terra-luna-ust)
+- [ForkLog: Hodlnaut crypto-lending platform halts withdrawals](https://forklog.com/en/hodlnaut-crypto-lending-platform-halts-withdrawals/)
+- [The Crypto Times: Hodlnaut Applies to be Placed Under Judicial Management](https://www.cryptotimes.io/2022/08/16/hodlnaut-applies-to-be-placed-under-judicial-management/)
+- [CoinMarketCap: Hodlnaut in a $193 Million Hole](https://coinmarketcap.com/academy/article/hodlnaut-in-a-193-million-hole)


### PR DESCRIPTION
## Summary
- Add a Market Health article for Hodlnaut's August 2022 withdrawal halt, Terra/UST exposure, and judicial-management recovery risk.
- Frame Terra exposure impairment, withdrawal pressure, service-halt breadth, judicial-management dependency, and asset-specific suspension signals as market-health indicators.
- Add a CSV signal table covering those indicators.

## Duplicate check
- Searched open PRs and issues for Hodlnaut, withdrawal freeze, UST, Terra, and judicial-management terms; no existing Market Health PR or issue found.
- Repo content search found no Hodlnaut Market Health or Cyberattacks coverage.

## Validation
- `npx prettier --check content/research/market-health/posts/2022-08-08-hodlnaut-terra-withdrawal-freeze/index.md`
- CSV parse: 6 rows, 7 columns, consistent field counts
- ASCII and final-newline checks
- `git diff --cached --check`
- Source URL probe: all cited URLs returned HTTP 200

Fixes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds a Market Health article documenting Hodlnaut's August 2022 withdrawal freeze, a service halt triggered by Terra/UST exposure.

## Changes
- **New article**: `content/research/market-health/posts/2022-08-08-hodlnaut-terra-withdrawal-freeze/index.md` (+134 lines)
  - Structured case narrative covering Hodlnaut's withdrawal freeze and recovery through judicial management
  - Defines five market-health indicators as monitoring signals: Terra exposure impairment, withdrawal pressure spike, service halt breadth, judicial-management dependency, and asset-specific suspension
  - Includes illustrative formulas, scenario/stress-test table, practical alert rules, and lessons learned
  - Provides source links to Hodlnaut updates and external reporting

## Validation
- Markdown formatting and CSV parsing verified (6 rows × 7 columns)
- ASCII and final-newline checks completed
- Cited URLs confirmed to return HTTP 200
- No existing Hodlnaut Market Health coverage found during duplicate check

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1712n/dn-institute/pull/1100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->