### PR TITLE
Add Vauld withdrawal moratorium market health case

### DIFF
--- a/content/research/market-health/posts/2022-07-04-vauld-withdrawal-moratorium/index.md
+++ b/content/research/market-health/posts/2022-07-04-vauld-withdrawal-moratorium/index.md
@@ -1,0 +1,135 @@
+---
+title: "Vauld Withdrawal Halt and Moratorium Liquidity Risk"
+date: "2022-07-04"
+description: "Vauld's July 2022 withdrawal, trading, and deposit halt shows how rapid customer outflows, restructuring uncertainty, and acquisition-dependent recovery can turn a crypto lender into an impaired-liquidity market."
+entities:
+  - Vauld
+  - Nexo
+  - Centralized Lending
+  - Crypto Credit Markets
+  - TerraUSD
+---
+
+## Summary
+
+Vauld suspended withdrawals, trading, and deposits on July 4, 2022 after a sharp run on customer funds and broader crypto-market stress. TechCrunch reported the immediate halt, while Vauld's restructuring FAQ later said customer net withdrawals had persisted after the TerraUSD collapse and before the suspension of customer accounts. The same FAQ described a Singapore moratorium process, and CoinCodex reported that Nexo had signed a term sheet to explore acquiring Vauld after the halt.
+
+This is a Market Health case because Vauld's customer balances stopped acting like liquid market inventory. Platform users could not withdraw, trade, or deposit, and recovery became tied to restructuring, creditor decisions, and a potential acquisition process. Later reporting from Blockhead described Vauld rejecting Nexo's proposal, which shows that acquisition-dependent recovery can remain uncertain long after an initial rescue narrative appears.
+
+For market-health monitoring, Vauld is useful because the warning signals appeared in sequence: customer withdrawals accelerated, the platform froze core actions, legal protection became part of the recovery path, and the proposed acquisition became a market-confidence variable.
+
+## Market Structure
+
+Vauld combined lending, exchange, and custody-like user expectations in one platform. That made the service halt unusually broad. Customers did not only lose one withdrawal method; the platform stopped withdrawals, trading, and deposits together.
+
+The risk chain had four layers:
+
+- customer outflows rose after market stress and the TerraUSD collapse;
+- Vauld froze customer actions to stabilize liquidity;
+- the company sought moratorium protection as part of restructuring;
+- recovery expectations became linked to a potential Nexo acquisition.
+
+Each layer changed the market-health meaning of account balances. A balance inside Vauld became a recovery claim rather than a freely deployable asset.
+
+## Signal 1: Withdrawal Run Velocity
+
+The first warning signal is the speed of customer outflows:
+
+```text
+withdrawal_run_velocity =
+  net_customer_withdrawals_during_stress_window / platform_assets_before_stress
+```
+
+Vauld's FAQ described persistent daily net withdrawals before the July 4 account suspension, and TechCrunch reported that customers had withdrawn nearly $198 million since June 12. A high withdrawal-run velocity means the platform is being forced to convert longer-duration or impaired positions into customer exits faster than its liquidity stack can support.
+
+## Signal 2: Full-Stack Service Halt
+
+Vauld halted withdrawals, trading, and deposits together:
+
+```text
+full_stack_service_halt =
+  withdrawals_paused and trading_paused and deposits_paused
+```
+
+This is a more severe market-health signal than a withdrawal queue or a single-asset pause. Customers could not exit, rebalance, or add assets through the platform. A full-stack halt means platform account balances no longer map cleanly to market liquidity.
+
+## Signal 3: Moratorium Dependency
+
+Vauld's restructuring FAQ described court protection through a moratorium. A market-health monitor can represent that as:
+
+```text
+moratorium_dependency =
+  customer_recovery_value_dependent_on_legal_stay
+  / customer_assets_locked_on_platform
+```
+
+Once this signal is high, normal price and yield metrics become secondary. The important variables are creditor ranking, restructuring terms, legal timelines, and whether any proposal actually restores customer access.
+
+## Signal 4: Acquisition Recovery Optionality
+
+Nexo's proposed acquisition created a recovery narrative, but acquisition talks are not the same as usable liquidity:
+
+```text
+acquisition_recovery_optionality =
+  expected_recovery_from_potential_acquirer / locked_customer_assets
+```
+
+CoinCodex reported Nexo's term sheet and plan to lift withdrawal limits, while later Blockhead reporting said Vauld rejected Nexo's proposal at that stage. That sequence shows why acquisition optionality should be treated as uncertain until binding terms and user distributions are available.
+
+## Signal 5: Terra Contagion Link
+
+Vauld's FAQ connected the withdrawal pressure to broader contagion after TerraUSD's collapse:
+
+```text
+terra_contagion_link =
+  withdrawals_or_losses_attributed_to_terra_contagion / normal_liquidity_buffer
+```
+
+Even if a platform is not a Terra protocol, customer behavior can change after a major ecosystem collapse. Vauld's case shows how market-wide trust loss can create lender-specific runs.
+
+## Counterfactual Stress Test
+
+A centralized crypto lender can be stress-tested with linked exit and recovery scenarios:
+
+| Scenario               | Assumption                                           | Market-health response                                             |
+| ---------------------- | ---------------------------------------------------- | ------------------------------------------------------------------ |
+| Normal outflow         | Withdrawals remain within liquid-asset capacity      | Monitor daily exit velocity                                        |
+| Run velocity spike     | Withdrawals persist above normal ranges              | Alert on liquidity-buffer depletion                                |
+| Full-stack halt        | Withdrawals, trading, and deposits are all paused    | Mark platform balances as impaired market liquidity                |
+| Moratorium process     | Customer outcomes depend on legal protection         | Track creditor and restructuring milestones as market-health data  |
+| Acquisition dependency | Recovery depends on a potential buyer or rescue plan | Discount recovery until binding terms and distributions are proven |
+
+The test asks whether customer balances remain usable when exit demand rises. If not, the product should be treated as a credit claim, not as immediately liquid crypto.
+
+## Detection Table
+
+| Signal                           | What changed                                              | Why it mattered                                                 |
+| -------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------- |
+| Withdrawal run velocity          | Customer net withdrawals persisted before the freeze      | Liquidity demand could outrun available platform assets         |
+| Full-stack service halt          | Withdrawals, trading, and deposits were suspended         | Customers lost the core actions needed to manage market risk    |
+| Moratorium dependency            | Recovery moved into creditor-protection proceedings       | Customer outcomes depended on legal process, not normal markets |
+| Acquisition recovery optionality | Nexo talks became part of the recovery narrative          | A possible rescue was not equivalent to restored liquidity      |
+| Terra contagion link             | TerraUSD collapse contributed to market-wide run dynamics | External ecosystem failure fed into platform-specific stress    |
+
+## Practical Alert Rules
+
+1. Track customer withdrawal run velocity after major market shocks.
+2. Treat simultaneous withdrawal, trading, and deposit freezes as a platform-wide liquidity failure.
+3. Separate proposed acquisitions from confirmed customer recoveries.
+4. Monitor moratorium and creditor-protection milestones as market-health events.
+5. Treat contagion from failed ecosystems as a liquidity-pressure input even for centralized lenders.
+6. Reclassify account balances as recovery claims when customer actions are frozen.
+
+## Lessons for Market Health
+
+Vauld shows that market health is about access, not just account values. Customers can hold balances on a platform that become practically illiquid once withdrawals, trading, and deposits are paused.
+
+The broader lesson is that lender health should be monitored as an exit-capacity problem. Withdrawal velocity, legal moratoriums, rescue talks, and contagion links can reveal when a platform is moving from ordinary business stress into impaired customer liquidity.
+
+## Sources
+
+- [TechCrunch: Crypto platform Vauld suspends withdrawals, trading and deposits amid financial challenges](https://techcrunch.com/2022/07/04/crypto-lending-platform-vauld-suspends-withdrawals-trading-and-deposits-amid-financial-challenges/)
+- [Vauld Help Center: FAQs on Vauld Group Restructuring as of 31 July 2022](https://support.vauld.com/en/articles/6382973-faqs-on-vauld-group-restructuring-as-of-31-july-22)
+- [CoinCodex: Nexo Plans to Acquire Troubled Crypto Lender Vauld](https://coincodex.com/article/16467/digital-asset-investment-platform-nexo-plans-to-acquire-troubled-crypto-lender-vauld/)
+- [InvestorPlace: Vauld Readying Itself for Merger With Nexo as It Freezes Withdrawals](https://investorplace.com/2022/07/vauld-readying-itself-for-merger-with-nexo-as-it-freezes-withdrawals/)
+- [Blockhead: SG Based Vauld Rejects Nexo Acquisition... For Now](https://www.blockhead.co/2022/12/28/sg-based-vauld-rejects-nexo-acquisition-for-now/)

--- a/content/research/market-health/posts/2022-07-04-vauld-withdrawal-moratorium/vauld-liquidity-signals.csv
+++ b/content/research/market-health/posts/2022-07-04-vauld-withdrawal-moratorium/vauld-liquidity-signals.csv
@@ -1,0 +1,7 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+withdrawal_run_velocity,2022-07-04,Vauld,critical,usd,https://techcrunch.com/2022/07/04/crypto-lending-platform-vauld-suspends-withdrawals-trading-and-deposits-amid-financial-challenges/,Customers withdrew nearly 198 million dollars after June 12 before the halt.
+full_stack_service_halt,2022-07-04,Vauld,critical,boolean,https://techcrunch.com/2022/07/04/crypto-lending-platform-vauld-suspends-withdrawals-trading-and-deposits-amid-financial-challenges/,Withdrawals trading and deposits were suspended together.
+moratorium_dependency,2022-07-31,Vauld,critical,legal_recovery,https://support.vauld.com/en/articles/6382973-faqs-on-vauld-group-restructuring-as-of-31-july-22,Customer recovery depended on restructuring and moratorium protection.
+acquisition_recovery_optionality,2022-07-05,Vauld/Nexo,high,recovery_option,https://coincodex.com/article/16467/digital-asset-investment-platform-nexo-plans-to-acquire-troubled-crypto-lender-vauld/,A Nexo term sheet created rescue optionality but not immediate liquidity.
+failed_rescue_discount,2022-12-28,Vauld/Nexo,high,recovery_discount,https://www.blockhead.co/2022/12/28/sg-based-vauld-rejects-nexo-acquisition-for-now/,Later rejection of the Nexo proposal showed acquisition recovery remained uncertain.
+terra_contagion_link,2022-07-31,Vauld,medium,contagion_signal,https://support.vauld.com/en/articles/6382973-faqs-on-vauld-group-restructuring-as-of-31-july-22,Vauld cited TerraUSD contagion as a factor behind increased withdrawal requests.


### PR DESCRIPTION
## Summary
- Add a Market Health article for Vauld's July 2022 withdrawal/trading/deposit halt and restructuring moratorium risk.
- Frame withdrawal run velocity, full-stack service halts, moratorium dependency, acquisition recovery optionality, and Terra contagion as market-health signals.
- Add a CSV signal table covering those indicators.

## Duplicate check
- Searched open PRs and issues for Vauld, withdrawal freeze, creditor protection, moratorium, and Nexo terms; no existing Market Health PR or issue found.
- Repo content search found no Vauld Market Health or Cyberattacks coverage.

## Validation
- `npx prettier --check content/research/market-health/posts/2022-07-04-vauld-withdrawal-moratorium/index.md`
- CSV parse: 6 rows, 7 columns, consistent field counts
- ASCII and final-newline checks
- `git diff --cached --check`
- Source URL probe: all cited URLs returned HTTP 200

Fixes #277