### PR TITLE
Add CoinLoan withdrawal cap market health case

### DIFF
--- a/content/research/market-health/posts/2022-07-05-coinloan-withdrawal-cap/coinloan-liquidity-signals.csv
+++ b/content/research/market-health/posts/2022-07-05-coinloan-withdrawal-cap/coinloan-liquidity-signals.csv
@@ -1,0 +1,7 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+withdrawal_cap_severity,2022-07-05,CoinLoan,high,usd_per_day,https://cryptoslate.com/coinloan-halts-all-withdrawals-user-services/,CoinLoan had used daily withdrawal limits of 5000 dollars before its later halt.
+legal_disposition_restraint,2023-04-24,CoinLoan,critical,legal_control,https://www.cointime.ai/news/cryptocurrency-lending-platform-coinloan-halts-operations-due-to-regulatory-restriction-81215,A notice of restraint required interim-liquidator approval for asset management.
+full_user_operation_halt,2023-04-25,CoinLoan,critical,boolean,https://crypto.news/coinloan-halts-withdrawals-and-services-following-court-order/,CoinLoan halted user withdrawals and services after the court-related notice.
+public_legal_notice,2023-04-24,CoinLoan,critical,court_notice,https://www.ametlikudteadaanded.ee/eng/teadaanne?teate_number=2065591,The Estonian public notice documented the restraint on disposition.
+service_provider_contagion,2023-04-26,CoinLoan/Bit4You,high,downstream_platform,https://finance.yahoo.com/news/belgian-crypto-lender-bit4you-suspends-162556274.html,Bit4You suspended operations after CoinLoan was declared insolvent by an Estonian court.
+creditor_claims_dependency,2023-06-14,CoinLoan,critical,claims_process,https://www.njordlaw.com/print/pdf/node/2765,CoinLoan recovery moved into a creditor claims process with submission deadlines.

--- a/content/research/market-health/posts/2022-07-05-coinloan-withdrawal-cap/index.md
+++ b/content/research/market-health/posts/2022-07-05-coinloan-withdrawal-cap/index.md
@@ -1,0 +1,139 @@
+---
+title: "CoinLoan Withdrawal Cap and Court-Order Liquidity Freeze"
+date: "2022-07-05"
+description: "CoinLoan's 2022 withdrawal cap and 2023 court-ordered halt show how provisional liquidity controls, legal restraints, and service-provider contagion can turn lender balances into impaired recovery claims."
+entities:
+  - CoinLoan
+  - Bit4You
+  - Centralized Lending
+  - Crypto Credit Markets
+  - Estonia
+---
+
+## Summary
+
+CoinLoan limited customer withdrawals during the 2022 crypto-credit stress period and later halted user operations after an Estonian legal restraint. CryptoSlate reported that CoinLoan had used daily withdrawal limits of $5,000 and then halted all user withdrawals and activity after receiving a notice of restraint on disposition in April 2023. Cointime reported that the notice required CoinLoan to halt operations including withdrawals because the company could not manage assets without interim-liquidator approval.
+
+This is a Market Health case because CoinLoan's balances moved through escalating liquidity states: provisional withdrawal limits, full user-operation halt, legal control over asset disposition, and downstream service-provider contagion. Yahoo Finance reported that Belgian lender Bit4You suspended operations after CoinLoan was declared insolvent by an Estonian court and because Bit4You had assets held with CoinLoan.
+
+For monitoring, CoinLoan is useful because the initial signal was not a total freeze. A withdrawal cap can look like a conservative risk-control measure, but it can also be an early warning that a lender is managing a run. The later court restraint shows why capped withdrawals should be tracked as a liquidity-state change rather than treated as normal service degradation.
+
+## Market Structure
+
+CoinLoan operated as a centralized crypto lending platform, so customer balances depended on the platform's ability to honor redemptions, manage loan-book liquidity, and satisfy legal requirements. Its risk was not isolated to direct users. Bit4You's suspension showed that a service provider's impaired assets can transmit liquidity stress to another customer-facing platform.
+
+The risk chain had five layers:
+
+- withdrawal access was restricted by a daily cap;
+- customer operations later halted under a legal restraint;
+- asset disposition required interim-liquidator approval;
+- counterparties and platforms with CoinLoan exposure faced their own customer-access problems;
+- user balances shifted from operational withdrawals to legal recovery.
+
+Each layer reduced the usefulness of account balances as liquid market inventory.
+
+## Signal 1: Withdrawal Cap Severity
+
+CoinLoan's daily withdrawal limit is the first market-health signal:
+
+```text
+withdrawal_cap_severity =
+  1 - permitted_daily_withdrawal_amount / user_balance_available_for_withdrawal
+```
+
+CryptoSlate reported that CoinLoan had set daily withdrawal limits to $5,000. The cap's severity depends on the customer's balance, but the direction is clear: large balances become slow-moving claims when customers cannot exit at full size.
+
+## Signal 2: Legal Restraint on Disposition
+
+The second signal is the move from platform policy to legal restraint:
+
+```text
+legal_disposition_restraint =
+  assets_requiring_interim_liquidator_approval / total_platform_assets
+```
+
+Cointime reported that the notice meant CoinLoan could not manage assets without approval from an interim liquidator. That changes the market-health state from "platform-controlled liquidity" to "court-supervised recovery path."
+
+## Signal 3: Full User-Operation Halt
+
+CryptoSlate reported that CoinLoan halted all user withdrawals and activity:
+
+```text
+full_user_operation_halt =
+  withdrawals_disabled and user_activity_disabled
+```
+
+This is more severe than a single withdrawal queue. A full halt means customers cannot rely on the platform for normal risk management, portfolio rebalancing, or predictable exit timing.
+
+## Signal 4: Service-Provider Contagion
+
+CoinLoan's stress propagated to Bit4You:
+
+```text
+service_provider_contagion =
+  downstream_platform_assets_locked_at_provider
+  / downstream_platform_customer_assets
+```
+
+Yahoo Finance reported that Bit4You suspended operations after CoinLoan was declared insolvent by an Estonian court. That makes CoinLoan a service-provider contagion case, not only a direct-lender case. Platforms that custody or deploy assets through another lender inherit that lender's liquidity state.
+
+## Signal 5: Creditor Claims Window
+
+The NJORD Law notice described creditor claims submission in CoinLoan's bankruptcy process:
+
+```text
+creditor_claims_dependency =
+  customer_recovery_value_submitted_through_claims_process
+  / customer_balances_before_halt
+```
+
+Once creditor claims become the recovery path, market-health monitoring should track claim deadlines, trustee updates, court decisions, and distribution expectations rather than ordinary withdrawal status.
+
+## Counterfactual Stress Test
+
+A centralized lender can be stress-tested by escalating customer access through policy and legal states:
+
+| Scenario                | Assumption                                       | Market-health response                                  |
+| ----------------------- | ------------------------------------------------ | ------------------------------------------------------- |
+| Normal withdrawals      | Customers can withdraw without daily cap         | Monitor withdrawal latency and asset-liability mismatch |
+| Provisional cap         | Daily withdrawal amount is capped                | Mark balances above the cap as slowed liquidity         |
+| Full operation halt     | Withdrawals and user activity are disabled       | Reclassify balances as impaired claims                  |
+| Legal restraint         | Asset movement needs interim-liquidator approval | Track court and trustee milestones as liquidity data    |
+| Provider contagion      | A downstream platform depends on CoinLoan assets | Map service-provider exposure into downstream user risk |
+| Creditor claims process | Recovery depends on filed claims                 | Track deadlines and creditor communications             |
+
+The test asks whether customer balances remain withdrawable under stress. If the answer moves from "yes" to "capped" to "court-controlled," the platform has crossed from market liquidity into recovery-claim territory.
+
+## Detection Table
+
+| Signal                      | What changed                                        | Why it mattered                                                   |
+| --------------------------- | --------------------------------------------------- | ----------------------------------------------------------------- |
+| Withdrawal cap severity     | Daily withdrawal access was limited                 | Large balances became slow-moving and run-sensitive               |
+| Legal disposition restraint | Asset movement required interim-liquidator approval | Platform-controlled liquidity became court-supervised recovery    |
+| Full user-operation halt    | Withdrawals and user activity stopped               | Customers lost normal exit and risk-management actions            |
+| Service-provider contagion  | Bit4You suspended activity after CoinLoan stress    | CoinLoan impairment propagated to another customer-facing service |
+| Creditor claims dependency  | Recovery moved into a bankruptcy claims process     | Customer outcomes depended on legal submissions and distributions |
+
+## Practical Alert Rules
+
+1. Treat daily withdrawal caps as liquidity-state changes, not routine product settings.
+2. Track whether a cap is described as provisional and whether it is later lifted, tightened, or replaced by a halt.
+3. Escalate risk when asset disposition requires a liquidator, trustee, or court approval.
+4. Map service-provider relationships so one lender's freeze is visible in downstream platform risk.
+5. Reclassify balances as recovery claims once creditor submission deadlines appear.
+6. Monitor public court notices alongside platform blog posts and customer communications.
+
+## Lessons for Market Health
+
+CoinLoan shows that withdrawal limits can be an early warning before a full legal freeze. The important signal is not only whether withdrawals are "on" or "off," but whether customers can exit at economically meaningful size.
+
+The broader lesson is that crypto-credit market health depends on both direct platform liquidity and hidden service-provider exposure. When a lender becomes court-controlled, platforms and users connected to that lender can inherit the same impaired-liquidity state.
+
+## Sources
+
+- [CryptoSlate: CoinLoan halts all withdrawals, user services](https://cryptoslate.com/coinloan-halts-all-withdrawals-user-services/)
+- [Cointime: Cryptocurrency Lending Platform CoinLoan Halts Operations Due to Regulatory Restriction](https://www.cointime.ai/news/cryptocurrency-lending-platform-coinloan-halts-operations-due-to-regulatory-restriction-81215)
+- [Crypto.news: CoinLoan halts withdrawals and services following court order](https://crypto.news/coinloan-halts-withdrawals-and-services-following-court-order/)
+- [Ametlikud Teadaanded: CoinLoan notice of restraint on disposition](https://www.ametlikudteadaanded.ee/eng/teadaanne?teate_number=2065591)
+- [Yahoo Finance: Belgian Crypto Lender Bit4You Suspends Activities After Service Provider Declared Insolvent](https://finance.yahoo.com/news/belgian-crypto-lender-bit4you-suspends-162556274.html)
+- [NJORD Law: Important Notice: CoinLoan's Bankruptcy](https://www.njordlaw.com/print/pdf/node/2765)


### PR DESCRIPTION
## Summary
- add a CoinLoan Market Health case for the 2022 withdrawal cap, 2023 user-operation halt, Estonian restraint on disposition, Bit4You downstream contagion, and creditor-claims recovery path
- add a companion CSV signal table covering withdrawal-cap severity, legal restraint, full halt, public notice, service-provider contagion, and creditor-claims dependency

Fixes #277

## Validation
- npx prettier --write content/research/market-health/posts/2022-07-05-coinloan-withdrawal-cap/index.md
- npx prettier --check content/research/market-health/posts/2022-07-05-coinloan-withdrawal-cap/index.md
- python3 CSV/ASCII/final-newline validation script
- python3 live URL probe for all Markdown and CSV sources
- git diff --check