### PR TITLE
Add Babel Finance withdrawal freeze market health case

### DIFF
--- a/content/research/market-health/posts/2022-06-17-babel-finance-withdrawal-freeze/babel-restructuring-signals.csv
+++ b/content/research/market-health/posts/2022-06-17-babel-finance-withdrawal-freeze/babel-restructuring-signals.csv
@@ -1,0 +1,8 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+redemption_freeze,2022-06-17,Babel Finance,critical,boolean,https://cryptoslate.com/babel-finance-suspends-withdrawals-due-to-unusual-liquidity-pressures/,Babel suspended redemptions and withdrawals after citing unusual liquidity pressures.
+liquidity_pressure_context,2022-06-17,Babel Finance,high,market_stress,https://www.cryptotimes.io/2022/06/17/babel-finance-temporarily-suspends-withdrawals/,The withdrawal pause followed broader crypto-credit market stress.
+proprietary_trading_loss_exposure,2022-07-29,Babel Finance,critical,usd,https://www.financemagnates.com/cryptocurrency/news/babel-finance-lost-280-million-in-proprietary-trading/,Reported proprietary trading losses exceeded 280 million dollars.
+moratorium_dependency,2023-03-06,Babel Finance,critical,legal_recovery,https://www.prnewswire.com/news-releases/babel-finance-files-moratorium-application-in-singapore-high-court-301763460.html,Babel filed Singapore moratorium applications to support restructuring.
+recovery_coin_dependency,2023-03-13,Babel Recovery Coin/Hope,high,recovery_token,https://techcrunch.com/2023/03/13/babel-flex-yang-stablecoin/,Restructuring discussion included Hope and Babel Recovery Coin economics.
+creditor_protection_extension,2023-04-19,Babel Finance,high,court_milestone,https://www.blockhead.co/2023/04/19/babel-begins-in-court-restructuring-creditor-protection-extended/,Creditor protection was extended as in-court restructuring began.
+novel_crypto_restructuring,2023-11-01,Babel Finance,medium,legal_analysis,https://law.nus.edu.sg/trail/cryptocurrency_group_granted_moratoria/,NUS legal commentary described Babel's crypto restructuring plan and moratoria.

--- a/content/research/market-health/posts/2022-06-17-babel-finance-withdrawal-freeze/index.md
+++ b/content/research/market-health/posts/2022-06-17-babel-finance-withdrawal-freeze/index.md
@@ -1,0 +1,142 @@
+---
+title: "Babel Finance Withdrawal Freeze and Recovery-Coin Restructuring Risk"
+date: "2022-06-17"
+description: "Babel Finance's June 2022 withdrawal freeze shows how lender liquidity pressure, proprietary-trading losses, moratorium protection, and recovery-coin restructuring can turn customer balances into long-dated creditor claims."
+entities:
+  - Babel Finance
+  - Babel Recovery Coin
+  - Hope
+  - Centralized Lending
+  - Crypto Credit Markets
+  - Singapore
+---
+
+## Summary
+
+Babel Finance suspended redemptions and withdrawals in June 2022 after citing unusual liquidity pressures. CryptoSlate reported that the company paused withdrawals during the same credit-stress period that affected other crypto lenders. Finance Magnates later reported that Babel lost more than $280 million through proprietary trading with customer funds, citing a restructuring proposal deck.
+
+This is a Market Health case because Babel's customer balances moved from lender deposits into a restructuring path. The company's own PRNewswire announcement said Babel filed Singapore moratorium applications in March 2023 and planned to implement restructuring through schemes of arrangement. TechCrunch reported that the restructuring effort was connected to a proposed recovery mechanism involving a separate stablecoin and Babel Recovery Coin.
+
+For monitoring, Babel is useful because the public timeline shows a full credit-risk transition: withdrawals stopped, hidden loss mechanics surfaced, creditor protection followed, and repayment became tied to new financing and tokenized recovery. That sequence is materially different from a temporary wallet outage or routine withdrawal delay.
+
+## Market Structure
+
+Babel operated as a crypto financial-services and lending firm. Customer access depended on Babel's asset-liability management, risk controls, and ability to resolve creditor claims. The later restructuring materials also show that recovery could depend on capital raising, new business plans, and token mechanics rather than immediate liquid assets.
+
+The risk chain had five layers:
+
+- redemptions and withdrawals stopped during market stress;
+- proprietary-trading losses turned customer funds into recovery exposure;
+- creditors became dependent on restructuring negotiations;
+- Singapore moratorium protection shielded the process from immediate creditor action;
+- proposed recovery coins and new stablecoin revenue became part of the repayment narrative.
+
+Each layer shifted market-health monitoring away from account balances and toward creditor-recovery mechanics.
+
+## Signal 1: Redemption Freeze
+
+The first signal was the suspension of redemptions and withdrawals:
+
+```text
+redemption_freeze =
+  withdrawals_suspended and redemptions_suspended
+```
+
+CryptoSlate reported that Babel faced unusual liquidity pressures and suspended withdrawals. A redemption freeze is a critical lender-health signal because customers lose the ability to test whether account balances are backed by liquid, deliverable assets.
+
+## Signal 2: Proprietary-Trading Loss Exposure
+
+Finance Magnates reported that Babel lost more than $280 million in proprietary trading with customer funds:
+
+```text
+proprietary_trading_loss_exposure =
+  proprietary_trading_losses_using_customer_funds
+  / customer_assets_or_creditor_claims
+```
+
+This signal is severe because it points to risk that is not visible from ordinary product terms. Customers may believe they are exposed to lending risk, while the platform has also embedded discretionary trading risk into the balance sheet.
+
+## Signal 3: Moratorium Dependency
+
+Babel's PRNewswire announcement said it filed Singapore moratorium applications under the Insolvency, Restructuring and Dissolution Act:
+
+```text
+moratorium_dependency =
+  creditor_recovery_value_protected_by_moratorium
+  / total_creditor_claims
+```
+
+Once creditor protection is part of the recovery path, market-health monitoring should treat legal milestones as liquidity events. A moratorium can preserve restructuring optionality, but it also confirms that normal customer withdrawals are no longer the central mechanism for recovery.
+
+## Signal 4: Recovery-Coin Repayment Dependency
+
+TechCrunch reported that Babel's restructuring was linked to a proposed repayment path involving a stablecoin project and Babel Recovery Coin.
+
+```text
+recovery_coin_dependency =
+  expected_repayment_from_new_token_or_project_revenue
+  / creditor_claims_to_be_repaid
+```
+
+This signal should be discounted heavily until distributions are made. Recovery-token plans depend on future market demand, governance, execution, and revenue rather than existing liquid collateral.
+
+## Signal 5: Creditor Objection and Plan Clarity Risk
+
+Blockhead reported that Babel's creditor protection was extended and that recovery plans involving Hope and Babel Recovery Coins were part of the restructuring discussion. NUS legal commentary later described the Babel Finance group's moratoria and restructuring plan as novel for cryptocurrency companies.
+
+```text
+plan_clarity_risk =
+  disputed_or_uncertain_restructuring_terms / total_recovery_plan_terms
+```
+
+When a recovery plan relies on unfamiliar token mechanics, creditor confidence depends on clarity about issuance, governance, backing, distribution rights, and revenue capture. Unclear terms can delay recovery even when a moratorium is granted.
+
+## Counterfactual Stress Test
+
+A centralized crypto lender can be stress-tested by escalating from ordinary liquidity to restructuring:
+
+| Scenario               | Assumption                                    | Market-health response                                      |
+| ---------------------- | --------------------------------------------- | ----------------------------------------------------------- |
+| Normal redemptions     | Customers can redeem at full size             | Monitor withdrawal latency and reserve quality              |
+| Liquidity pressure     | Redemptions and withdrawals are paused        | Mark lender balances as impaired liquidity                  |
+| Hidden trading losses  | Customer funds were used in unhedged trading  | Add governance and risk-control failure to the loss model   |
+| Moratorium process     | Creditor recovery depends on court protection | Track court filings, moratorium dates, and scheme documents |
+| Recovery-coin proposal | Repayment depends on a new token or project   | Discount recovery until cash or liquid distributions occur  |
+| Plan objections        | Creditors challenge structure or economics    | Track objection risk and plan revision milestones           |
+
+The test asks whether a customer's claim can be satisfied through existing liquid assets. If recovery depends on legal protection and future token economics, the balance should be modeled as a creditor claim, not as available crypto liquidity.
+
+## Detection Table
+
+| Signal                            | What changed                                                | Why it mattered                                                   |
+| --------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------- |
+| Redemption freeze                 | Withdrawals and redemptions stopped                         | Customers lost direct access to lender balances                   |
+| Proprietary-trading loss exposure | Customer funds were tied to large trading losses            | Hidden risk controls became a creditor-recovery variable          |
+| Moratorium dependency             | Babel filed Singapore moratorium applications               | Recovery moved into court-supervised restructuring                |
+| Recovery-coin dependency          | Repayment narrative included new token/project economics    | Creditor recovery depended on future execution, not existing cash |
+| Plan clarity risk                 | Novel crypto restructuring terms needed creditor acceptance | Ambiguous recovery mechanics could delay or reduce distributions  |
+
+## Practical Alert Rules
+
+1. Treat withdrawal and redemption freezes at lenders as immediate market-health impairments.
+2. Escalate risk when reported losses come from proprietary trading with customer funds.
+3. Track moratorium filings and scheme-of-arrangement milestones as liquidity events.
+4. Discount recovery-token proposals until actual distributions are made.
+5. Separate lender solvency from proposed future revenue or token-market assumptions.
+6. Monitor creditor objections and plan revisions as recovery-value signals.
+
+## Lessons for Market Health
+
+Babel shows how a lender can move from a short public notice about liquidity pressure into a long restructuring process. The customer-facing symptom was simple: withdrawals stopped. The underlying risk stack was much more complex.
+
+The broader lesson is that crypto-credit market health requires visibility into risk controls, legal protection, and proposed recovery mechanics. When repayment depends on a new token or future project economics, customer balances should be treated as uncertain creditor claims.
+
+## Sources
+
+- [CryptoSlate: Babel Finance suspends withdrawals due to unusual liquidity pressures](https://cryptoslate.com/babel-finance-suspends-withdrawals-due-to-unusual-liquidity-pressures/)
+- [The Crypto Times: Babel Finance Temporarily Suspends Withdrawals](https://www.cryptotimes.io/2022/06/17/babel-finance-temporarily-suspends-withdrawals/)
+- [Finance Magnates: Babel Finance Lost $280 Million in Proprietary Trading](https://www.financemagnates.com/cryptocurrency/news/babel-finance-lost-280-million-in-proprietary-trading/)
+- [Babel Finance via PRNewswire: Babel Finance Files Moratorium Application in Singapore High Court](https://www.prnewswire.com/news-releases/babel-finance-files-moratorium-application-in-singapore-high-court-301763460.html)
+- [TechCrunch: Founder of troubled crypto asset unicorn Babel launches new DeFi project, stablecoin](https://techcrunch.com/2023/03/13/babel-flex-yang-stablecoin/)
+- [Blockhead: Babel Begins In-Court Restructuring, Creditor Protection Extended](https://www.blockhead.co/2023/04/19/babel-begins-in-court-restructuring-creditor-protection-extended/)
+- [NUS TRAIL: Cryptocurrency Group Granted Moratoria to Formulate Worldwide Restructuring Plan Centred in Singapore](https://law.nus.edu.sg/trail/cryptocurrency_group_granted_moratoria/)


### PR DESCRIPTION
## Summary
- add a Babel Finance Market Health case for the June 2022 redemption freeze, reported proprietary-trading loss exposure, Singapore moratorium, Hope/Babel Recovery Coin restructuring path, and creditor-plan clarity risk
- add a companion CSV signal table covering redemption freeze, liquidity pressure, proprietary-trading losses, moratorium dependency, recovery-coin dependency, creditor-protection extension, and legal-analysis milestones

Fixes #277

## Validation
- npx prettier --write content/research/market-health/posts/2022-06-17-babel-finance-withdrawal-freeze/index.md
- npx prettier --check content/research/market-health/posts/2022-06-17-babel-finance-withdrawal-freeze/index.md
- python3 CSV/ASCII/final-newline validation script
- python3 live URL probe for all Markdown and CSV sources
- git diff --check