### PR TITLE
Add Haru Delio withdrawal contagion market health case

### DIFF
--- a/content/research/market-health/posts/2023-06-13-haru-delio-withdrawal-contagion/haru-delio-contagion-signals.csv
+++ b/content/research/market-health/posts/2023-06-13-haru-delio-withdrawal-contagion/haru-delio-contagion-signals.csv
@@ -1,0 +1,7 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+service_partner_opacity,2023-06-13,Haru Invest,critical,counterparty_opacity,https://www.cryptotimes.io/2023/06/13/haru-invest-halts-withdrawals-and-deposits-in-south-korea/,Haru cited an issue with a service partner when suspending deposits and withdrawals.
+deposit_withdrawal_freeze,2023-06-13,Haru Invest,critical,boolean,https://forklog.com/en/haru-invest-platform-halts-withdrawals/,Haru halted deposits and withdrawals to protect assets under custody.
+downstream_platform_contagion,2023-06-15,Delio/Haru Invest,critical,platform_contagion,https://www.cryptotimes.io/2023/06/15/delio-temporarily-suspends-crypto-withdrawals/,Delio suspended withdrawals after Haru's freeze raised customer-protection concerns.
+haru_linked_delio_halt,2023-06-14,Delio,high,exposure_link,https://www.dlnews.com/articles/deals/korean-crypto-lender-delio-halts-withdrawals-after-haru/,Reporting linked Delio's halt to funds stuck in Haru.
+rehabilitation_dependency,2024-02-06,Haru Invest,critical,legal_recovery,https://cm.asiae.co.kr/en/article/2024020611071384620,Haru was reported to be undergoing rehabilitation procedures after the withdrawal suspension.
+criminal_enforcement_escalation,2024-02-06,Haru Invest,critical,legal_enforcement,https://cm.asiae.co.kr/en/article/2024020611071384620,Haru Invest management arrests were reported in connection with the large withdrawal-suspension case.

--- a/content/research/market-health/posts/2023-06-13-haru-delio-withdrawal-contagion/index.md
+++ b/content/research/market-health/posts/2023-06-13-haru-delio-withdrawal-contagion/index.md
@@ -1,0 +1,139 @@
+---
+title: "Haru Invest Withdrawal Freeze and Delio Contagion Risk"
+date: "2023-06-13"
+description: "Haru Invest's June 2023 withdrawal freeze and Delio's follow-on halt show how service-partner opacity, yield-platform custody exposure, and legal-criminal escalation can turn advertised yield balances into impaired recovery claims."
+entities:
+  - Haru Invest
+  - Delio
+  - B&S Holdings
+  - Crypto Credit Markets
+  - Yield Products
+  - South Korea
+---
+
+## Summary
+
+Haru Invest suspended deposits and withdrawals on June 13, 2023 after citing an issue with a service partner. The Crypto Times and ForkLog reported the halt, which affected a platform known for yield-oriented crypto products. Two days later, The Crypto Times reported that Delio temporarily suspended withdrawals, and DL News reported that Delio's halt was connected to funds stuck in Haru.
+
+This is a Market Health case because the risk did not remain inside one platform. A service-partner problem at Haru impaired customer access at Haru, then transmitted to Delio customers through Delio's own exposure. Later, Asia Economy reported that Haru Invest management had been arrested after the large withdrawal-suspension case, and that the platform was undergoing rehabilitation procedures.
+
+For monitoring, Haru and Delio are useful because the warning signs span operational, counterparty, and legal layers: an unexplained partner issue, immediate withdrawal freeze, downstream lender contagion, rehabilitation proceedings, and criminal allegations. Those signals show how yield-platform balances can stop functioning as liquid assets long before a final legal recovery outcome is known.
+
+## Market Structure
+
+Haru Invest and Delio were yield-oriented crypto platforms serving Korean customers. Users expected custody, yield, and withdrawal access, but the platforms relied on third-party managers, counterparties, and inter-platform exposure. That created opacity: customer balances depended not only on the platform interface, but also on external service partners and internal allocation controls.
+
+The risk chain had five layers:
+
+- Haru suspended deposits and withdrawals after citing a service-partner issue;
+- Delio suspended withdrawals after Haru's freeze affected its own liquidity picture;
+- customers lost access at both direct and downstream platforms;
+- rehabilitation and legal proceedings became part of recovery;
+- arrests and criminal allegations turned risk-control questions into legal-enforcement signals.
+
+Each layer reduced the usefulness of customer account balances as immediately liquid market inventory.
+
+## Signal 1: Service-Partner Opacity
+
+Haru's initial explanation centered on a partner issue:
+
+```text
+service_partner_opacity =
+  customer_assets_dependent_on_unidentified_partner / total_customer_assets
+```
+
+The danger is not only that a partner failed. The market-health problem is that customers could not independently map which balances were exposed to that partner, what collateral or controls existed, or how long recovery would take.
+
+## Signal 2: Deposit and Withdrawal Freeze
+
+Haru stopped deposits and withdrawals:
+
+```text
+deposit_withdrawal_freeze =
+  deposits_suspended and withdrawals_suspended
+```
+
+Stopping both directions is a severe signal. It means the platform is no longer accepting normal customer flows and is trying to stabilize custody or recovery conditions. Users cannot exit, and new deposits are also blocked because the platform cannot safely continue ordinary operations.
+
+## Signal 3: Downstream Platform Contagion
+
+Delio's withdrawal halt shows downstream contagion:
+
+```text
+downstream_platform_contagion =
+  downstream_platform_assets_or_liquidity_exposed_to_haru
+  / downstream_platform_customer_liabilities
+```
+
+DL News reported that Delio halted withdrawals after Haru. The Crypto Times described Delio's halt as a customer-protection measure following Haru's suspension. A market-health monitor should treat one yield platform's freeze as a risk input for other platforms that custody, lend, or invest through it.
+
+## Signal 4: Rehabilitation Dependency
+
+Asia Economy reported that Haru was undergoing rehabilitation procedures:
+
+```text
+rehabilitation_dependency =
+  customer_recovery_value_dependent_on_court_process
+  / customer_balances_before_freeze
+```
+
+Once rehabilitation becomes central, ordinary product metrics such as advertised yield, app balances, or historical withdrawal speed become secondary. Recovery depends on court timelines, asset tracing, creditor treatment, and claims administration.
+
+## Signal 5: Criminal-Enforcement Escalation
+
+Asia Economy reported arrests of Haru Invest management related to the withdrawal-suspension case:
+
+```text
+criminal_enforcement_escalation =
+  legal_enforcement_events_related_to_customer_asset_shortfall
+```
+
+Criminal-enforcement escalation is a market-health signal because it often reflects deeper governance, disclosure, or asset-control problems. It can also slow customer recovery by moving evidence, asset tracing, and management decisions into legal proceedings.
+
+## Counterfactual Stress Test
+
+A yield platform can be stress-tested by tracing service-partner exposure and downstream reliance:
+
+| Scenario                    | Assumption                                                 | Market-health response                                 |
+| --------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ |
+| Normal operation            | Deposits, withdrawals, and rewards operate                 | Monitor withdrawal latency and partner concentration   |
+| Partner issue               | A service partner reports inaccurate or impaired positions | Flag opaque custody and yield allocation risk          |
+| Platform freeze             | Deposits and withdrawals stop                              | Reclassify customer balances as impaired liquidity     |
+| Downstream contagion        | Another platform halts withdrawals due to exposure         | Map inter-platform custody and investment dependencies |
+| Rehabilitation process      | Recovery depends on court proceedings                      | Track creditor, court, and rehabilitation milestones   |
+| Criminal-enforcement signal | Executives or partners face arrest or charges              | Escalate governance and asset-tracing risk             |
+
+The test asks whether users can identify and exit partner-linked exposure before a freeze. If not, yield balances should be monitored as opaque credit claims rather than as simple app-account liquidity.
+
+## Detection Table
+
+| Signal                          | What changed                                   | Why it mattered                                                 |
+| ------------------------------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| Service-partner opacity         | Haru cited an issue with a service partner     | Customers could not independently map exposure or recovery path |
+| Deposit and withdrawal freeze   | Haru stopped both deposits and withdrawals     | The platform exited normal operating mode                       |
+| Downstream platform contagion   | Delio halted withdrawals after Haru's freeze   | Haru's impairment transmitted to another customer-facing lender |
+| Rehabilitation dependency       | Recovery moved into rehabilitation proceedings | Customer outcomes depended on court process                     |
+| Criminal-enforcement escalation | Haru management arrests were reported          | Governance and asset-control risk became legal-enforcement risk |
+
+## Practical Alert Rules
+
+1. Flag any yield platform that cites an unnamed or opaque service-partner issue before freezing withdrawals.
+2. Treat simultaneous deposit and withdrawal suspensions as a critical liquidity impairment.
+3. Map downstream platforms that custody, invest, or lend through the frozen platform.
+4. Track rehabilitation and creditor-process milestones as market-health data.
+5. Escalate governance risk when criminal-enforcement events follow a customer-asset freeze.
+6. Separate advertised app balances from recoverable balances once legal proceedings begin.
+
+## Lessons for Market Health
+
+Haru and Delio show how crypto-yield platform risk can move through hidden service relationships. Customers may see a simple account balance, while the actual liquidity path depends on third-party managers and other platforms.
+
+The broader lesson is that yield-platform market health needs a counterparty map, not only a user-interface check. Once a partner issue triggers a freeze, downstream platforms can inherit the same liquidity impairment, and customers may be left with recovery claims rather than withdrawable assets.
+
+## Sources
+
+- [The Crypto Times: Haru Invest Halts Withdrawals and Deposits in South Korea](https://www.cryptotimes.io/2023/06/13/haru-invest-halts-withdrawals-and-deposits-in-south-korea/)
+- [ForkLog: Haru Invest platform halts withdrawals](https://forklog.com/en/haru-invest-platform-halts-withdrawals/)
+- [The Crypto Times: Delio Temporarily Suspends Crypto Withdrawals](https://www.cryptotimes.io/2023/06/15/delio-temporarily-suspends-crypto-withdrawals/)
+- [DL News: Korean crypto lender Delio halts withdrawals after Haru](https://www.dlnews.com/articles/deals/korean-crypto-lender-delio-halts-withdrawals-after-haru/)
+- [Asia Economy: HaruInvest Management Arrested](https://cm.asiae.co.kr/en/article/2024020611071384620)


### PR DESCRIPTION
## Summary
- add a Haru Invest / Delio Market Health case for the June 2023 service-partner withdrawal freeze, downstream Delio contagion, rehabilitation dependency, and criminal-enforcement escalation
- add a companion CSV signal table covering service-partner opacity, deposit/withdrawal freeze, downstream contagion, Delio exposure link, rehabilitation dependency, and enforcement escalation

Fixes #277

## Validation
- npx prettier --write content/research/market-health/posts/2023-06-13-haru-delio-withdrawal-contagion/index.md
- npx prettier --check content/research/market-health/posts/2023-06-13-haru-delio-withdrawal-contagion/index.md
- python3 CSV/ASCII/final-newline validation script
- python3 live URL probe for all Markdown and CSV sources
- git diff --check