### PR TITLE
Add Wyre withdrawal limit market health case

### DIFF
--- a/content/research/market-health/posts/2023-01-07-wyre-withdrawal-limit/index.md
+++ b/content/research/market-health/posts/2023-01-07-wyre-withdrawal-limit/index.md
@@ -1,0 +1,133 @@
+---
+title: "Wyre 90% Withdrawal Limit and Payment-Rail Liquidity Stress"
+date: "2023-01-07"
+description: "Wyre's 2023 90% customer withdrawal limit shows how crypto payment infrastructure can create market-health stress through partial withdrawal caps, partner-service interruption, leadership changes, and emergency financing dependence."
+entities:
+  - Wyre
+  - Wyre Payments
+  - Ledger Live
+  - Crypto Payment Providers
+  - Fiat Onramps
+  - Payment Rails
+---
+
+## Summary
+
+Wyre limited customer withdrawals to 90% of assets held in each account in January 2023. CoinMarketCap Academy reported that the cap spooked users amid reports that a shutdown was imminent, and that Wyre later lifted the limit after securing financing from a partner. The Crypto Times reported that Wyre had modified withdrawal policy for all users to a 90% limit, while Ledger published a support notice saying its Wyre-powered buy/swap service was temporarily unavailable.
+
+This is a Market Health case because Wyre was payment infrastructure, not only a standalone wallet. When a payment provider limits withdrawals or partners disable service routes, users can lose access to fiat onramps, swaps, and custody-adjacent flows across multiple apps.
+
+For monitoring, Wyre shows that partial withdrawal limits deserve the same attention as full withdrawal freezes. A 90% limit still leaves customer balances trapped and signals that the platform is rationing liquidity while seeking capital or operational relief.
+
+## Market Structure
+
+Wyre operated as a crypto payment and infrastructure provider. Its risk surface included direct customer balances, partner integrations, and fiat-to-crypto service routes:
+
+- customers depended on Wyre's withdrawal policy;
+- partner apps depended on Wyre's buy and swap availability;
+- platform confidence depended on leadership and financing updates;
+- a partial withdrawal cap created a measurable residual trapped-balance signal;
+- later limit removal depended on new financing.
+
+This made Wyre a payment-rail stress event. The affected market was not only Wyre accounts, but also downstream users whose access route relied on Wyre.
+
+## Signal 1: Partial Withdrawal Cap
+
+The first signal is a capped withdrawal policy:
+
+```text
+partial_withdrawal_cap =
+  customer_balance_not_withdrawable / total_customer_balance
+```
+
+Wyre's 90% cap meant that 10% of each account could remain trapped even when withdrawals were technically available. Partial caps should be tracked separately from normal daily limits because they are platform-wide stress controls.
+
+## Signal 2: Partner-Service Interruption
+
+Ledger said that its Wyre-powered buy/swap service was temporarily unavailable:
+
+```text
+partner_service_interruption =
+  disabled_partner_integrations / active_partner_integrations
+```
+
+This signal matters because infrastructure stress can surface first in partner applications. A user may not hold a Wyre account directly, but still lose a purchase or swap route when a partner disables Wyre connectivity.
+
+## Signal 3: Shutdown-Rumor Sensitivity
+
+CoinMarketCap Academy described the cap as occurring amid reports that a shutdown was imminent:
+
+```text
+shutdown_rumor_sensitivity =
+  liquidity_restriction_events_after_shutdown_reports / reported_shutdown_events
+```
+
+Shutdown-rumor sensitivity is a market-confidence signal. Even if the platform later survives, the combination of shutdown reports and withdrawal rationing can trigger partner exits and customer flight.
+
+## Signal 4: Leadership and Risk-Control Change
+
+The Crypto Times reported that Wyre named a former chief risk and compliance officer as interim CEO around the same time:
+
+```text
+leadership_risk_control_change =
+  emergency_leadership_changes / liquidity_stress_events
+```
+
+Emergency leadership changes do not prove insolvency, but they are relevant when paired with withdrawal caps. They show that governance and risk controls are changing while customer access is already constrained.
+
+## Signal 5: Emergency Financing Dependence
+
+CoinMarketCap Academy reported that Wyre lifted the 90% withdrawal limit after securing financing from a strategic partner:
+
+```text
+financing_dependent_limit_removal =
+  withdrawal_limits_removed_after_financing / active_withdrawal_limits
+```
+
+This is an important recovery signal. If the cap is removed only after new financing, market-health systems should treat the original cap as a liquidity-stress event, not a routine policy change.
+
+## Counterfactual Stress Test
+
+A payment-rail provider can be stress-tested by tracing whether users can exit without rationing:
+
+| Scenario                     | Customer or partner access path             | Market-health interpretation                         |
+| ---------------------------- | ------------------------------------------- | ---------------------------------------------------- |
+| Normal payment-rail function | Customers withdraw and partners route flows | Monitor latency, fees, and payment-failure rates     |
+| Partial withdrawal cap       | Customers can withdraw only part of balance | Track residual trapped balance as impaired liquidity |
+| Partner-service interruption | Apps disable buy/swap routes using provider | Track downstream service dependency                  |
+| Shutdown-rumor pressure      | Reports of closure coincide with limits     | Escalate confidence and run-risk monitoring          |
+| Leadership change            | Risk/compliance leadership takes over       | Track governance changes during liquidity stress     |
+| Financing-dependent recovery | Limits lift after partner financing         | Treat recovery as capital-dependent                  |
+
+The test asks whether users can withdraw all balances and whether partners can keep routing through the provider. If either answer is no, the payment rail is impaired.
+
+## Detection Table
+
+| Signal                             | What changed                                     | Why it mattered                                  |
+| ---------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
+| Partial withdrawal cap             | Customers were limited to 90% withdrawals        | A measurable residual balance stayed trapped     |
+| Partner-service interruption       | Ledger's Wyre-powered service became unavailable | Wyre stress propagated into partner applications |
+| Shutdown-rumor sensitivity         | Limits followed reports of possible shutdown     | Confidence and run-risk increased                |
+| Leadership and risk-control change | Interim leadership changed during stress         | Governance shifted while access was constrained  |
+| Emergency financing dependence     | Limit removal followed new partner financing     | Recovery depended on outside capital/support     |
+
+## Practical Alert Rules
+
+1. Treat partial withdrawal caps as liquidity impairment, even if users can withdraw most funds.
+2. Measure the residual trapped-balance percentage created by platform-wide caps.
+3. Track partner apps that disable services tied to the stressed provider.
+4. Escalate when shutdown reports, leadership changes, and withdrawal limits occur together.
+5. Classify limit removal after financing as capital-dependent recovery.
+6. Map payment providers as shared infrastructure across wallets, onramps, and swap flows.
+
+## Lessons for Market Health
+
+Wyre shows that a platform does not need to fully freeze withdrawals to impair market liquidity. A partial cap can still lock customer balances, scare partner platforms, and force users into alternate payment rails.
+
+The broader lesson is that payment infrastructure should be monitored as a shared liquidity layer. When a provider constrains withdrawals or partners disable integrations, the effect can spread beyond the provider's own customer base.
+
+## Sources
+
+- [CoinMarketCap Academy: Wyre Lifts 90% Withdrawal Limit After Landing Financing From Partner](https://coinmarketcap.com/academy/article/wyre-lifts-90-withdrawal-limit-after-landing-financing-from-partner)
+- [The Crypto Times: Crypto Payment Firm Wyre Obtrudes Withdrawal Limit for All Users](https://www.cryptotimes.io/2023/01/09/crypto-payment-firm-wyre-obtrudes-withdrawal-limit-for-all-users/)
+- [Ledger Support: Wyre Buy/Sell Service Temporarily Unavailable](https://support.ledger.com/article/8662167069469-zd)

--- a/content/research/market-health/posts/2023-01-07-wyre-withdrawal-limit/wyre-withdrawal-limit-signals.csv
+++ b/content/research/market-health/posts/2023-01-07-wyre-withdrawal-limit/wyre-withdrawal-limit-signals.csv
@@ -1,0 +1,8 @@
+signal,date,venue_or_protocol,severity,unit,source,note
+partial_withdrawal_cap,2023-01-07,Wyre,high,withdrawal_cap,https://coinmarketcap.com/academy/article/wyre-lifts-90-withdrawal-limit-after-landing-financing-from-partner,Wyre limited customers to withdrawing 90% of account assets.
+policy_change_scope,2023-01-09,Wyre,high,all_users,https://www.cryptotimes.io/2023/01/09/crypto-payment-firm-wyre-obtrudes-withdrawal-limit-for-all-users/,The Crypto Times reported the withdrawal limit applied to all users.
+partner_service_interruption,2023-01-06,Ledger Live Wyre route,medium,partner_route,https://support.ledger.com/article/8662167069469-zd,Ledger said the Wyre-powered buy/swap service was temporarily unavailable.
+shutdown_rumor_sensitivity,2023-01-07,Wyre,high,confidence_signal,https://coinmarketcap.com/academy/article/wyre-lifts-90-withdrawal-limit-after-landing-financing-from-partner,The withdrawal cap arrived amid reports that a shutdown was imminent.
+leadership_risk_control_change,2023-01-09,Wyre,medium,interim_leadership,https://www.cryptotimes.io/2023/01/09/crypto-payment-firm-wyre-obtrudes-withdrawal-limit-for-all-users/,Wyre named a former risk and compliance executive as interim CEO during the stress period.
+financing_dependent_limit_removal,2023-01-12,Wyre,medium,recovery_signal,https://coinmarketcap.com/academy/article/wyre-lifts-90-withdrawal-limit-after-landing-financing-from-partner,Wyre lifted the withdrawal limit after securing financing from a strategic partner.
+residual_trapped_balance,2023-01-07,Wyre,high,percent_of_balance,https://coinmarketcap.com/academy/article/wyre-lifts-90-withdrawal-limit-after-landing-financing-from-partner,A 90% cap implied 10% of each customer account remained non-withdrawable under the policy.


### PR DESCRIPTION
## Summary
- add a Wyre Market Health case for the 90% withdrawal cap, partner-service interruption, shutdown-rumor sensitivity, leadership/risk-control change, and financing-dependent limit removal
- add a companion CSV signal table covering partial withdrawal cap, policy scope, Ledger/Wyre service interruption, shutdown-rumor pressure, interim leadership, financing-dependent recovery, and residual trapped balance

Fixes #277

## Validation
- npx prettier --write content/research/market-health/posts/2023-01-07-wyre-withdrawal-limit/index.md
- npx prettier --check content/research/market-health/posts/2023-01-07-wyre-withdrawal-limit/index.md
- python3 CSV/ASCII/final-newline validation script
- python3 live URL probe for all Markdown and CSV sources
- git diff --check