### PR TITLE
🌰 fix: correct buy/sell ratio reference point (0.5, not 1) in Buy/Sell docs

### DIFF
--- a/content/research/market-health/docs/buy-sell/index.md
+++ b/content/research/market-health/docs/buy-sell/index.md
@@ -76,8 +76,8 @@ The dataset comprised 60 data points with the following statistical insights:
 
 #### Interpretation
 
-- The mean Buy-Sell Ratio being less than 1 indicates a slight tendency towards sell orders over this period.
-- The Absolute Buy-Sell Ratio provides additional context, suggesting that while sell orders might be more frequent, the discrepancy is not extremely significant.
+- The mean Buy-Sell Ratio of 0.488 being below the balanced midpoint of 0.5 indicates a slight tendency towards sell orders over this period. (Note: because `buysellratio` is defined as buy trades divided by *total* trades, it ranges from 0 to 1 with 0.5 as the neutral point — consistent with the "balanced market tends towards 0.4-0.6" range stated above — so 0.5, not 1, is the correct reference for buy/sell balance.)
+- The mean Absolute Buy-Sell Ratio of 0.519 sits just above 0.5, indicating that buy *volume* slightly outweighs sell volume even though sell *trades* are marginally more frequent. This count-versus-volume divergence suggests sells were placed in slightly more numerous but smaller orders, while buys were fewer but larger — a nuance the count-based ratio alone would miss.
 - Variations in the Buy-Sell Ratio could indicate shifts in market sentiment or reaction to external events.
 
 #### Visuals


### PR DESCRIPTION
## 🌰 Summary

Fixes a factual error in the **Buy/Sell Ratio** metric documentation (`content/research/market-health/docs/buy-sell/index.md`), per the "fixing factual errors" objective of #277.

## 🌰 The error

The doc defines `buysellratio` as:

> $\text{buy sell ratio} = \frac{n}{m}$ — where `n` is the count of 'buy' trades and `m` is the **total** count of all trades

So the ratio is bounded **[0, 1]** with **0.5** as the neutral point — which the doc's own opening line confirms ("A balanced market tends towards 0.4-0.6").

But the Interpretation section used **1** as the reference:

> The mean Buy-Sell Ratio being **less than 1** indicates a slight tendency towards sell orders over this period.

This is incorrect: since the ratio is buys/total, it is essentially **always** below 1, so "less than 1 ⇒ sell tendency" is not meaningful. By that logic a value of 0.9 — a strong **buy** skew — would read as a sell tendency. The correct reference is the **0.5 midpoint**: the example mean of 0.488 is just below 0.5, which is what actually indicates the slight sell lean.

## 🌰 The fix

1. Compare the mean (0.488) against the **0.5** balanced midpoint instead of 1, and cite the doc's own definition + "0.4-0.6 balanced" range for consistency.
2. Sharpened the absolute-ratio note: its mean (**0.519**) is *above* 0.5, so buy **volume** slightly outweighs sell volume even though sell **trades** are marginally more frequent by count — i.e. buys were fewer but larger. The original text ("the discrepancy is not extremely significant") missed this count-vs-volume divergence, which is exactly what having both metrics is meant to reveal.

No data values were changed; only the interpretation text was corrected.