### PR TITLE
🌰 fix: resolve contradictory 'uniform distribution' interpretation in Volume Distribution docs

### DIFF
--- a/content/research/market-health/docs/volumedist/index.md
+++ b/content/research/market-health/docs/volumedist/index.md
@@ -98,8 +98,8 @@ Here is the histogram representing the trading volumes based on the provided sam
 
 #### Interpretation
 
-- Ideally, trading volume should follow a [power law](https://en.wikipedia.org/wiki/Power_law) heavy tail distribution, where small trades are common, and large trades are rare.
-- A more uniform distribution might suggest a healthy mix of small and large volume trades.
+- Ideally, trading volume should follow a [power law](https://en.wikipedia.org/wiki/Power_law) heavy-tail distribution, where small trades are common and large trades are rare.
+- A marked departure from this shape — for example, volume spread unusually **uniformly** across bins, or clustered at a few repeated discrete sizes — is a potential red flag rather than a sign of health. This is consistent with the wash-trading signature noted below ("unnatural uniformity in trade sizes across many bins"), since automated wash trading tends to generate repetitive, similarly-sized orders that flatten the natural heavy-tail shape.
 
 ### Applications in Market Surveillance
 


### PR DESCRIPTION
## 🌰 Summary

Fixes a self-contradiction in the **Volume Distribution** metric documentation (`content/research/market-health/docs/volumedist/index.md`), per the "fixing factual errors" objective of #277.

## 🌰 The contradiction

The Interpretation section says uniformity is **healthy**:

> - Ideally, trading volume should follow a power law heavy tail distribution, where small trades are common, and large trades are rare.
> - **A more uniform distribution might suggest a healthy mix of small and large volume trades.**

But this contradicts:

1. **The line directly above it** — a power-law heavy tail (small common, large rare) is the *opposite* of a uniform distribution, so "uniform = healthy" cannot follow from "heavy tail = ideal".
2. **The Applications section of the same doc**, which lists uniformity as a **manipulation signal**:
   > **Detecting Wash Trading**: Unnatural uniformity in trade sizes across many bins could indicate potential wash trading.

Uniformity cannot be simultaneously a sign of health and a sign of wash trading.

## 🌰 The fix

Corrected the second bullet so that a departure from the heavy-tail shape toward uniformity (or clustering at a few repeated discrete sizes) is treated as a **potential red flag**, consistent with the wash-trading detection criterion stated later in the same document. This also aligns with the established literature on wash trading, where automated, similarly-sized orders flatten the natural heavy-tail volume distribution.

No data or figures were changed; only the interpretive text was corrected for internal consistency.