### PR TITLE
test: expand Similarity Search dependency coverage

### DIFF
--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -46,7 +46,11 @@ app.post("/", async (c) => {
     })
 
     vector = modelResp.data?.[0]
-    if (!vector) {
+    if (
+      !Array.isArray(vector) ||
+      vector.length === 0 ||
+      vector.some((value) => typeof value !== "number" || !Number.isFinite(value))
+    ) {
       throw new Error("Workers AI returned invalid response shape")
     }
   } catch (error) {
@@ -60,6 +64,10 @@ app.post("/", async (c) => {
       namespace,
       topK: 1
     })
+
+    if (!Array.isArray(searchResponse?.matches)) {
+      throw new Error("Vectorize returned invalid response shape")
+    }
   } catch (error) {
     console.error("Vectorize query failed", error)
     return c.text("Vectorize query failed", 502)

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -40,15 +40,20 @@ app.post("/", async (c) => {
   }
 
   let modelResp
+  let vector
   try {
     modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
       text: [text]
     })
+
+    vector = modelResp.data?.[0]
+    if (!vector) {
+      throw new Error("Workers AI returned invalid response shape")
+    }
   } catch {
     return c.text("Workers AI request failed", 502)
   }
 
-  const vector = modelResp.data[0]
   let searchResponse
   try {
     searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -39,14 +39,25 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
-    text: [text]
-  })
+  let modelResp
+  try {
+    modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+      text: [text]
+    })
+  } catch {
+    return c.text("Workers AI request failed", 502)
+  }
+
   const vector = modelResp.data[0]
-  const searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
-    namespace,
-    topK: 1
-  })
+  let searchResponse
+  try {
+    searchResponse = await c.env.VECTORIZE_INDEX.query(vector, {
+      namespace,
+      topK: 1
+    })
+  } catch {
+    return c.text("Vectorize query failed", 502)
+  }
   const similarityScore = searchResponse.matches[0]?.score || 0
 
   return c.json({ similarity_score: similarityScore })

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -39,10 +39,9 @@ app.post("/", async (c) => {
     return c.text("Invalid JSON format", 400)
   }
 
-  let modelResp
   let vector
   try {
-    modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
+    const modelResp = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
       text: [text]
     })
 
@@ -50,7 +49,8 @@ app.post("/", async (c) => {
     if (!vector) {
       throw new Error("Workers AI returned invalid response shape")
     }
-  } catch {
+  } catch (error) {
+    console.error("Workers AI request failed", error)
     return c.text("Workers AI request failed", 502)
   }
 
@@ -60,7 +60,8 @@ app.post("/", async (c) => {
       namespace,
       topK: 1
     })
-  } catch {
+  } catch (error) {
+    console.error("Vectorize query failed", error)
     return c.text("Vectorize query failed", 502)
   }
   const similarityScore = searchResponse.matches[0]?.score || 0

--- a/tools/similarity_search/src/index.ts
+++ b/tools/similarity_search/src/index.ts
@@ -31,7 +31,11 @@ app.post("/", async (c) => {
   const data = await c.req.json<TextEntry>()
   const { text, namespace } = data
 
-  if (typeof text !== "string" || typeof namespace !== "string") {
+  if (
+    typeof text !== "string" ||
+    text.trim() === "" ||
+    typeof namespace !== "string"
+  ) {
     return c.text("Invalid JSON format", 400)
   }
 

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -67,6 +67,16 @@ describe("Request validation", () => {
     expect(await response.text()).toBe("Invalid JSON format")
   })
 
+  it("returns 400 when text is only whitespace", async () => {
+    const response = await postSimilaritySearch({
+      text: "  \t  ",
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
   it("returns 400 when namespace is not a string", async () => {
     const response = await postSimilaritySearch({
       text: "duplicate message",
@@ -138,6 +148,16 @@ describe("Similarity search", () => {
   it("returns 502 when Workers AI embedding fails", async () => {
     const response = await postSimilaritySearch({
       text: "trigger-workers-ai-failure",
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Workers AI request failed")
+  })
+
+  it("returns 502 when Workers AI returns an invalid response shape", async () => {
+    const response = await postSimilaritySearch({
+      text: "trigger-workers-ai-empty-response",
       namespace: "security-incidents"
     })
 

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -66,6 +66,26 @@ describe("Request validation", () => {
     expect(response.status).toBe(400)
     expect(await response.text()).toBe("Invalid JSON format")
   })
+
+  it("returns 400 when text is null", async () => {
+    const response = await postSimilaritySearch({
+      text: null,
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is null", async () => {
+    const response = await postSimilaritySearch({
+      text: "duplicate message",
+      namespace: null
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
 })
 
 describe("Similarity search", () => {

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -57,6 +57,16 @@ describe("Request validation", () => {
     expect(await response.text()).toBe("Invalid JSON format")
   })
 
+  it("returns 400 when text is empty", async () => {
+    const response = await postSimilaritySearch({
+      text: "",
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
   it("returns 400 when namespace is not a string", async () => {
     const response = await postSimilaritySearch({
       text: "duplicate message",

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -134,4 +134,24 @@ describe("Similarity search", () => {
       similarity_score: 0.4321
     })
   })
+
+  it("returns 502 when Workers AI embedding fails", async () => {
+    const response = await postSimilaritySearch({
+      text: "trigger-workers-ai-failure",
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Workers AI request failed")
+  })
+
+  it("returns 502 when Vectorize query fails", async () => {
+    const response = await postSimilaritySearch({
+      text: "Vectorize boundary failure should be handled",
+      namespace: "vectorize-failure"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Vectorize query failed")
+  })
 })

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -165,10 +165,30 @@ describe("Similarity search", () => {
     expect(await response.text()).toBe("Workers AI request failed")
   })
 
+  it("returns 502 when Workers AI returns a non-numeric vector", async () => {
+    const response = await postSimilaritySearch({
+      text: "trigger-workers-ai-invalid-vector",
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Workers AI request failed")
+  })
+
   it("returns 502 when Vectorize query fails", async () => {
     const response = await postSimilaritySearch({
       text: "Vectorize boundary failure should be handled",
       namespace: "vectorize-failure"
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).toBe("Vectorize query failed")
+  })
+
+  it("returns 502 when Vectorize returns an invalid response shape", async () => {
+    const response = await postSimilaritySearch({
+      text: "Malformed Vectorize response should be handled",
+      namespace: "vectorize-invalid-response"
     })
 
     expect(response.status).toBe(502)

--- a/tools/similarity_search/test/index.spec.ts
+++ b/tools/similarity_search/test/index.spec.ts
@@ -3,8 +3,21 @@ import { describe, it, expect } from "vitest"
 
 import "../src/index"
 
+const apiKey = "test-api-key"
+
+const postSimilaritySearch = (body: unknown, apiKeyHeader = apiKey) => {
+  return SELF.fetch("https://example.com/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": apiKeyHeader
+    },
+    body: JSON.stringify(body)
+  })
+}
+
 describe("Authentication", () => {
-  it("returns 401 Unauthorized when API key is missing or invalid", async () => {
+  it("returns 401 Unauthorized when API key is missing", async () => {
     const response = await SELF.fetch("https://example.com/", {
       method: "POST",
       headers: {
@@ -18,5 +31,77 @@ describe("Authentication", () => {
 
     expect(response.status).toBe(401)
     expect(await response.text()).toBe("Unauthorized")
+  })
+
+  it("returns 401 Unauthorized when API key is invalid", async () => {
+    const response = await postSimilaritySearch(
+      {
+        text: "Sample text",
+        namespace: "test-namespace"
+      },
+      "wrong-api-key"
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe("Unauthorized")
+  })
+})
+
+describe("Request validation", () => {
+  it("returns 400 when text is missing", async () => {
+    const response = await postSimilaritySearch({
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+
+  it("returns 400 when namespace is not a string", async () => {
+    const response = await postSimilaritySearch({
+      text: "duplicate message",
+      namespace: 42
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Invalid JSON format")
+  })
+})
+
+describe("Similarity search", () => {
+  it("embeds the request text and returns the top Vectorize match score", async () => {
+    const response = await postSimilaritySearch({
+      text: "Suspicious wallet cluster activity",
+      namespace: "security-incidents"
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      similarity_score: 0.8765
+    })
+  })
+
+  it("returns zero when Vectorize has no matches for the namespace", async () => {
+    const response = await postSimilaritySearch({
+      text: "No matching record should exist",
+      namespace: "empty-namespace"
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      similarity_score: 0
+    })
+  })
+
+  it("handles unicode input through the full worker request path", async () => {
+    const response = await postSimilaritySearch({
+      text: "Similar alert: stablecoin depeg risk increased in 東京 markets",
+      namespace: "unicode-smoke-test"
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      similarity_score: 0.4321
+    })
   })
 })

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -26,7 +26,15 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   run: async (model, data) => {
-                    return Promise.resolve({ data: {} });
+                    if (model !== "@cf/baai/bge-base-en-v1.5") {
+                      throw new Error("unexpected model");
+                    }
+
+                    if (!Array.isArray(data.text) || typeof data.text[0] !== "string") {
+                      throw new Error("unexpected AI input");
+                    }
+
+                    return Promise.resolve({ data: [[0.11, 0.22, 0.33]] });
                   }
                 };
               };`
@@ -37,7 +45,19 @@ export default defineWorkersConfig({
               script: `export default function() {
                 return {
                   query: async (vectorData, options) => {
-                    const score = 0.5678;
+                    if (!Array.isArray(vectorData) || vectorData.length !== 3) {
+                      throw new Error("unexpected vector data");
+                    }
+
+                    if (options.topK !== 1) {
+                      throw new Error("unexpected topK");
+                    }
+
+                    if (options.namespace === "empty-namespace") {
+                      return Promise.resolve({ matches: [] });
+                    }
+
+                    const score = options.namespace === "security-incidents" ? 0.8765 : 0.4321;
                     return Promise.resolve({ matches: [{ score }] });
                   }
                 };

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -34,6 +34,10 @@ export default defineWorkersConfig({
                       throw new Error("unexpected AI input");
                     }
 
+                    if (data.text[0] === "trigger-workers-ai-failure") {
+                      throw new Error("simulated Workers AI failure");
+                    }
+
                     return Promise.resolve({ data: [[0.11, 0.22, 0.33]] });
                   }
                 };
@@ -55,6 +59,10 @@ export default defineWorkersConfig({
 
                     if (options.namespace === "empty-namespace") {
                       return Promise.resolve({ matches: [] });
+                    }
+
+                    if (options.namespace === "vectorize-failure") {
+                      throw new Error("simulated Vectorize failure");
                     }
 
                     const score = options.namespace === "security-incidents" ? 0.8765 : 0.4321;

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -42,6 +42,10 @@ export default defineWorkersConfig({
                       return Promise.resolve({ data: [] });
                     }
 
+                    if (data.text[0] === "trigger-workers-ai-invalid-vector") {
+                      return Promise.resolve({ data: [["not-a-number"]] });
+                    }
+
                     return Promise.resolve({ data: [[0.11, 0.22, 0.33]] });
                   }
                 };
@@ -67,6 +71,10 @@ export default defineWorkersConfig({
 
                     if (options.namespace === "vectorize-failure") {
                       throw new Error("simulated Vectorize failure");
+                    }
+
+                    if (options.namespace === "vectorize-invalid-response") {
+                      return Promise.resolve({});
                     }
 
                     const score = options.namespace === "security-incidents" ? 0.8765 : 0.4321;

--- a/tools/similarity_search/vitest.config.ts
+++ b/tools/similarity_search/vitest.config.ts
@@ -38,6 +38,10 @@ export default defineWorkersConfig({
                       throw new Error("simulated Workers AI failure");
                     }
 
+                    if (data.text[0] === "trigger-workers-ai-empty-response") {
+                      return Promise.resolve({ data: [] });
+                    }
+
                     return Promise.resolve({ data: [[0.11, 0.22, 0.33]] });
                   }
                 };


### PR DESCRIPTION
Follow-up to #927 after the closure feedback:

> Closing: solid auth/validation/happy-path coverage, but with no Vectorize/Workers-AI dependency-failure tests it does not assure behavior at the integration boundaries.

## Summary
- keeps the expanded Similarity Search request-path coverage from #927
- adds controlled 502 handling for Workers AI embedding failures
- adds controlled 502 handling for Vectorize query failures
- adds worker-test mock failure triggers plus assertions for both dependency-boundary failure paths
- preserves stricter invalid/empty text validation coverage

## Verification
- `npm test -- --run` was attempted locally, but the Cloudflare/Vitest worker runner hung without test output and had to be stopped
- `npm test -- --run --reporter=verbose` was retried under a timeout and also produced no test output before timeout
- `npm exec tsc -- --noEmit` could not run because this package does not install `typescript` directly

Review request: @evgenydmitriev @Lavriz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes / Improvements
- Tightened Similarity Search request validation:
  - `text` must be a string that is non-empty after `trim()` (including explicit whitespace-only coverage)
  - `namespace` must be a string
  - invalid inputs now return **400** with **“Invalid JSON format”**
- Hardened downstream dependency handling with step-specific **502** responses and logging:
  - Workers AI responses are now validated inside the failure boundary to ensure the returned embedding shape is usable (`data[0]` exists and is a non-empty finite numeric vector); otherwise returns **502** with **“Workers AI request failed”**
  - Vectorize query is wrapped in its own `try/catch`; successful responses must include a `matches` array (while preserving the existing empty-matches behavior that yields `similarity_score: 0`); otherwise returns **502** with **“Vectorize query failed”**
- Adjusted implementation details to improve safety and correctness:
  - `modelResp` is scoped to the Workers AI `try` block; `vector` is hoisted for the Vectorize step
  - Strengthened checks for malformed/empty success shapes from both dependencies

## Tests
- Added/expanded test coverage using a shared `postSimilaritySearch` helper:
  - Authentication and malformed payload variants (including `text` null/missing/whitespace-only and `namespace` null/non-string)
  - Workers AI failure propagation:
    - embedding failures
    - empty/malformed successful response shapes
    - non-numeric vector regression
  - Vectorize failure propagation:
    - query errors
    - malformed successful response regression (missing/invalid `matches`)
  - Assertions verify the correct **400/401/502** bodies and preserved success behavior (including zero scoring when there are no matches)
- Updated `vitest` worker-pool simulations to deterministically trigger the new edge cases:
  - Workers AI: empty response trigger and invalid vector triggers
  - Vectorize: failure, empty matches, and invalid response shape triggers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->