### PR TITLE
[codex] Add DMM Bitcoin attack article

### DIFF
--- a/content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md
+++ b/content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md
@@ -1,10 +1,6 @@
 ---
 date: 2024-05-31
 target-entities: DMM Bitcoin
-tags:
-  - Lazarus Group
-  - North Korea
-  - TraderTraitor
 entity-types:
   - Exchange
   - Custodian
@@ -46,13 +42,14 @@ The loss was a single-asset Bitcoin theft. Public reports did not identify other
 
 ## Timeline
 
-- **Late March 2024:** A North Korean actor masquerading as a recruiter on LinkedIn contacted a Ginco employee who had access to Ginco's wallet management system, according to the FBI.
-- **After mid-May 2024:** TraderTraitor actors exploited session cookie information to impersonate the compromised Ginco employee and access Ginco's unencrypted communications system, according to the FBI.
-- **May 31, 2024:** DMM Bitcoin detected an unauthorized Bitcoin outflow from its wallet involving 4,502.9 BTC. Elliptic reported that the bitcoin had already been split and sent to multiple new wallets.
-- **May 31, 2024:** DMM Bitcoin restricted spot buys and warned that Japanese yen withdrawals could take longer than usual, while saying it would procure equivalent BTC to cover the outflow, according to CoinDesk.
-- **December 2, 2024:** SBI VC Trade announced that it had reached a basic agreement to accept DMM Bitcoin customer accounts and deposited assets.
-- **December 23, 2024:** The FBI, DC3, and Japan's National Police Agency publicly attributed the theft to North Korean TraderTraitor actors.
-- **March 8, 2025:** DMM Bitcoin ended service and transferred customer accounts and custody assets to SBI VC Trade.
+- **March 31, 2024, 11:59 PM UTC:** A North Korean actor masquerading as a recruiter on LinkedIn had contacted a Ginco employee who had access to Ginco's wallet management system; the FBI report gives the timing as late March 2024, not an exact timestamp.
+- **May 16, 2024, 12:00 AM UTC:** TraderTraitor actors began the source-reported post-mid-May phase of exploiting session cookie information to impersonate the compromised Ginco employee and access Ginco's unencrypted communications system; the FBI report does not publish a more exact timestamp.
+- **May 31, 2024, 04:26 AM UTC:** DMM Bitcoin detected an unauthorized Bitcoin outflow from its wallet involving 4,502.9 BTC, corresponding to the company's reported 1:26 PM JST detection time.
+- **May 31, 2024, 01:40 PM UTC:** CoinDesk reported DMM Bitcoin's service restrictions, including restricted spot buys and longer Japanese yen withdrawal times, and DMM Bitcoin's statement that it would procure equivalent BTC to cover the outflow.
+- **May 31, 2024, 03:00 PM UTC:** Elliptic reported that the stolen bitcoin had already been split and sent to multiple new wallets as of 15:00 UTC.
+- **December 2, 2024, 12:00 AM UTC:** SBI VC Trade announced that it had reached a basic agreement to accept DMM Bitcoin customer accounts and deposited assets; the announcement source provides a date but not a UTC timestamp.
+- **December 23, 2024, 12:00 AM UTC:** The FBI, DC3, and Japan's National Police Agency publicly attributed the theft to North Korean TraderTraitor actors; the public attribution source provides a date but not an intraday UTC timestamp.
+- **March 8, 2025, 12:00 AM UTC:** DMM Bitcoin ended service and transferred customer accounts and custody assets to SBI VC Trade; the DMM service notice provides a date but not an intraday UTC timestamp.
 
 ## Security Failure Causes
 

--- a/content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md
+++ b/content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md
@@ -19,15 +19,15 @@ loss: 308000000
 
 On May 31, 2024, Japanese cryptocurrency exchange DMM Bitcoin detected an unauthorized Bitcoin outflow from its wallet. The incident moved [4,502.9 BTC, valued at about $308 million](https://www.elliptic.co/blog/dmm-bitcoin-loses-308-million-in-unauthorized-leak), to attacker-controlled wallets. DMM Bitcoin restricted some services after the incident and said it would procure the equivalent amount of BTC to guarantee customer balances, according to [CoinDesk's report on the exchange announcement](https://www.coindesk.com/business/2024/05/31/japanese-crypto-exchange-dmm-bitcoin-suffers-305m-hack).
 
-In December 2024, the FBI, Department of Defense Cyber Crime Center, and Japan's National Police Agency [attributed the theft to North Korean TraderTraitor activity](https://www.coindesk.com/policy/2024/12/24/north-korea-blamed-for-may-s-usd305m-hack-on-japanese-crypto-exchange-dmm). The agencies described a social-engineering chain that first compromised an employee of Ginco, a Japan-based enterprise cryptocurrency wallet software company, and then used that access to manipulate a legitimate DMM Bitcoin transaction request.
+In December 2024, the FBI, Department of Defense Cyber Crime Center, and Japan's National Police Agency [attributed the theft to North Korean TraderTraitor activity](https://www.npa.go.jp/bureau/cyber/pdf/20241224_jp.pdf). The agencies described a social-engineering chain that first compromised an employee of Ginco, a Japan-based enterprise cryptocurrency wallet software company, and then used that access to manipulate a legitimate DMM Bitcoin transaction request. CoinDesk also [reported the joint attribution](https://www.coindesk.com/policy/2024/12/24/north-korea-blamed-for-may-s-usd305m-hack-on-japanese-crypto-exchange-dmm).
 
 The breach had long operational consequences. DMM Bitcoin later arranged to transfer customer accounts and deposited assets to SBI VC Trade. SBI VC Trade [announced a basic agreement](https://www.sbivc.co.jp/newsview/1zkj8mf5x3y) to accept DMM Bitcoin customer accounts and custody assets in December 2024, and DMM Bitcoin's service [ended on March 8, 2025](https://bitcoin.dmm.com/news/20240531_01), with customer accounts and assets transferred to SBI VC Trade.
 
 ## Attackers
 
-The attackers were identified by U.S. and Japanese authorities as North Korean cyber actors tracked as TraderTraitor, also known as Jade Sleet, UNC4899, and Slow Pisces. The FBI stated that TraderTraitor activity often uses targeted social engineering against multiple employees at the same company.
+The attackers were identified by U.S. and Japanese authorities as North Korean cyber actors tracked as TraderTraitor, also known as Jade Sleet, UNC4899, and Slow Pisces. The joint FBI/DC3/NPA attribution notice stated that TraderTraitor activity often uses targeted social engineering against multiple employees at the same company.
 
-The attack path described by the FBI involved:
+The attack path described by the joint attribution notice involved:
 
 - a North Korean actor posing as a recruiter on LinkedIn;
 - a Ginco employee receiving a malicious Python script under the cover of a pre-employment test;
@@ -56,7 +56,7 @@ The loss was a single-asset Bitcoin theft. Public reports did not identify other
 
 ## Security Failure Causes
 
-**Third-party wallet operations compromise:** The FBI's attribution did not describe a direct breach of DMM Bitcoin's internal systems. Instead, it described compromise of a Ginco employee with wallet-management access and later use of that access to manipulate a legitimate DMM transaction request. This made the wallet operations workflow, including third-party communications and authorization checks, part of the effective attack surface.
+**Third-party wallet operations compromise:** The joint attribution did not describe a direct breach of DMM Bitcoin's internal systems. Instead, it described compromise of a Ginco employee with wallet-management access and later use of that access to manipulate a legitimate DMM transaction request. This made the wallet operations workflow, including third-party communications and authorization checks, part of the effective attack surface.
 
 **Social engineering and malicious code execution:** The initial compromise came from a targeted LinkedIn recruiter lure and a malicious Python script presented as a pre-employment test. That path converted a human hiring interaction into access to systems relevant to cryptocurrency wallet operations.
 

--- a/content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md
+++ b/content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md
@@ -1,0 +1,65 @@
+---
+date: 2024-05-31
+target-entities: DMM Bitcoin
+tags:
+  - Lazarus Group
+  - North Korea
+  - TraderTraitor
+entity-types:
+  - Exchange
+  - Custodian
+attack-types:
+  - Wallet Hack
+  - Social Engineering
+title: "DMM Bitcoin Loses $308 Million in TraderTraitor Wallet Attack"
+loss: 308000000
+---
+
+## Summary
+
+On May 31, 2024, Japanese cryptocurrency exchange DMM Bitcoin detected an unauthorized Bitcoin outflow from its wallet. The incident moved [4,502.9 BTC, valued at about $308 million](https://www.elliptic.co/blog/dmm-bitcoin-loses-308-million-in-unauthorized-leak), to attacker-controlled wallets. DMM Bitcoin restricted some services after the incident and said it would procure the equivalent amount of BTC to guarantee customer balances, according to [CoinDesk's report on the exchange announcement](https://www.coindesk.com/business/2024/05/31/japanese-crypto-exchange-dmm-bitcoin-suffers-305m-hack).
+
+In December 2024, the FBI, Department of Defense Cyber Crime Center, and Japan's National Police Agency [attributed the theft to North Korean TraderTraitor activity](https://www.coindesk.com/policy/2024/12/24/north-korea-blamed-for-may-s-usd305m-hack-on-japanese-crypto-exchange-dmm). The agencies described a social-engineering chain that first compromised an employee of Ginco, a Japan-based enterprise cryptocurrency wallet software company, and then used that access to manipulate a legitimate DMM Bitcoin transaction request.
+
+The breach had long operational consequences. DMM Bitcoin later arranged to transfer customer accounts and deposited assets to SBI VC Trade. SBI VC Trade [announced a basic agreement](https://www.sbivc.co.jp/newsview/1zkj8mf5x3y) to accept DMM Bitcoin customer accounts and custody assets in December 2024, and DMM Bitcoin's service [ended on March 8, 2025](https://bitcoin.dmm.com/news/20240531_01), with customer accounts and assets transferred to SBI VC Trade.
+
+## Attackers
+
+The attackers were identified by U.S. and Japanese authorities as North Korean cyber actors tracked as TraderTraitor, also known as Jade Sleet, UNC4899, and Slow Pisces. The FBI stated that TraderTraitor activity often uses targeted social engineering against multiple employees at the same company.
+
+The attack path described by the FBI involved:
+
+- a North Korean actor posing as a recruiter on LinkedIn;
+- a Ginco employee receiving a malicious Python script under the cover of a pre-employment test;
+- compromise of the employee, who had access to Ginco's wallet management system;
+- exploitation of session cookie information after mid-May 2024;
+- access to Ginco's unencrypted communications system;
+- likely manipulation of a legitimate DMM Bitcoin transaction request in late May 2024.
+
+Elliptic reported that the stolen bitcoin was split and sent to multiple new wallets shortly after the outflow.
+
+## Losses
+
+DMM Bitcoin lost 4,502.9 BTC, valued at about $308 million at the time of the attack.
+
+The loss was a single-asset Bitcoin theft. Public reports did not identify other cryptocurrency assets as part of the unauthorized outflow.
+
+## Timeline
+
+- **Late March 2024:** A North Korean actor masquerading as a recruiter on LinkedIn contacted a Ginco employee who had access to Ginco's wallet management system, according to the FBI.
+- **After mid-May 2024:** TraderTraitor actors exploited session cookie information to impersonate the compromised Ginco employee and access Ginco's unencrypted communications system, according to the FBI.
+- **May 31, 2024:** DMM Bitcoin detected an unauthorized Bitcoin outflow from its wallet involving 4,502.9 BTC. Elliptic reported that the bitcoin had already been split and sent to multiple new wallets.
+- **May 31, 2024:** DMM Bitcoin restricted spot buys and warned that Japanese yen withdrawals could take longer than usual, while saying it would procure equivalent BTC to cover the outflow, according to CoinDesk.
+- **December 2, 2024:** SBI VC Trade announced that it had reached a basic agreement to accept DMM Bitcoin customer accounts and deposited assets.
+- **December 23, 2024:** The FBI, DC3, and Japan's National Police Agency publicly attributed the theft to North Korean TraderTraitor actors.
+- **March 8, 2025:** DMM Bitcoin ended service and transferred customer accounts and custody assets to SBI VC Trade.
+
+## Security Failure Causes
+
+**Third-party wallet operations compromise:** The FBI's attribution did not describe a direct breach of DMM Bitcoin's internal systems. Instead, it described compromise of a Ginco employee with wallet-management access and later use of that access to manipulate a legitimate DMM transaction request. This made the wallet operations workflow, including third-party communications and authorization checks, part of the effective attack surface.
+
+**Social engineering and malicious code execution:** The initial compromise came from a targeted LinkedIn recruiter lure and a malicious Python script presented as a pre-employment test. That path converted a human hiring interaction into access to systems relevant to cryptocurrency wallet operations.
+
+**Session cookie and communication-system abuse:** After the Ginco compromise, TraderTraitor actors used session cookie information to impersonate the employee and access unencrypted communications. The incident shows how session security and communication confidentiality can directly affect custody transaction integrity.
+
+**Insufficient transaction-request verification:** The reported manipulation of a legitimate transaction request suggests that the transaction approval process did not independently detect that the destination or request context had been altered before 4,502.9 BTC moved out of DMM Bitcoin's wallet.


### PR DESCRIPTION
## Summary
- Adds a Crypto Attacks Wiki incident article for the May 31, 2024 DMM Bitcoin theft.
- Covers the 4,502.9 BTC / ~$308M loss, TraderTraitor attribution, Ginco social-engineering path, DMM operational restrictions, and the SBI VC Trade asset-transfer outcome.
- Keeps the security-failure section scoped to sourced facts and avoids treating unconfirmed private-key theories as settled.

Refs #237.

## Validation
- `npx prettier --check content/research/cyberattacks/incidents/2024-05-31-DMM-Bitcoin.md`
- `git diff --check`
- ASCII/final-newline check
- URL accessibility check for all Markdown links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## DMM Bitcoin Attack Article

### Changes
Added a new incident report documenting the May 31, 2024 TraderTraitor theft against DMM Bitcoin, including YAML front-matter and structured sections for attribution, attack narrative, impacts, timeline, and sourced security-failure themes. A follow-up update strengthened primary sourcing by replacing the secondary TraderTraitor attribution link with an NPA-hosted joint FBI/DC3/NPA attribution notice (while keeping CoinDesk as secondary coverage) and aligned the attacker/security-failure wording to that primary notice.

### Content Summary
The article documents:
- **Incident / Losses**: Unauthorized Bitcoin outflow of **4,502.9 BTC** (about **$308M**) detected on May 31, 2024, framed as a **single-asset Bitcoin theft**.
- **Attribution**: Public attribution (December 2024) to **TraderTraitor** activity by the **FBI**, **Department of Defense Cyber Crime Center (DC3)**, and **Japan’s National Police Agency (NPA)**, using the **joint FBI/DC3/NPA notice** as the primary source, with **CoinDesk** as secondary coverage.
- **Attack Path**: Social-engineering chain against **Ginco** starting with a **LinkedIn recruiter lure** and a **malicious Python pre-employment test**, leading to compromise of a **Ginco employee** with wallet-management access, followed by **session-cookie and unencrypted communications exploitation**, and ultimately **manipulation of a legitimate DMM Bitcoin transaction request**; stolen bitcoin was reported as split across multiple new wallets.
- **Operational Impact**: **Service restrictions** after the breach, subsequent transfer of customer accounts/custody to **SBI VC Trade**, and **DMM Bitcoin service ending March 8, 2025**.
- **Timeline**: Key events from late-March 2024 through March 2025 with explicit UTC timestamps and source-precision notes.
- **Security Failures (sourced-only framing)**: Four themes—**third-party wallet operations exposure**, **social engineering and malicious code execution**, **session-cookie/communications abuse**, and **insufficient transaction-request verification**—kept deliberately grounded in the cited attribution materials (avoiding unconfirmed private-key theories).

### Validation
- Prettier formatting check
- Git diff validation (e.g., trailing whitespace)
- ASCII/final-newline verification
- URL accessibility verification for all Markdown links (including HTTP 200 checks for the NPA-hosted joint attribution notice/PDF)
- GitGuardian security scanning
<!-- end of auto-generated comment: release notes by coderabbit.ai -->