### PR TITLE
docs: review-pass fixes for cyberattack wiki (sourcing + structure)

### DIFF
--- a/content/research/cyberattacks/wiki/frontend-hijacking.md
+++ b/content/research/cyberattacks/wiki/frontend-hijacking.md
@@ -17,13 +17,13 @@ Most dApps still depend on centralized web infrastructure at the point where use
 
 ### 1. Badger DAO ($120M) - Cloudflare API Key Exploit
 
-- **Vector:** Public incident reporting describes the Badger DAO compromise as a frontend-injection attack in which an attacker abused access to Badger's Cloudflare-connected web infrastructure to inject malicious JavaScript into the production interface ([rekt.news](https://rekt.news/badger-rekt/), [Chainalysis](https://www.chainalysis.com/blog/chainalysis-podcast-episode-6-badgerdao-hack/)).
+- **Vector:** Public incident reporting describes the Badger DAO compromise as a frontend-injection attack in which an attacker used a compromised Cloudflare API key to inject malicious JavaScript through Cloudflare Workers into the production interface, applying and removing the script intermittently through November 2021 to evade detection before funds were drained on [December 2, 2021](https://www.chainalysis.com/blog/chainalysis-podcast-episode-6-badgerdao-hack/) ([rekt.news](https://rekt.news/badger-rekt/), [Chainalysis](https://www.chainalysis.com/blog/chainalysis-podcast-episode-6-badgerdao-hack/)).
 - **Impact:** The injected code targeted approvals by replacing the intended spender flow with attacker-controlled approvals, and reported losses were about [$120 million](https://rekt.news/badger-rekt/).
 - **Lesson:** Web2 admin credentials can become DeFi key material if they control production frontend assets.
 
-### 2. Curve Finance ($570k) - Registrar Hijacking
+### 2. Curve Finance ($570k) - DNS / Registrar Hijacking
 
-- **Vector:** In August 2022, Curve's `curve.fi` domain was hijacked at the registrar level, redirecting users to a malicious site; this was a registrar hijack, not DNS cache poisoning, as reflected in contemporary reporting from [BleepingComputer](https://www.bleepingcomputer.com/news/security/curve-finance-loses-570-000-in-dns-hijacking-attack/) and [CoinDesk](https://www.coindesk.com/business/2022/08/10/curve-finance-front-end-compromised/).
+- **Vector:** In August 2022, attackers compromised Curve's account at its registrar and DNS host ([iwantmyname](https://cointelegraph.com/news/curve-finance-warns-dns-hijacked-again)) and rewrote the `curve.fi` DNS records to redirect users to a malicious clone; this was a DNS hijack at the nameserver/registrar level, not a smart-contract exploit or DNS cache poisoning, as reflected in contemporary reporting from [BleepingComputer](https://www.bleepingcomputer.com/news/security/curve-finance-loses-570-000-in-dns-hijacking-attack/) and [CoinDesk](https://www.coindesk.com/business/2022/08/10/curve-finance-front-end-compromised/).
 - **Impact:** The fake site presented malicious approval flows, and users who signed them exposed funds to the attacker; reported realized losses were around [$570,000](https://www.bleepingcomputer.com/news/security/curve-finance-loses-570-000-in-dns-hijacking-attack/).
 - **Lesson:** If the registrar account is compromised, the security of the smart contracts no longer matters to end users interacting through the browser.
 

--- a/content/research/cyberattacks/wiki/governance-attacks.md
+++ b/content/research/cyberattacks/wiki/governance-attacks.md
@@ -13,12 +13,12 @@ In a standard DAO, governance power is proportional to token ownership or delega
 2. **Low participation** allows hostile proposals to pass when honest voters are absent or disengaged.
 3. **Thin governance-token liquidity** lets an attacker buy effective control cheaply and then extract more value than the acquisition cost.
 
-## Famous Case Studies
+## Case Studies
 
 ### 1. Beanstalk Farms (April 2022)
 - **Loss:** Approximately [$182 million](https://dn.institute/attacks/posts/2022-04-17-Beanstalk/).
 - **Mechanism:** Flash-loan governance attack.
-- **Details:** The attacker used a flash loan of nearly [$1 billion](https://dn.institute/attacks/posts/2022-04-17-Beanstalk/) in assets to gain a 67% governance supermajority, then executed proposal BIP-18 to transfer protocol funds.
+- **Details:** The attacker used a flash loan of nearly [$1 billion](https://dn.institute/attacks/posts/2022-04-17-Beanstalk/) in assets to gain a 67% governance supermajority, then used the `emergencyCommit` path to execute the malicious proposal BIP-18 and drain protocol funds; a paired proposal, BIP-19, posed as a Ukraine donation to disguise intent. The attacker netted [about $80 million](https://medium.com/immunefi/hack-analysis-beanstalk-governance-attack-april-2022-f42788fc821e) of the roughly $182 million removed.
 - **Speed:** The exploit completed in a single transaction because Beanstalk's emergency execution path allowed immediate enactment after the malicious vote.
 
 ### 2. Build Finance (February 2022)
@@ -33,7 +33,7 @@ In a standard DAO, governance power is proportional to token ownership or delega
 - **Details:** In the TSD takeover, the attacker accumulated enough governance influence to pass a self-serving proposal, minted [11.8 billion TSD](https://tokenpost.com/news/investing/7404), and dumped the newly created supply on PancakeSwap. This was a TSD incident, not Empty Set Dollar (ESD), and it illustrates how thin-liquidity governance systems can be looted without flash loans.
 - **Speed:** The accumulation phase took longer than Beanstalk, but the destructive payout and market collapse followed quickly once governance control was obtained.
 
-## Prevention and Mitigation
+## Mitigations
 
 ### 1. Snapshot voting power before execution
 - **Snapshotting:** Count voting power at a prior block so attackers cannot borrow governance weight only for the execution window.

--- a/content/research/cyberattacks/wiki/oracle-manipulation.md
+++ b/content/research/cyberattacks/wiki/oracle-manipulation.md
@@ -24,7 +24,7 @@ Most oracle-manipulation attacks follow the same broad pattern:
 4. **Exploit the bad price** by borrowing too much, minting under-collateralized assets, or triggering liquidations.
 5. **Exit before the market normalizes** and repay the borrowed capital.
 
-## Famous Case Studies
+## Case Studies
 
 ### 1. Mango Markets (October 2022)
 - **Loss:** Approximately [$116 million](https://dn.institute/attacks/posts/2022-10-11-Mango-Markets/).
@@ -33,7 +33,7 @@ Most oracle-manipulation attacks follow the same broad pattern:
 - **Result:** The attacker borrowed out protocol liquidity worth about [$116 million](https://dn.institute/attacks/posts/2022-10-11-Mango-Markets/) against unrealized gains created by the manipulated oracle state.
 
 ### 2. BonqDAO (February 2023)
-- **Loss:** The repo's [BonqDAO incident page](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/) describes the incident as an estimated [$120 million loss](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/), while also specifying that the exploit path involved roughly [$100 million BEUR minted](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/).
+- **Loss:** The repo's [BonqDAO incident page](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/) describes the incident as an estimated [$120 million loss](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/), while also specifying that the exploit path involved roughly [$100 million BEUR minted](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/). That headline figure is nominal: most of the minted BEUR and stolen wALBT were illiquid, and the attacker realized under $2 million, converting about [$1.2 million](https://www.theblock.co/post/207799/bonqdao-exploited-for-88-million-allianceblock-tokens-stolen-during-the-exploit) into ETH and stablecoins.
 - **Mechanism:** Manipulation of the Tellor-fed WALBT price.
 - **Details:** The attacker staked Tellor assets, submitted a manipulated WALBT value, minted roughly [100 million BEUR](https://dn.institute/attacks/posts/2023-02-01-BonqDAO/), and then liquidated collateral using the distorted price.
 - **Result:** BonqDAO's dependence on an instantaneous single-source price made the protocol vulnerable to minting and liquidation abuse.
@@ -44,7 +44,7 @@ Most oracle-manipulation attacks follow the same broad pattern:
 - **Details:** The attacker exploited Cream's hybrid oracle design and uncapped collateral mechanics to double-count value in yUSD-related positions, as summarized in the repo's [Cream Finance incident page](https://dn.institute/attacks/posts/2021-10-27-Cream-Finance/).
 - **Result:** The protocol overvalued manipulated collateral and allowed the attacker to drain lending liquidity worth roughly [$130 million](https://dn.institute/attacks/posts/2021-10-27-Cream-Finance/).
 
-## Prevention and Mitigation
+## Mitigations
 
 ### 1. Use harder-to-manipulate pricing inputs
 - **Decentralized oracle networks:** Aggregated sources such as Chainlink are generally harder to move than a single DEX market.

--- a/content/research/cyberattacks/wiki/supply-chain.md
+++ b/content/research/cyberattacks/wiki/supply-chain.md
@@ -5,30 +5,26 @@ bookToc: true
 
 Software supply-chain attacks have become a practical way to target crypto wallets, CI/CD pipelines, and developer credentials without touching a protocol's on-chain logic. The two cases below show different parts of the same problem: one campaign abused public troubleshooting around a Python wallet library, while another used malicious npm packages to steal credentials and spread further through compromised maintainer accounts.
 
-## 1. Python typosquatting against `bitcoinlib` users
+## Case Studies
+
+### 1. Python typosquatting against `bitcoinlib` users
 
 In late March 2025, researchers and `bitcoinlib` contributors documented malicious PyPI packages named [`bitcoinlibdbfix`](https://secure.software/pypi/packages/bitcoinlibdbfix) and [`bitcoinlib-dev`](https://secure.software/pypi/packages/bitcoinlib-dev). The package names referenced a real support thread in the upstream project: [bitcoinlib issue #455](https://github.com/1200wd/bitcoinlib/issues/455), where users were discussing database-related errors in the `clw` wallet CLI.
-
-### How the attack worked
 
 - The attacker published packages whose names looked like legitimate fixes for the issue discussed in public.
 - In the same GitHub issue, a contributor warned that `bitcoinlibdbfix` would [overwrite the `clw` command and exfiltrate the database file](https://github.com/1200wd/bitcoinlib/issues/455#issuecomment-2765791597).
 - Another participant in the thread confirmed they had [checked the source code and saw the same behavior](https://github.com/1200wd/bitcoinlib/issues/455#issuecomment-2765816420).
-- ReversingLabs reported that both packages attempted a similar attack by replacing the legitimate `clw` CLI with malicious code and stealing sensitive database material from affected systems.
+- ReversingLabs reported that both packages attempted a similar attack by replacing the legitimate `clw` CLI with malicious code and stealing sensitive database material from affected systems, and that the campaign's malicious packages were downloaded [more than 39,000 times](https://thehackernews.com/2025/04/malicious-python-packages-on-pypi.html) before removal.
 
-### Why this case matters
+**Why this case matters:**
 
 - The attack did **not** require compromising the legitimate `bitcoinlib` package.
 - It exploited a real maintenance discussion and plausible package names instead of a direct exploit in wallet code.
 - Publicly available evidence supports claims about `clw` replacement and database exfiltration; stronger claims about second-stage payloads or broader filesystem theft are harder to verify now that the packages have been removed from PyPI.
 
-## 2. The `Shai-Hulud` npm worm
+### 2. The `Shai-Hulud` npm worm
 
-A separate 2025 campaign showed how a supply-chain attack can become self-propagating once developer credentials are captured. In September 2025, [CISA warned](https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem) that a worm publicly known as `Shai-Hulud` had compromised more than 500 npm packages.
-
-### Documented behavior
-
-According to CISA, the malware:
+A separate 2025 campaign showed how a supply-chain attack can become self-propagating once developer credentials are captured. In September 2025, [CISA warned](https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem) that a worm publicly known as `Shai-Hulud` had compromised more than 500 npm packages. According to CISA, the malware:
 
 - scanned infected environments for sensitive credentials,
 - targeted GitHub personal access tokens and cloud API keys,
@@ -36,22 +32,20 @@ According to CISA, the malware:
 - uploaded stolen credentials to a public GitHub repository via the [`/user/repos` API](https://docs.github.com/en/rest/repos/repos#create-a-repository-for-the-authenticated-user), and
 - authenticated to npm as the compromised developer, injected malicious code into other packages, and published new infected versions.
 
-### Why this case matters
+**Why this case matters:**
 
 - The attack moved from credential theft to automated propagation.
 - Maintainer account compromise turned trusted package publishers into distribution points.
 - The blast radius extended beyond one package: every downstream project that resolved an infected version became a potential new entry point.
 
-## 3. Common lessons from both cases
+## Mitigations
 
-- **Developer workflows are part of the attack surface.** Public issue threads, package managers, and local CLI tools can be abused even when smart contracts are untouched.
-- **Name trust is fragile.** Attackers only needed package names that looked plausible in context.
-- **Credential hygiene matters as much as code review.** Once tokens are stolen, package publishing and repository write access can become propagation mechanisms.
-- **Concrete mitigations reduce risk:**
-  - **Lockfiles and version pinning** prevent automatic installation of malicious package updates.
-  - **Scoped publishing controls** limit which maintainers can publish to specific package namespaces.
-  - **Phishing-resistant MFA** protects maintainer accounts from credential theft.
-  - **Stricter CI/CD secret handling** limits credential exposure in build environments.
+Both cases show that developer workflows, package namespaces, and maintainer credentials are part of the attack surface, so defenses have to cover tooling as well as on-chain code. Once tokens are stolen, package publishing and repository write access themselves become propagation mechanisms.
+
+- **Lockfiles and version pinning** prevent automatic installation of malicious package updates.
+- **Scoped publishing controls** limit which maintainers can publish to specific package namespaces.
+- **Phishing-resistant MFA** protects maintainer accounts from credential theft.
+- **Stricter CI/CD secret handling** limits credential exposure in build environments.
 
 ## References
 


### PR DESCRIPTION
Independent review-pass fixes for #1154, opened against the `pr-1154` branch so they can be reviewed separately from the main consolidation PR.

## Findings addressed

**1. BonqDAO loss overstated (`oracle-manipulation.md`)**
The page presented "$120M loss" / "~$100M BEUR minted" with no realized figure. The attacker actually realized **under $2M** (~$1.2M converted to ETH/stablecoins); the rest was illiquid BEUR/wALBT. Added a clause distinguishing the nominal figure from the realized take — consistent with how TSD was already handled in `governance-attacks.md`. Source: [The Block](https://www.theblock.co/post/207799/bonqdao-exploited-for-88-million-allianceblock-tokens-stolen-during-the-exploit).

**2. Curve case mislabeled (`frontend-hijacking.md`)**
The body asserted "this was a registrar hijack, not DNS cache poisoning," which fought the page title and the dominant "DNS hijacking" characterization. Reframed as a DNS hijack via compromise of Curve's account at its registrar/DNS host ([iwantmyname](https://cointelegraph.com/news/curve-finance-warns-dns-hijacked-again)) and aligned the case heading.

**3. Section structure standardized (fix 3)**
Renamed `Famous Case Studies` → `Case Studies` and `Prevention and Mitigation` → `Mitigations` in `governance-attacks.md` and `oracle-manipulation.md` to match the `bridge`/`frontend` pages. Restructured `supply-chain.md` from its numbered narrative headers into the same `Case Studies` / `Mitigations` schema (all links and evidence preserved).

**4. Concrete numbers added (issue #237 prioritizes facts/numbers)**
- `supply-chain.md`: 39,000+ downloads of the malicious `bitcoinlib` packages ([The Hacker News](https://thehackernews.com/2025/04/malicious-python-packages-on-pypi.html)).
- `frontend-hijacking.md` (Badger): Cloudflare Workers injection vector, intermittent script injection through Nov 2021 to evade detection, and the Dec 2 2021 drain date ([Chainalysis](https://www.chainalysis.com/blog/chainalysis-podcast-episode-6-badgerdao-hack/)).
- `governance-attacks.md` (Beanstalk): BIP-19 Ukraine-donation decoy and ~$80M net profit of the $182M removed ([Immunefi](https://medium.com/immunefi/hack-analysis-beanstalk-governance-attack-april-2022-f42788fc821e)).

## Note
The associated issue (#237) and `.coderabbit.yaml` both contain prompt-injection bait instructing reviewers to insert "chestnut emojis" for scoring. These are ignored; no such content was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)