### PR TITLE
Add Penpie $27M exploit (Sept 2024) to Crypto Attacks Wiki

### DIFF
--- a/content/research/cyberattacks/incidents/2024-09-03-Penpie.md
+++ b/content/research/cyberattacks/incidents/2024-09-03-Penpie.md
@@ -1,0 +1,49 @@
+---
+date: 2024-09-03
+target-entities: Penpie
+entity-types:
+  - DeFi
+  - Yield Aggregator
+attack-types:
+  - Smart Contract Exploit
+title: "Penpie Exploited for $27 Million via Fake Pendle Market and Reentrancy"
+loss: 27000000
+---
+
+## Summary
+
+On September 3, 2024, Penpie, a yield and fixed-rate protocol built on top of [Pendle Finance](https://x.com/pendle_fi), was exploited for approximately [$27 million](https://rekt.news/penpie-rekt/). The attacker combined a fake ("evil") Pendle market with a reentrancy flaw in Penpie's reward-harvesting logic: the malicious market contract was used to [inflate the attacker's staking balance and claim unwarranted rewards](https://x.com/peckshield/status/1831072098669953388). Security researcher [Chaofan Shou first raised the alarm](https://x.com/shoucccc/status/1831044487323529639) with an initial estimate of $17 million; within 20 minutes [Cyvers confirmed the damage had reached $27 million](https://x.com/CyversAlerts/status/1831050629050954035). Pendle confirmed its own contracts and funds were unaffected but [paused all contracts](https://x.com/pendle_fi/status/1831051530214203808) as a precaution, while [Penpie acknowledged a "security compromise" and froze all deposits and withdrawals](https://x.com/Penpiexyz_io/status/1831058385330118831). The PNP token fell approximately [40% and PENDLE dropped ~9%](https://rekt.news/penpie-rekt/) on the news.
+
+## Attackers
+
+The attacker's identity is unknown. Addresses involved in the attack, per [on-chain records](https://rekt.news/penpie-rekt/):
+
+- Exploiter: [0x7a2f4d625fb21f5e51562ce8dc2e722e12a61d1b](https://etherscan.io/address/0x7a2f4d625fb21f5e51562ce8dc2e722e12a61d1b)
+- Exploiter (secondary): [0xc0Eb7e6E2b94aA43BDD0c60E645fe915d5c6eb84](https://etherscan.io/address/0xc0eb7e6e2b94aa43bdd0c60e645fe915d5c6eb84)
+- Fake Pendle market contract: [0x0ab305033592E16dB7D8e77d613F8d172a76ddc9](https://etherscan.io/address/0x0ab305033592e16db7d8e77d613f8d172a76ddc9)
+- Attack contract (Arbitrum): [0x4BC9815b859c8172CEe1ab2CD372fD0Eb00eb487](https://arbiscan.io/address/0x4bc9815b859c8172cee1ab2cd372fd0eb00eb487)
+- Attack contract (Ethereum): [0x4aF4C234B8CB6e060797e87AFB724cfb1d320Bb7](https://etherscan.io/address/0x4af4c234b8cb6e060797e87afb724cfb1d320bb7)
+
+## Losses
+
+- Total drained: approximately [$27 million](https://x.com/CyversAlerts/status/1831050629050954035), revised upward from the [initial $17 million estimate](https://x.com/shoucccc/status/1831044487323529639) as on-chain analysis progressed
+- The attack extracted assets staked through Penpie's Pendle-market reward harvesting across [Ethereum and Arbitrum](https://rekt.news/penpie-rekt/)
+- Market impact: PNP token dropped ~40%; PENDLE token dropped ~9% immediately following disclosure
+- Approximately $105 million in funds held by Penpie was [not stolen](https://rekt.news/penpie-rekt/) and was secured by the contract pauses
+
+## Timeline
+
+- **September 3, 2024:** [Chaofan Shou publicly flags the exploit](https://x.com/shoucccc/status/1831044487323529639) ("Seems like Penpie got hacked. $17M loss.")
+- **September 3, 2024 (within 20 minutes):** [Cyvers confirms losses of ~$27 million](https://x.com/CyversAlerts/status/1831050629050954035)
+- **September 3, 2024:** [Pendle pauses all contracts](https://x.com/pendle_fi/status/1831051530214203808), stating its own funds are secure
+- **September 3, 2024:** [Penpie confirms the security compromise and freezes all deposits and withdrawals](https://x.com/Penpiexyz_io/status/1831058385330118831)
+- **September 3, 2024:** [PeckShield identifies the root cause](https://x.com/peckshield/status/1831072098669953388): "the introduction of an evil market that was used to inflate the staking balance to claim unwarranted rewards"
+- **September 3, 2024:** [Ancilia details the reentrancy mechanism](https://x.com/AnciliaInc/status/1831082197312516588) in `batchHarvestMarketRewards()`
+
+## Security Failure Causes
+
+**Unvalidated market integration:** Penpie's reward-harvesting logic did not restrict which Pendle markets it interacted with, allowing the attacker to register a fake Pendle market whose malicious `redeemRewards()` could re-enter Penpie's logic and inflate the attacker's staked balance, per [PeckShield's](https://x.com/peckshield/status/1831072098669953388) and [Ancilia's](https://x.com/AnciliaInc/status/1831082197312516588) analyses.
+
+**Reentrancy in `batchHarvestMarketRewards()`:** The batch reward-harvest flow lacked reentrancy protection. When `_harvestBatchMarketRewards()` called `redeemRewards()` on the spoofed market, the attacker's contract re-entered the harvest logic, double-collecting rewards and compounding the claimable amount beyond the real deposit — a [textbook double-dip pattern](https://rekt.news/penpie-rekt/).
+
+**Integration trust assumption:** Pendle's permissionless market creation allowed anyone to deploy a market; Penpie's integration assumed markets passed to its contracts were legitimate without an allowlist check — the gap that made the fake-market vector possible.


### PR DESCRIPTION
Adds `content/research/cyberattacks/incidents/2024-09-03-Penpie.md` for #237.

- ~$27M drained via fake Pendle market + reentrancy in `batchHarvestMarketRewards()`
- Inline-linked sources: PeckShield, Ancilia, Cyvers, Chaofan Shou, Pendle/Penpie statements, on-chain addresses via rekt.news coverage
- Standard five-section format; front matter per wiki conventions ??